### PR TITLE
refactor: separates `Server` shape and parsing concerns

### DIFF
--- a/src/features/TextToImage/config/types/ConfigSchema.ts
+++ b/src/features/TextToImage/config/types/ConfigSchema.ts
@@ -10,14 +10,9 @@ import {
 
 /** Defines how to parse an instance of {@link TextToImage_Config} */
 const TextToImage_ConfigSchema = z.object({
-  server: z.unknown().transform((parsableSubject) => {
-    try {
-      return WebAPI.Server.tryToParseFrom(parsableSubject);
-    }
-    catch {
-      return null;
-    }
-  }),
+  server: WebAPI.ServerSchema
+    .or(z.null())
+    .default(null),
 }).transform($0 => new TextToImage_Config(
   $0.server,
 ));

--- a/src/library/WebAPI/Server.ts
+++ b/src/library/WebAPI/Server.ts
@@ -1,19 +1,9 @@
-import {
-  z,
-} from 'zod';
-
-const z_serverSchema = z.object({
-  origin: z.string(),
-});
-
-type ServerSchema = z.infer<typeof z_serverSchema>;
-
 /**
  * The machine conforming to some web API that:
  * - listens for requests
  * - responds to those requests
  */
-export default class Server implements ServerSchema {
+export default class Server {
   public constructor(
     /**
      * The web location of the server, which is the base URL of the API.
@@ -26,10 +16,5 @@ export default class Server implements ServerSchema {
     return new Server(
       given.origin,
     );
-  }
-
-  public static tryToParseFrom(givenSubject: unknown): Server {
-    const parsedSubject = z_serverSchema.parse(givenSubject);
-    return Server.from(parsedSubject);
   }
 }

--- a/src/library/WebAPI/ServerSchema.ts
+++ b/src/library/WebAPI/ServerSchema.ts
@@ -1,0 +1,10 @@
+import {
+  z,
+} from 'zod';
+
+import Server from './Server';
+
+/** Defines how to parse into an instance of {@link Server} */
+export const ServerSchema = z.object({
+  origin: z.string(),
+}).transform($0 => Server.from($0));

--- a/src/library/WebAPI/index.ts
+++ b/src/library/WebAPI/index.ts
@@ -1,5 +1,10 @@
 import Server from './Server.ts';
 
+import {
+  ServerSchema,
+} from './ServerSchema.ts';
+
 export {
   Server,
+  ServerSchema,
 };


### PR DESCRIPTION
- extracts `ServerSchema` from `Server`

When a 3rd party schema is inspired by an internal type, the schema should depend on the type to prevent lock-in