### PR TITLE
types: avoids naming imports as "StabilityAIClient"

### DIFF
--- a/src/models/ImageGenerationPromptWeight.ts
+++ b/src/models/ImageGenerationPromptWeight.ts
@@ -1,11 +1,13 @@
-import * as StabilityAIClient from 'stabilityai-client-typescript/models/components';
+import type {
+  TextPrompt,
+} from 'stabilityai-client-typescript/models/components';
 
 enum ImageGenerationPromptWeight {
   positive,
   negative,
 }
 
-export const quantitative = (givenQualitativeWeight: ImageGenerationPromptWeight): StabilityAIClient.TextPrompt['weight'] => {
+export const quantitative = (givenQualitativeWeight: ImageGenerationPromptWeight): TextPrompt['weight'] => {
   switch (givenQualitativeWeight) {
     case ImageGenerationPromptWeight.positive: return +1;
     case ImageGenerationPromptWeight.negative: return -1;

--- a/src/pages/TextToImagePage.vue
+++ b/src/pages/TextToImagePage.vue
@@ -9,7 +9,9 @@ import {
   useStatefulProcess,
 } from '@/library/vue/statefulProcess.ts';
 
-import * as StabilityAIClient from 'stabilityai-client-typescript/models/components';
+import type {
+  TextToImageRequestBody,
+} from 'stabilityai-client-typescript/models/components';
 
 import type {
   Branded,
@@ -54,7 +56,7 @@ const generatedImage: Ref<RelativeImagePath | null> = ref(null);
 const toStabilityAITextPrompts = (
   givenPrompt: ImageGenerationPrompt,
   givenWeightQuality: 'positive' | 'negative',
-): StabilityAIClient.TextToImageRequestBody['textPrompts'] => {
+): TextToImageRequestBody['textPrompts'] => {
   const derivedWeight = ImageGenerationPromptWeight[givenWeightQuality];
 
   return givenPrompt[givenWeightQuality]


### PR DESCRIPTION
- avoids potential collision with `StabilityAIClient` class