### PR TITLE
fix: ensures DiscreteSlider works for any width

### DIFF
--- a/src/components/DiscreteSlider.vue
+++ b/src/components/DiscreteSlider.vue
@@ -95,11 +95,6 @@ const boundaryTickLabels = (
     !givenRange.inclusivelyContains(givenValue)
   ) throw new RangeError(`Expected value within range: ${givenRange.inInclusiveNotation}, got: ${givenValue.toString()}`);
 
-  const valueLabels = tickLabels({
-    for: givenValue,
-    in : givenRange,
-  });
-
   const proximityOffset = 5;
 
   const minLabels = tickLabels({
@@ -117,7 +112,6 @@ const boundaryTickLabels = (
   return shallowlyMerged(
     minLabels,
     maxLabels,
-    valueLabels,
   );
 };
 </script>

--- a/src/components/DiscreteSlider.vue
+++ b/src/components/DiscreteSlider.vue
@@ -114,6 +114,8 @@ const boundaryTickLabels = (
       :ticks="boundaryTickLabels({ in: range })"
       show-ticks="always"
       thumb-color="primary"
+      thumb-label="always"
+      class="pt-6"
     >
       <template #prepend>
         <VBtn
@@ -125,6 +127,15 @@ const boundaryTickLabels = (
           @click="() => incrementCurrentValueBy(-1)"
         />
       </template>
+
+      <template #thumb-label="{ modelValue }">
+        <span
+          style="color: rgb(var(--v-theme-on-background));"
+        >
+          {{ modelValue }}
+        </span>
+      </template>
+
       <template #append>
         <VBtn
           icon="mdi-plus"

--- a/src/components/DiscreteSlider.vue
+++ b/src/components/DiscreteSlider.vue
@@ -63,15 +63,11 @@ const tickLabels = (
   {
     for: givenValue,
     in : givenRange,
-    when: shouldMakeLabelsFor = () => true,
   }: {
     for: number;
     in: Range;
-    when?: (value: number) => boolean;
   },
 ): SliderLabelsByTick | null => {
-  if (!shouldMakeLabelsFor(givenValue)) return null;
-
   const derivedOffset = stylisticOffset({
     for: givenValue,
     in : givenRange,
@@ -85,28 +81,18 @@ const tickLabels = (
 const boundaryTickLabels = (
   {
     in: givenRange,
-    around: givenValue,
   }: {
     in: Range;
-    around: number;
   },
 ): SliderLabelsByTick => {
-  if (
-    !givenRange.inclusivelyContains(givenValue)
-  ) throw new RangeError(`Expected value within range: ${givenRange.inInclusiveNotation}, got: ${givenValue.toString()}`);
-
-  const proximityOffset = 5;
-
   const minLabels = tickLabels({
-    for : givenRange.lowerBound,
-    in  : givenRange,
-    when: $0 => (($0 + proximityOffset) <= givenValue),
+    for: givenRange.lowerBound,
+    in : givenRange,
   });
 
   const maxLabels = tickLabels({
-    for : givenRange.upperBound,
-    in  : givenRange,
-    when: $0 => (givenValue <= ($0 - proximityOffset)),
+    for: givenRange.upperBound,
+    in : givenRange,
   });
 
   return shallowlyMerged(
@@ -125,7 +111,7 @@ const boundaryTickLabels = (
       :min="range.lowerBound"
       :step="range.stepSize"
       :max="range.upperBound"
-      :ticks="boundaryTickLabels({ in: range, around: currentValue})"
+      :ticks="boundaryTickLabels({ in: range })"
       show-ticks="always"
       thumb-color="primary"
     >


### PR DESCRIPTION
- the dynamic tick mark representing the current value took precedence over the others
- when it got close to them, the others would disappear
- at certain widths, this felt natural.
- But any wider made it feel premature. Any narrower would cause overlap, making the labels unreadable 