### PR TITLE
refactor: avoids coupling of error handling and deferment

### DIFF
--- a/src/library/vue/statefulProcess.ts
+++ b/src/library/vue/statefulProcess.ts
@@ -20,16 +20,16 @@ export const useStatefulProcess = <
   const capturedResult: Ref<SomeResult | null> = ref(null);
 
   const tryToPerformFlaggedProcess = async (): Promise<void> => {
+    using cleanup = new DisposableStack();
     set(flagIsRaised, true);
 
-    try {
-      set(capturedResult, null);
-      const resultOfProcess = await tryToPerformFlaggableProcess();
-      set(capturedResult, resultOfProcess);
-    }
-    finally {
+    cleanup.defer(() => {
       set(flagIsRaised, false);
-    }
+    });
+
+    set(capturedResult, null);
+    const resultOfProcess = await tryToPerformFlaggableProcess();
+    set(capturedResult, resultOfProcess);
   };
 
   return {

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -5,6 +5,13 @@
   "compilerOptions": {
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
 
+    "target": "ES2022",
+    "lib": [
+      "ES2022",
+      "DOM",
+      "DOM.Iterable",
+      "ESNext.Disposable"
+    ],
     "noImplicitOverride": true,
     "noUncheckedIndexedAccess": true,
     "paths": {


### PR DESCRIPTION
- prefers `using` + `DisposableStack` over `finally` block