### PR TITLE
fix: reverts over-reporting of actionable errors

### DIFF
--- a/src/features/TextToImage/models/SDXL/client/index.ts
+++ b/src/features/TextToImage/models/SDXL/client/index.ts
@@ -1,5 +1,6 @@
 import type {
   GenerateFromTextRequest,
+  GenerateFromTextResponse,
 } from 'stabilityai-client-typescript/models/operations';
 
 import Attempt from '@/library/Attempt';
@@ -8,6 +9,10 @@ import ShimmedStabilityAIClient from '@/library/ShimmedStabilityAIClient/index.t
 import Base64CharacterEncodedByteSequence from '@/library/customTypes/Base64CharacterEncodedByteSequence.ts';
 
 import ImageURI from '@/library/customTypes/UniformResourceIdentifier/Data/Image/index.ts';
+
+import {
+  asError,
+} from '@/library/utilitiesByType/error';
 
 import type {
   Output,
@@ -50,15 +55,25 @@ export const forciblyGenerateOutputFrom = async (
     },
   });
 
-  const outcomeOfSettlingTextToImageResponse = await Attempt.toSettle(promisedTextToImageResponse);
+  let textToImageResponse: GenerateFromTextResponse;
 
-  if (outcomeOfSettlingTextToImageResponse.isFailure) {
-    const errorThatPreventedResponse = outcomeOfSettlingTextToImageResponse.causeOfFailure;
-    const clientFailedToReachServer = errorThatPreventedResponse.message.includes('Failed to fetch');
+  // eslint-disable-next-line no-restricted-syntax
+  try {
+    const outcomeOfSettlingTextToImageResponse = await Attempt.toSettle(promisedTextToImageResponse);
+
+    if (
+      outcomeOfSettlingTextToImageResponse.isFailure
+    ) throw outcomeOfSettlingTextToImageResponse.causeOfFailure;
+
+    textToImageResponse = outcomeOfSettlingTextToImageResponse.productOfSuccess;
+  }
+  catch (whateverThatWasThrown) {
+    const someError = asError(whateverThatWasThrown);
+    const clientFailedToReachServer = someError.message.includes('Failed to fetch');
 
     if (
       !clientFailedToReachServer
-    ) throw errorThatPreventedResponse;
+    ) throw someError;
 
     const messageForServerConnectionError = [
       'Failed to reach the text-to-image server.',
@@ -67,8 +82,6 @@ export const forciblyGenerateOutputFrom = async (
 
     throw new Error(messageForServerConnectionError);
   }
-
-  const textToImageResponse = outcomeOfSettlingTextToImageResponse.productOfSuccess;
 
   if (
     !('artifacts' in textToImageResponse.result)

--- a/src/library/Attempt/index.ts
+++ b/src/library/Attempt/index.ts
@@ -3,7 +3,6 @@ import {
 } from '@/library/utilitiesByType/error';
 
 import Outcome, {
-  Failure,
   Success,
 } from './Outcome';
 
@@ -17,7 +16,7 @@ const outcomeOfFailedAttempt = <
   },
 ): Outcome<SomeProduct> => {
   const someError = asError(givenSubject);
-  return Failure.dueTo(someError);
+  throw someError;
 };
 
 const attemptTo = <

--- a/src/library/Attempt/index.ts
+++ b/src/library/Attempt/index.ts
@@ -7,6 +7,19 @@ import Outcome, {
   Success,
 } from './Outcome';
 
+const outcomeOfFailedAttempt = <
+  SomeProduct,
+>(
+  {
+    basedOn: givenSubject,
+  }: {
+    basedOn: unknown;
+  },
+): Outcome<SomeProduct> => {
+  const someError = asError(givenSubject);
+  return Failure.dueTo(someError);
+};
+
 const attemptTo = <
   SomeProduct,
 >(
@@ -18,8 +31,9 @@ const attemptTo = <
     return Success.thatYielded(productFromSomeProcessThatDidNotThrow);
   }
   catch (whateverThatWasThrown) {
-    const someError = asError(whateverThatWasThrown);
-    return Failure.dueTo(someError);
+    return outcomeOfFailedAttempt<SomeProduct>({
+      basedOn: whateverThatWasThrown,
+    });
   }
 };
 
@@ -48,8 +62,9 @@ const attemptToEventually = async <
     return Success.thatYielded(productFromSomeSuccessfulAsyncProcess);
   }
   catch (whateverThatWasThrown) {
-    const someError = asError(whateverThatWasThrown);
-    return Failure.dueTo(someError);
+    return outcomeOfFailedAttempt<SomeProduct>({
+      basedOn: whateverThatWasThrown,
+    });
   }
 };
 


### PR DESCRIPTION
- "every error will be implicitly rethrown": the initial model for error propagation out of the box
   - i.e. every error is assumed to be "non-actionable"
- "every error will be implicitly wrapped and returned": **the misstep addressed by this commit**
   - i.e. every error is assumed to be "actionable"
- "every error will be _explicitly_ rethrown": **the solution introduced by this commit**
   - i.e. every error is stated to be "non-actionable"
- "every error will be explicitly handled": the desired model that we're working towards
   - i.e. some will be explicitly "actionable", others explicitly "non-actionable"
