### PR TITLE
refactor: clarifies intent for URI-to-string conversion

### DIFF
--- a/src/library/customTypes/UniformResourceIdentifier/index.ts
+++ b/src/library/customTypes/UniformResourceIdentifier/index.ts
@@ -77,7 +77,7 @@ export default class UniformResourceIdentifier {
     return UniformResourceIdentifier.fragmentPrefix + this.fragment.toString();
   }
 
-  public toString(): string {
+  public get serialized(): string {
     const components: (string | null | undefined)[] = [
       this.scheme.toString(),
       UniformResourceIdentifier.schemeSuffix,

--- a/src/pages/TextToImagePage.vue
+++ b/src/pages/TextToImagePage.vue
@@ -188,7 +188,7 @@ const imageGeneration = useStatefulProcess(async () => {
     >
       <VImg
         v-if="generatedImage !== null"
-        :src="generatedImage.toString()"
+        :src="generatedImage.serialized"
         alt="presented image"
       />
       <VSkeletonLoader


### PR DESCRIPTION
- lots of types have `toString()`, but URI string conversion has really specific use-case
- separating it is more type-safe when the shape of some data structure changes slightly but `toString()` is still a valid call