### PR TITLE
refactor: avoids unconventional "exception" terminology

### DIFF
--- a/src/features/TextToImage/models/SDXL/client/index.ts
+++ b/src/features/TextToImage/models/SDXL/client/index.ts
@@ -60,12 +60,12 @@ export const forciblyGenerateOutputFrom = async (
       !clientFailedToReachServer
     ) throw errorThatPreventedResponse;
 
-    const serverConnectionException = [
+    const messageForServerConnectionError = [
       'Failed to reach the text-to-image server.',
       `Are you sure it's running?`,
     ].join('\n');
 
-    throw new Error(serverConnectionException);
+    throw new Error(messageForServerConnectionError);
   }
 
   const textToImageResponse = outcomeOfSettlingTextToImageResponse.productOfSuccess;

--- a/src/library/Attempt/index.ts
+++ b/src/library/Attempt/index.ts
@@ -17,8 +17,8 @@ const attemptTo = <
     const productFromSomeProcessThatDidNotThrow = getProductFromSomeProcessThatCanThrow();
     return Success.thatYielded(productFromSomeProcessThatDidNotThrow);
   }
-  catch (someException) {
-    const someError = asError(someException);
+  catch (whateverThatWasThrown) {
+    const someError = asError(whateverThatWasThrown);
     return Failure.dueTo(someError);
   }
 };
@@ -47,8 +47,8 @@ const attemptToEventually = async <
     const productFromSomeSuccessfulAsyncProcess: SomeProduct = await getProductFromSomeAsyncProcessThatCanThrow();
     return Success.thatYielded(productFromSomeSuccessfulAsyncProcess);
   }
-  catch (someException) {
-    const someError = asError(someException);
+  catch (whateverThatWasThrown) {
+    const someError = asError(whateverThatWasThrown);
     return Failure.dueTo(someError);
   }
 };

--- a/src/main.ts
+++ b/src/main.ts
@@ -27,7 +27,7 @@ window.onunhandledrejection = (someEvent) => {
 };
 
 // In production version (post build/bundling), errors that originate from Vue components bypass the listeners on the current `Window` instance
-app.config.errorHandler = (someException) => {
-  const someError = asError(someException);
+app.config.errorHandler = (whateverThatWasThrown) => {
+  const someError = asError(whateverThatWasThrown);
   promptUserToReport(someError.message);
 };


### PR DESCRIPTION
- In JavaScript, there's no official construct that differentiates "errors" from "exceptions"
- For the catch parameter we say `whateverThatWasThrown` because
    - "whatever" -> emphasizes lack of type-safety/use of `unknown`
    - "wasThrown" -> since `throw`ing is the only way an error can be caught
    - "that" -> separates subject from predicate so it doesn't give the impression that it's a `boolean`