### PR TITLE
types: loosens strictness for parameter in `shallowlyMerged`

### DIFF
--- a/src/library/utilitiesByType/record.ts
+++ b/src/library/utilitiesByType/record.ts
@@ -1,8 +1,7 @@
 export const shallowlyMerged = <
   SomeRecord extends Record<string, unknown>,
-  SomeNullableRecord = SomeRecord | null,
 >(
-  ...givenRecords: [SomeNullableRecord, ...SomeNullableRecord[]]
+  ...givenRecords: (SomeRecord | null)[]
 ): SomeRecord => {
   return givenRecords.reduce<SomeRecord>((runningRecords, eachRecord) => {
     return {


### PR DESCRIPTION
- no reason to avoid mapping an empty array to an empty record