### PR TITLE
refactor: separates branding concerns from `StringSubset`

### DIFF
--- a/src/library/customTypes/StringSubset.ts
+++ b/src/library/customTypes/StringSubset.ts
@@ -1,14 +1,14 @@
+import type {
+  Branded,
+} from '@/library/typeUtilities/Branded';
+
 /**
  * When an open-ended `string` is too permissive, extend this class and provide a means to instantiate some subset
  */
-export default abstract class StringSubset<Brand extends string> extends String {
-  /**
-   * Makes subclasses structurally different from each other.
-   * This allows the type-checker to discern between them and complain about mismatched types.
-   */
-  private readonly brand!: Brand;
-
-  protected constructor(givenInstance: string) {
-    super(givenInstance);
-  }
+abstract class StringSubset<SomeBrand extends string>
+  extends String
+  implements Branded<SomeBrand> {
+  public readonly brand!: SomeBrand;
 }
+
+export default StringSubset;

--- a/src/library/typeUtilities/Branded.ts
+++ b/src/library/typeUtilities/Branded.ts
@@ -1,6 +1,12 @@
-export type Branded<
-  SomePrimitive extends string | number,
-  SomeBrand extends string,
-> = SomePrimitive & {
-  _brand: SomeBrand;
-};
+/**
+ * Creates a type-safe way to distinguish between different subclasses of a base class.
+ *
+ * When implemented by a class, makes subclasses structurally different from each other such that
+ * the type-checker will complain if you try to assign a subclass to a variable of a different subclass.
+ */
+export interface Branded<SomeBrand extends string> {
+  /**
+   * Allows the type-checker to discern between subclasses and complain about mismatched types.
+   */
+  readonly brand: SomeBrand;
+}


### PR DESCRIPTION
- extracts `Branded` from `StringSubset`, taking all the context and docs with it