### PR TITLE
fix: ensures that string subsets are treated distinctly

### DIFF
--- a/src/library/customTypes/Base64CharacterEncodedByteSequence.ts
+++ b/src/library/customTypes/Base64CharacterEncodedByteSequence.ts
@@ -7,6 +7,8 @@ import {
   lastCharacterOf,
 } from '@/library/utilitiesByType/string.ts';
 
+import StringSubset from './StringSubset.ts';
+
 const Byte = {
   bitCount: 8 as const,
 };
@@ -21,13 +23,7 @@ const Base64 = {
 };
 
 /** See [RFC 4648 Section 4](https://www.rfc-editor.org/rfc/rfc4648.html#section-4) for more information */
-export default class Base64CharacterEncodedByteSequence extends String {
-  private constructor(
-    givenCharacters: string,
-  ) {
-    super(givenCharacters);
-  }
-
+export default class Base64CharacterEncodedByteSequence extends StringSubset<'Base64CharacterEncodedByteSequence'> {
   public static paddingCharacter = '=';
 
   private static readonly byteCofactor = cofactor({

--- a/src/library/customTypes/NonTrivialString.ts
+++ b/src/library/customTypes/NonTrivialString.ts
@@ -2,13 +2,9 @@ import {
   isEmpty,
 } from '@/library/utilitiesByType/string.ts';
 
-export default class NonTrivialString extends String {
-  private constructor(
-    givenSubject: string,
-  ) {
-    super(givenSubject);
-  }
+import StringSubset from './StringSubset.ts';
 
+export default class NonTrivialString extends StringSubset<'NonTrivialString'> {
   public static tryToParseFrom(givenSubject: string): NonTrivialString {
     const trimmedSubject = givenSubject.trim();
 

--- a/src/library/customTypes/StringSubset.ts
+++ b/src/library/customTypes/StringSubset.ts
@@ -1,0 +1,14 @@
+/**
+ * When an open-ended `string` is too permissive, extend this class and provide a means to instantiate some subset
+ */
+export default abstract class StringSubset<Brand extends string> extends String {
+  /**
+   * Makes subclasses structurally different from each other.
+   * This allows the type-checker to discern between them and complain about mismatched types.
+   */
+  private readonly brand!: Brand;
+
+  protected constructor(givenInstance: string) {
+    super(givenInstance);
+  }
+};


### PR DESCRIPTION
- from `string`
- and from each other