### PR TITLE
refactor: makes more obvious the functions that might throw

### DIFF
--- a/src/features/TextToImage/config/utilities/DynamicConfig.ts
+++ b/src/features/TextToImage/config/utilities/DynamicConfig.ts
@@ -17,7 +17,7 @@ const contentIsJSONIn = (givenResponse: Response): boolean => {
 
 const configEndpoint = URLPath.forciblyParsedFrom('/config/text-to-image');
 
-const tryToFetchConfig = async (): Promise<Config> => {
+const forciblyFetchConfig = async (): Promise<Config> => {
   const endpointResponse = await fetch(configEndpoint.toString());
 
   if (
@@ -34,5 +34,5 @@ const tryToFetchConfig = async (): Promise<Config> => {
 
 export {
   configEndpoint as endpoint,
-  tryToFetchConfig as tryToFetch,
+  forciblyFetchConfig as forciblyFetch,
 };

--- a/src/features/TextToImage/config/utilities/DynamicConfig.ts
+++ b/src/features/TextToImage/config/utilities/DynamicConfig.ts
@@ -15,7 +15,7 @@ const contentIsJSONIn = (givenResponse: Response): boolean => {
   return contentType.includes('application/json');
 };
 
-const configEndpoint = URLPath.tryToParseFrom('/config/text-to-image');
+const configEndpoint = URLPath.forciblyParsedFrom('/config/text-to-image');
 
 const tryToFetchConfig = async (): Promise<Config> => {
   const endpointResponse = await fetch(configEndpoint.toString());

--- a/src/features/TextToImage/config/utilities/StaticConfig.ts
+++ b/src/features/TextToImage/config/utilities/StaticConfig.ts
@@ -7,7 +7,7 @@ import {
   ConfigSchema,
 } from '../types';
 
-const configFile = URLPath.tryToParseFrom('/config/text-to-image.json');
+const configFile = URLPath.forciblyParsedFrom('/config/text-to-image.json');
 
 const tryToReadConfig = async (): Promise<Config> => {
   const fileResponse = await fetch(configFile.toString());

--- a/src/features/TextToImage/config/utilities/StaticConfig.ts
+++ b/src/features/TextToImage/config/utilities/StaticConfig.ts
@@ -9,7 +9,7 @@ import {
 
 const configFile = URLPath.forciblyParsedFrom('/config/text-to-image.json');
 
-const tryToReadConfig = async (): Promise<Config> => {
+const forciblyReadConfig = async (): Promise<Config> => {
   const fileResponse = await fetch(configFile.toString());
 
   if (
@@ -22,5 +22,5 @@ const tryToReadConfig = async (): Promise<Config> => {
 
 export {
   configFile as file,
-  tryToReadConfig as tryToRead,
+  forciblyReadConfig as forciblyRead,
 };

--- a/src/features/TextToImage/models/SDXL/client/index.ts
+++ b/src/features/TextToImage/models/SDXL/client/index.ts
@@ -93,7 +93,7 @@ export const tryToGenerateOutputFrom = async (
     soleGeneratedArtifact.base64 === undefined
   ) throw new Error('Expected image data from sole artifact');
 
-  const base64DataOfNewImage = Base64CharacterEncodedByteSequence.tryToParseFrom(soleGeneratedArtifact.base64);
+  const base64DataOfNewImage = Base64CharacterEncodedByteSequence.forciblyParsedFrom(soleGeneratedArtifact.base64);
 
   const newImage = {
     uri        : new ImageURI('png', 'base64', base64DataOfNewImage),

--- a/src/features/TextToImage/models/SDXL/client/index.ts
+++ b/src/features/TextToImage/models/SDXL/client/index.ts
@@ -21,7 +21,7 @@ import {
 } from '@/features/TextToImage/webAPI';
 
 const tryToInitializeShimmedStabilityAIClient = async (): Promise<ShimmedStabilityAIClient> => {
-  const textToImageServer = await Server.tryToRetrieveCurrent();
+  const textToImageServer = await Server.forciblyRetrieveCurrent();
 
   return new ShimmedStabilityAIClient({
     serverURL: textToImageServer.origin,

--- a/src/features/TextToImage/models/SDXL/client/index.ts
+++ b/src/features/TextToImage/models/SDXL/client/index.ts
@@ -20,7 +20,7 @@ import {
   Server,
 } from '@/features/TextToImage/webAPI';
 
-const tryToInitializeShimmedStabilityAIClient = async (): Promise<ShimmedStabilityAIClient> => {
+const forciblyInitializeShimmedStabilityAIClient = async (): Promise<ShimmedStabilityAIClient> => {
   const textToImageServer = await Server.forciblyRetrieveCurrent();
 
   return new ShimmedStabilityAIClient({
@@ -28,7 +28,7 @@ const tryToInitializeShimmedStabilityAIClient = async (): Promise<ShimmedStabili
   });
 };
 
-export const tryToGenerateOutputFrom = async (
+export const forciblyGenerateOutputFrom = async (
   given: {
     textToImageRequestBody: Pick<GenerateFromTextRequest['textToImageRequestBody'],
     | 'textPrompts'
@@ -40,7 +40,7 @@ export const tryToGenerateOutputFrom = async (
     >;
   },
 ): Promise<Output> => {
-  const shimmedStabilityAIClient = await tryToInitializeShimmedStabilityAIClient();
+  const shimmedStabilityAIClient = await forciblyInitializeShimmedStabilityAIClient();
 
   let textToImageResponse: GenerateFromTextResponse;
 
@@ -111,7 +111,7 @@ export const tryToGenerateOutputFrom = async (
 };
 
 const SDXLTextToImageClient = {
-  tryToGenerateOutputFrom,
+  forciblyGenerateOutputFrom,
 };
 
 export default SDXLTextToImageClient;

--- a/src/features/TextToImage/models/SDXL/client/index.ts
+++ b/src/features/TextToImage/models/SDXL/client/index.ts
@@ -45,7 +45,7 @@ export const forciblyGenerateOutputFrom = async (
   let textToImageResponse: GenerateFromTextResponse;
 
   try {
-    textToImageResponse = await shimmedStabilityAIClient.version1.image.tryToGenerateFromText({
+    textToImageResponse = await shimmedStabilityAIClient.version1.image.forciblyGenerateFromText({
       engineId              : 'stable-diffusion-xl-1024-v1-0',
       textToImageRequestBody: {
         textPrompts: given.textToImageRequestBody.textPrompts,

--- a/src/features/TextToImage/models/SDXL/client/index.ts
+++ b/src/features/TextToImage/models/SDXL/client/index.ts
@@ -21,7 +21,7 @@ import {
 } from '@/features/TextToImage/webAPI';
 
 const tryToInitializeShimmedStabilityAIClient = async (): Promise<ShimmedStabilityAIClient> => {
-  const textToImageServer = await Server.tryToGetFrom();
+  const textToImageServer = await Server.tryToRetrieveCurrent();
 
   return new ShimmedStabilityAIClient({
     serverURL: textToImageServer.origin,

--- a/src/features/TextToImage/webAPI/server.ts
+++ b/src/features/TextToImage/webAPI/server.ts
@@ -21,7 +21,7 @@ export const accordingToEnvironment = ((): Server | null => {
   });
 })();
 
-export const tryToRetrieveCurrent = async (): Promise<Server> => {
+export const forciblyRetrieveCurrent = async (): Promise<Server> => {
   if (
     accordingToEnvironment !== null
   ) return accordingToEnvironment;

--- a/src/features/TextToImage/webAPI/server.ts
+++ b/src/features/TextToImage/webAPI/server.ts
@@ -26,7 +26,7 @@ export const tryToRetrieveCurrent = async (): Promise<Server> => {
     accordingToEnvironment !== null
   ) return accordingToEnvironment;
 
-  const staticConfig = await StaticConfig.tryToRead();
+  const staticConfig = await StaticConfig.forciblyRead();
 
   if (
     staticConfig.server !== null

--- a/src/features/TextToImage/webAPI/server.ts
+++ b/src/features/TextToImage/webAPI/server.ts
@@ -32,7 +32,7 @@ export const tryToRetrieveCurrent = async (): Promise<Server> => {
     staticConfig.server !== null
   ) return staticConfig.server;
 
-  const dynamicConfig = await DynamicConfig.tryToFetch();
+  const dynamicConfig = await DynamicConfig.forciblyFetch();
 
   if (
     dynamicConfig.server !== null

--- a/src/features/TextToImage/webAPI/server.ts
+++ b/src/features/TextToImage/webAPI/server.ts
@@ -21,7 +21,7 @@ export const accordingToEnvironment = ((): Server | null => {
   });
 })();
 
-export const tryToGetFrom = async (): Promise<Server> => {
+export const tryToRetrieveCurrent = async (): Promise<Server> => {
   if (
     accordingToEnvironment !== null
   ) return accordingToEnvironment;

--- a/src/library/HTTPClient/index.ts
+++ b/src/library/HTTPClient/index.ts
@@ -29,7 +29,7 @@ export default class HTTPClient {
     );
   }
 
-  public async tryToSend(
+  public async forciblySend(
     givenRequestBody: unknown,
     {
       to: givenPath,
@@ -50,20 +50,20 @@ export default class HTTPClient {
     return await response.json();
   }
 
-  public async tryToFetchResource(
+  public async forciblyFetchResource(
     {
       from: givenPath,
     }: {
       from: URLPath;
     },
   ): Promise<unknown> {
-    return await this.tryToSend(null, {
+    return await this.forciblySend(null, {
       to   : givenPath,
       using: HTTPRequest.Method.FETCH,
     });
   }
 
-  public async tryToSubmitResource(
+  public async forciblySubmitResource(
     {
       bySending: givenSubmission,
       to: givenPath,
@@ -72,13 +72,13 @@ export default class HTTPClient {
       to: URLPath;
     },
   ): Promise<unknown> {
-    return await this.tryToSend(givenSubmission, {
+    return await this.forciblySend(givenSubmission, {
       to   : givenPath,
       using: HTTPRequest.Method.SUBMIT,
     });
   }
 
-  public async tryToCreateResource(
+  public async forciblyCreateResource(
     {
       bySending: givenProperties,
       to: givenPath,
@@ -87,13 +87,13 @@ export default class HTTPClient {
       to: URLPath;
     },
   ): Promise<unknown> {
-    return await this.tryToSend(givenProperties, {
+    return await this.forciblySend(givenProperties, {
       to   : givenPath,
       using: HTTPRequest.Method.CREATE,
     });
   }
 
-  public async tryToUpdateResource(
+  public async forciblyUpdateResource(
     {
       bySending: givenChanges,
       to: givenPath,
@@ -102,14 +102,14 @@ export default class HTTPClient {
       to: URLPath;
     },
   ): Promise<unknown> {
-    return await this.tryToSend(givenChanges, {
+    return await this.forciblySend(givenChanges, {
       to   : givenPath,
       using: HTTPRequest.Method.UPDATE,
     });
   }
 
-  public async tryToDeleteResourceAt(givenPath: URLPath): Promise<unknown> {
-    return await this.tryToSend(null, {
+  public async forciblyDeleteResourceAt(givenPath: URLPath): Promise<unknown> {
+    return await this.forciblySend(null, {
       to   : givenPath,
       using: HTTPRequest.Method.DELETE,
     });

--- a/src/library/ShimmedStabilityAIClient/index.ts
+++ b/src/library/ShimmedStabilityAIClient/index.ts
@@ -101,7 +101,7 @@ const z_imageGenerationResponseBody = z.object({
 });
 
 class ImageClient extends HTTPClient {
-  public async tryToGenerateFromText(
+  public async forciblyGenerateFromText(
     givenRequest: GenerateFromTextRequest,
   ): Promise<GenerateFromTextResponse> {
     const newResource = await this.forciblySubmitResource({

--- a/src/library/ShimmedStabilityAIClient/index.ts
+++ b/src/library/ShimmedStabilityAIClient/index.ts
@@ -93,7 +93,7 @@ const toBatchGenerationRequestBody = (givenRequests: GenerateFromTextRequest['te
 };
 
 const z_image = z.string().transform((someSubject) => {
-  return Base64CharacterEncodedByteSequence.tryToParseFrom(someSubject);
+  return Base64CharacterEncodedByteSequence.forciblyParsedFrom(someSubject);
 });
 
 const z_imageGenerationResponseBody = z.object({
@@ -108,7 +108,7 @@ class ImageClient extends HTTPClient {
       bySending: toBatchGenerationRequestBody([
         givenRequest.textToImageRequestBody,
       ]),
-      to: URLPath.tryToParseFrom('/generate'),
+      to: URLPath.forciblyParsedFrom('/generate'),
     });
 
     const {
@@ -146,7 +146,7 @@ export default class ShimmedStabilityAIClient extends HTTPClient {
     serverURL: string;
   }) {
     super({
-      origin : URLOrigin.tryToParseFrom(given.serverURL),
+      origin : URLOrigin.forciblyParsedFrom(given.serverURL),
       headers: {
         'Content-Type': 'application/json',
       },

--- a/src/library/ShimmedStabilityAIClient/index.ts
+++ b/src/library/ShimmedStabilityAIClient/index.ts
@@ -104,7 +104,7 @@ class ImageClient extends HTTPClient {
   public async tryToGenerateFromText(
     givenRequest: GenerateFromTextRequest,
   ): Promise<GenerateFromTextResponse> {
-    const newResource = await this.tryToSubmitResource({
+    const newResource = await this.forciblySubmitResource({
       bySending: toBatchGenerationRequestBody([
         givenRequest.textToImageRequestBody,
       ]),

--- a/src/library/customTypes/Base64CharacterEncodedByteSequence.ts
+++ b/src/library/customTypes/Base64CharacterEncodedByteSequence.ts
@@ -69,7 +69,7 @@ export default class Base64CharacterEncodedByteSequence
     throw new TypeError(`Characters contained 1+ characters outside of the Base64 Alphabet: ${regExForBase64Alphabet.toString()}`);
   }
 
-  public static tryToParseFrom(
+  public static forciblyParsedFrom(
     givenCharacters: string,
   ): Base64CharacterEncodedByteSequence {
     const paddedByteEncodableCharacters = this.assertIsByteEncodable(givenCharacters);

--- a/src/library/customTypes/NonTrivialString.ts
+++ b/src/library/customTypes/NonTrivialString.ts
@@ -11,7 +11,7 @@ import StringSubset from './StringSubset.ts';
 export default class NonTrivialString
   extends StringSubset<'NonTrivialString'>
   implements StaticStringParser<typeof NonTrivialString> {
-  public static tryToParseFrom(givenSubject: string): NonTrivialString {
+  public static forciblyParsedFrom(givenSubject: string): NonTrivialString {
     const trimmedSubject = givenSubject.trim();
 
     if (isEmpty(trimmedSubject)) throw new Error('Expected a non-trivial string');
@@ -23,7 +23,7 @@ export default class NonTrivialString
     if (givenSubject === null) return givenSubject;
 
     try {
-      return this.tryToParseFrom(givenSubject);
+      return this.forciblyParsedFrom(givenSubject);
     }
     catch {
       return null;

--- a/src/library/customTypes/URLComponent/URLOrigin.ts
+++ b/src/library/customTypes/URLComponent/URLOrigin.ts
@@ -7,7 +7,7 @@ import type {
 export class URLOrigin
   extends StringSubset<'URLOrigin'>
   implements StaticStringParser<typeof URLOrigin> {
-  public static tryToParseFrom(givenSubject: string): URLOrigin {
+  public static forciblyParsedFrom(givenSubject: string): URLOrigin {
     const derived = new URL(givenSubject);
 
     if (

--- a/src/library/customTypes/URLComponent/URLPath.ts
+++ b/src/library/customTypes/URLComponent/URLPath.ts
@@ -7,7 +7,7 @@ import type {
 export class URLPath
   extends StringSubset<'URLPath'>
   implements StaticStringParser<typeof URLPath> {
-  public static tryToParseFrom(givenSubject: string): URLPath {
+  public static forciblyParsedFrom(givenSubject: string): URLPath {
     const exampleURL = new URL(`https://example.com${givenSubject}`);
 
     if (

--- a/src/library/customTypes/UniformResourceIdentifier/Data/Image/index.ts
+++ b/src/library/customTypes/UniformResourceIdentifier/Data/Image/index.ts
@@ -45,8 +45,8 @@ export default class ImageURI extends DataURI {
     );
   }
 
-  public static override tryToParseFrom(givenSubject: string): ImageURI {
-    const proposedURI = super.tryToParseFrom(givenSubject);
+  public static override forciblyParsedFrom(givenSubject: string): ImageURI {
+    const proposedURI = super.forciblyParsedFrom(givenSubject);
 
     if (proposedURI.mediaType.fileType !== ImageURI.mediaType) throw new Error(`Expected media type starting with ${ImageURI.mediaType}`);
 

--- a/src/library/customTypes/UniformResourceIdentifier/Data/MediaType.ts
+++ b/src/library/customTypes/UniformResourceIdentifier/Data/MediaType.ts
@@ -92,7 +92,7 @@ export default class MediaType implements StaticStringParser<typeof MediaType> {
     return components.map($0 => $0 ?? '').join('');
   }
 
-  public static tryToParseFrom(givenSubject: string): MediaType {
+  public static forciblyParsedFrom(givenSubject: string): MediaType {
     const [
       rawFileType,
       remainderAfterFileType,

--- a/src/library/customTypes/UniformResourceIdentifier/Data/index.ts
+++ b/src/library/customTypes/UniformResourceIdentifier/Data/index.ts
@@ -17,7 +17,7 @@ import MediaType from './MediaType.ts';
 
 /** See [RFC 2397](https://datatracker.ietf.org/doc/rfc2397) for more info */
 export default class DataURI extends UniformResourceIdentifier {
-  public static readonly scheme = NonTrivialString.tryToParseFrom('data');
+  public static readonly scheme = NonTrivialString.forciblyParsedFrom('data');
   public static readonly encodingPrefix = ';';
   public static readonly dataPrefix = ',';
 
@@ -62,11 +62,11 @@ export default class DataURI extends UniformResourceIdentifier {
       this.data.toString(),
     ];
 
-    return NonTrivialString.tryToParseFrom(components.join(''));
+    return NonTrivialString.forciblyParsedFrom(components.join(''));
   }
 
-  public static override tryToParseFrom(givenSubject: string): DataURI {
-    const proposedURI = super.tryToParseFrom(givenSubject);
+  public static override forciblyParsedFrom(givenSubject: string): DataURI {
+    const proposedURI = super.forciblyParsedFrom(givenSubject);
 
     if (!proposedURI.scheme.isEqualTo(DataURI.scheme)) throw new Error(`Expected scheme to be "${DataURI.scheme.toString()}"`);
 
@@ -99,9 +99,9 @@ export default class DataURI extends UniformResourceIdentifier {
     if (coercedEncoding === undefined) throw new Error(`Expected encoding portion to be defined as one of: ${allDataURIBinaryEncodings.toString()}`);
 
     return new DataURI(
-      MediaType.tryToParseFrom(rawMediaType),
+      MediaType.forciblyParsedFrom(rawMediaType),
       coercedEncoding,
-      Base64CharacterEncodedByteSequence.tryToParseFrom(rawData),
+      Base64CharacterEncodedByteSequence.forciblyParsedFrom(rawData),
     );
   }
 }

--- a/src/library/customTypes/UniformResourceIdentifier/index.ts
+++ b/src/library/customTypes/UniformResourceIdentifier/index.ts
@@ -94,7 +94,7 @@ export default class UniformResourceIdentifier implements StaticStringParser<typ
     return components.map($0 => $0 ?? '').join('');
   }
 
-  public static tryToParseFrom(givenSubject: string): UniformResourceIdentifier {
+  public static forciblyParsedFrom(givenSubject: string): UniformResourceIdentifier {
     const {
       schemeSuffix,
       authorityPrefix,
@@ -173,9 +173,9 @@ export default class UniformResourceIdentifier implements StaticStringParser<typ
     })();
 
     return new UniformResourceIdentifier(
-      NonTrivialString.tryToParseFrom(scheme),
+      NonTrivialString.forciblyParsedFrom(scheme),
       NonTrivialString.nullableParsedFrom(authority),
-      NonTrivialString.tryToParseFrom(path),
+      NonTrivialString.forciblyParsedFrom(path),
       NonTrivialString.nullableParsedFrom(query ?? null),
       NonTrivialString.nullableParsedFrom(fragment ?? null),
     );

--- a/src/library/typeUtilities/StringParser.ts
+++ b/src/library/typeUtilities/StringParser.ts
@@ -1,3 +1,3 @@
 export default interface StringParser<ParsedOutput> {
-  tryToParseFrom(givenSubject: string): ParsedOutput;
+  forciblyParsedFrom(givenSubject: string): ParsedOutput;
 }

--- a/src/pages/TextToImagePage.vue
+++ b/src/pages/TextToImagePage.vue
@@ -48,7 +48,7 @@ const imageGeneration = useStatefulProcess(async () => {
 
   if (proposedPrompt === null) throw new Error('Prompt was not set before submission');
 
-  const generatedOutput = await TextToImage.Client.SDXL.tryToGenerateOutputFrom({
+  const generatedOutput = await TextToImage.Client.SDXL.forciblyGenerateOutputFrom({
     textToImageRequestBody: {
       textPrompts: proposedPrompt,
       height     : 1024,


### PR DESCRIPTION
- migrates the naming convention of these functions from `tryTo...()` to `forcibly...()`

Comparison
- `tryTo...(...)`: was semantically redundant when wrapped with a `try` block
- `forcibly...(...)`:
    - avoids that redundance
    - communicates "an override that might be dangerous or cause some damage, use with caution"