### PR TITLE
refactor: separates throwing concerns in SDXL client

### DIFF
--- a/src/features/TextToImage/models/SDXL/client/index.ts
+++ b/src/features/TextToImage/models/SDXL/client/index.ts
@@ -13,10 +13,6 @@ import {
   asError,
 } from '@/library/utilitiesByType/error';
 
-import {
-  DynamicConfig,
-  StaticConfig,
-} from '@/features/TextToImage/config';
 import type {
   Output,
 } from '@/features/TextToImage/types';
@@ -25,23 +21,11 @@ import {
 } from '@/features/TextToImage/webAPI';
 
 const tryToInitializeShimmedStabilityAIClient = async (): Promise<ShimmedStabilityAIClient> => {
-  try {
-    const textToImageServer = await Server.tryToGetFrom();
+  const textToImageServer = await Server.tryToGetFrom();
 
-    return new ShimmedStabilityAIClient({
-      serverURL: textToImageServer.origin,
-    });
-  }
-  catch {
-    throw new Error([
-      'No text-to-image server was specified!',
-      'Either:',
-      `a) supply it's corresponding environment variable named \`${Server.environmentKeyForOrigin}\` and rebuild`,
-      `b) specify it within ${StaticConfig.file.toString()}`,
-      'OR',
-      `c) specify it within the response from ${DynamicConfig.endpoint.toString()}`,
-    ].join('\n'));
-  }
+  return new ShimmedStabilityAIClient({
+    serverURL: textToImageServer.origin,
+  });
 };
 
 export const tryToGenerateOutputFrom = async (

--- a/src/features/TextToImage/webAPI/server.ts
+++ b/src/features/TextToImage/webAPI/server.ts
@@ -7,7 +7,7 @@ import {
   StaticConfig,
 } from '../config';
 
-export const environmentKeyForOrigin = 'VITE__TEXT_TO_IMAGE__API__SERVER__ORIGIN';
+const environmentKeyForOrigin = 'VITE__TEXT_TO_IMAGE__API__SERVER__ORIGIN';
 
 export const accordingToEnvironment = ((): Server | null => {
   const originAccordingToEnvironment = import.meta.env[environmentKeyForOrigin];
@@ -38,5 +38,14 @@ export const tryToGetFrom = async (): Promise<Server> => {
     dynamicConfig.server !== null
   ) return dynamicConfig.server;
 
-  throw new Error('Server not specified');
+  const serverNotSpecifiedErrorMessage = [
+    'No text-to-image server was specified!',
+    'Either:',
+    `a) supply it's corresponding environment variable named \`${environmentKeyForOrigin}\` and rebuild`,
+    `b) specify it within ${StaticConfig.file.toString()}`,
+    'OR',
+    `c) specify it within the response from ${DynamicConfig.endpoint.toString()}`,
+  ].join('\n');
+
+  throw new Error(serverNotSpecifiedErrorMessage);
 };


### PR DESCRIPTION
- moves server error so it originates from `Server` module