### PR TITLE
refactor: emphasizes "actionable" errors

### DIFF
--- a/src/features/TextToImage/config/utilities/DynamicConfig/DynamicConfigFetchError.ts
+++ b/src/features/TextToImage/config/utilities/DynamicConfig/DynamicConfigFetchError.ts
@@ -1,0 +1,12 @@
+import type {
+  URLPath,
+} from '@/library/customTypes/URLComponent';
+
+class DynamicConfigFetchingError extends Error {
+  public constructor(givenEndpoint: URLPath) {
+    super(`Failed to fetch text-to-image config from endpoint: ${givenEndpoint.toString()}`);
+    this.name = 'DynamicConfigFetchError';
+  }
+}
+
+export default DynamicConfigFetchingError;

--- a/src/features/TextToImage/config/utilities/DynamicConfig/index.ts
+++ b/src/features/TextToImage/config/utilities/DynamicConfig/index.ts
@@ -5,7 +5,9 @@ import {
 import {
   Config,
   ConfigSchema,
-} from '../types';
+} from '../../types';
+
+import DynamicConfigFetchingError from './DynamicConfigFetchError';
 
 const contentIsJSONIn = (givenResponse: Response): boolean => {
   const contentType = givenResponse.headers.get('Content-Type');
@@ -22,7 +24,7 @@ const forciblyFetchConfig = async (): Promise<Config> => {
 
   if (
     !endpointResponse.ok
-  ) throw new Error('Dynamic config: failed to fetch config from endpoint');
+  ) throw new DynamicConfigFetchingError(configEndpoint);
 
   if (
     !contentIsJSONIn(endpointResponse)
@@ -35,4 +37,5 @@ const forciblyFetchConfig = async (): Promise<Config> => {
 export {
   configEndpoint as endpoint,
   forciblyFetchConfig as forciblyFetch,
+  DynamicConfigFetchingError as FetchingError,
 };

--- a/src/features/TextToImage/config/utilities/StaticConfig/StaticConfigReadingError.ts
+++ b/src/features/TextToImage/config/utilities/StaticConfig/StaticConfigReadingError.ts
@@ -1,0 +1,12 @@
+import type {
+  URLPath,
+} from '@/library/customTypes/URLComponent';
+
+class StaticConfigReadingError extends Error {
+  public constructor(givenFile: URLPath, givenResponse: Response) {
+    super(`Failed to read config at "${givenFile.toString()}". Cause: "${givenResponse.statusText}"`);
+    this.name = 'StaticConfigReadError';
+  }
+}
+
+export default StaticConfigReadingError;

--- a/src/features/TextToImage/config/utilities/StaticConfig/index.ts
+++ b/src/features/TextToImage/config/utilities/StaticConfig/index.ts
@@ -5,7 +5,9 @@ import {
 import {
   Config,
   ConfigSchema,
-} from '../types';
+} from '../../types';
+
+import StaticConfigReadingError from './StaticConfigReadingError';
 
 const configFile = URLPath.forciblyParsedFrom('/config/text-to-image.json');
 
@@ -14,7 +16,7 @@ const forciblyReadConfig = async (): Promise<Config> => {
 
   if (
     !fileResponse.ok
-  ) throw new Error(`Failed to read config: ${fileResponse.statusText}`);
+  ) throw new StaticConfigReadingError(configFile, fileResponse);
 
   const unparsedSchema = await fileResponse.json() as unknown;
   return ConfigSchema.parse(unparsedSchema);
@@ -23,4 +25,5 @@ const forciblyReadConfig = async (): Promise<Config> => {
 export {
   configFile as file,
   forciblyReadConfig as forciblyRead,
+  StaticConfigReadingError as ReadingError,
 };

--- a/src/features/TextToImage/models/SDXL/client/index.ts
+++ b/src/features/TextToImage/models/SDXL/client/index.ts
@@ -75,12 +75,7 @@ export const forciblyGenerateOutputFrom = async (
       !clientFailedToReachServer
     ) throw someError;
 
-    const messageForServerConnectionError = [
-      'Failed to reach the text-to-image server.',
-      `Are you sure it's running?`,
-    ].join('\n');
-
-    throw new Error(messageForServerConnectionError);
+    throw new Server.ConnectionError();
   }
 
   if (

--- a/src/features/TextToImage/webAPI/Server/ServerConnectionError.ts
+++ b/src/features/TextToImage/webAPI/Server/ServerConnectionError.ts
@@ -1,0 +1,13 @@
+class TextToImage_Server_ConnectionError extends Error {
+  public constructor() {
+    const message = [
+      'Failed to reach the text-to-image server.',
+      `Are you sure it's running?`,
+    ].join('\n');
+
+    super(message);
+    this.name = 'TextToImage_ServerConnectionError';
+  }
+}
+
+export default TextToImage_Server_ConnectionError;

--- a/src/features/TextToImage/webAPI/Server/ServerSpecificationError.ts
+++ b/src/features/TextToImage/webAPI/Server/ServerSpecificationError.ts
@@ -1,0 +1,27 @@
+import type {
+  URLPath,
+} from '@/library/customTypes/URLComponent';
+
+class TextToImage_Server_SpecificationError extends Error {
+  public constructor(
+    given: {
+      environmentKey: string;
+      file: URLPath;
+      endpoint: URLPath;
+    },
+  ) {
+    const serverNotSpecifiedErrorMessage = [
+      'No text-to-image server was specified!',
+      'Either:',
+      `a) supply it's corresponding environment variable named \`${given.environmentKey}\` and rebuild`,
+      `b) specify it within ${given.file.toString()}`,
+      'OR',
+      `c) specify it within the response from ${given.endpoint.toString()}`,
+    ].join('\n');
+
+    super(serverNotSpecifiedErrorMessage);
+    this.name = 'ServerSpecificationError';
+  }
+}
+
+export default TextToImage_Server_SpecificationError;

--- a/src/features/TextToImage/webAPI/Server/index.ts
+++ b/src/features/TextToImage/webAPI/Server/index.ts
@@ -7,6 +7,8 @@ import {
   StaticConfig,
 } from '../../config';
 
+import TextToImage_Server_SpecificationError from './ServerSpecificationError';
+
 const environmentKeyForOriginOfTextToImageServer = 'VITE__TEXT_TO_IMAGE__API__SERVER__ORIGIN';
 
 const textToImageServerAccordingToEnvironment = ((): Server | null => {
@@ -22,15 +24,6 @@ const textToImageServerAccordingToEnvironment = ((): Server | null => {
 })();
 
 const forciblyRetrieveCurrentTextToImageServer = async (): Promise<Server> => {
-  const serverNotSpecifiedErrorMessage = [
-    'No text-to-image server was specified!',
-    'Either:',
-    `a) supply it's corresponding environment variable named \`${environmentKeyForOriginOfTextToImageServer}\` and rebuild`,
-    `b) specify it within ${StaticConfig.file.toString()}`,
-    'OR',
-    `c) specify it within the response from ${DynamicConfig.endpoint.toString()}`,
-  ].join('\n');
-
   // eslint-disable-next-line no-restricted-syntax
   try {
     if (
@@ -49,14 +42,23 @@ const forciblyRetrieveCurrentTextToImageServer = async (): Promise<Server> => {
       dynamicConfig.server !== null
     ) return dynamicConfig.server;
 
-    throw new Error(serverNotSpecifiedErrorMessage);
+    throw new TextToImage_Server_SpecificationError({
+      environmentKey: environmentKeyForOriginOfTextToImageServer,
+      file          : StaticConfig.file,
+      endpoint      : DynamicConfig.endpoint,
+    });
   }
   catch {
-    throw new Error(serverNotSpecifiedErrorMessage);
+    throw new TextToImage_Server_SpecificationError({
+      environmentKey: environmentKeyForOriginOfTextToImageServer,
+      file          : StaticConfig.file,
+      endpoint      : DynamicConfig.endpoint,
+    });
   }
 };
 
 export {
   textToImageServerAccordingToEnvironment as accordingToEnvironment,
   forciblyRetrieveCurrentTextToImageServer as forciblyRetrieveCurrent,
+  TextToImage_Server_SpecificationError as SpecificationError,
 };

--- a/src/features/TextToImage/webAPI/Server/index.ts
+++ b/src/features/TextToImage/webAPI/Server/index.ts
@@ -7,6 +7,10 @@ import {
   StaticConfig,
 } from '../../config';
 
+export {
+  default as ConnectionError,
+} from './ServerConnectionError';
+
 import TextToImage_Server_SpecificationError from './ServerSpecificationError';
 
 const environmentKeyForOriginOfTextToImageServer = 'VITE__TEXT_TO_IMAGE__API__SERVER__ORIGIN';

--- a/src/features/TextToImage/webAPI/Server/index.ts
+++ b/src/features/TextToImage/webAPI/Server/index.ts
@@ -5,12 +5,12 @@ import {
 import {
   DynamicConfig,
   StaticConfig,
-} from '../config';
+} from '../../config';
 
-const environmentKeyForOrigin = 'VITE__TEXT_TO_IMAGE__API__SERVER__ORIGIN';
+const environmentKeyForOriginOfTextToImageServer = 'VITE__TEXT_TO_IMAGE__API__SERVER__ORIGIN';
 
-export const accordingToEnvironment = ((): Server | null => {
-  const originAccordingToEnvironment = import.meta.env[environmentKeyForOrigin];
+const textToImageServerAccordingToEnvironment = ((): Server | null => {
+  const originAccordingToEnvironment = import.meta.env[environmentKeyForOriginOfTextToImageServer];
 
   if (
     originAccordingToEnvironment === undefined
@@ -21,11 +21,11 @@ export const accordingToEnvironment = ((): Server | null => {
   });
 })();
 
-export const forciblyRetrieveCurrent = async (): Promise<Server> => {
+const forciblyRetrieveCurrentTextToImageServer = async (): Promise<Server> => {
   const serverNotSpecifiedErrorMessage = [
     'No text-to-image server was specified!',
     'Either:',
-    `a) supply it's corresponding environment variable named \`${environmentKeyForOrigin}\` and rebuild`,
+    `a) supply it's corresponding environment variable named \`${environmentKeyForOriginOfTextToImageServer}\` and rebuild`,
     `b) specify it within ${StaticConfig.file.toString()}`,
     'OR',
     `c) specify it within the response from ${DynamicConfig.endpoint.toString()}`,
@@ -34,8 +34,8 @@ export const forciblyRetrieveCurrent = async (): Promise<Server> => {
   // eslint-disable-next-line no-restricted-syntax
   try {
     if (
-      accordingToEnvironment !== null
-    ) return accordingToEnvironment;
+      textToImageServerAccordingToEnvironment !== null
+    ) return textToImageServerAccordingToEnvironment;
 
     const staticConfig = await StaticConfig.forciblyRead();
 
@@ -54,4 +54,9 @@ export const forciblyRetrieveCurrent = async (): Promise<Server> => {
   catch {
     throw new Error(serverNotSpecifiedErrorMessage);
   }
+};
+
+export {
+  textToImageServerAccordingToEnvironment as accordingToEnvironment,
+  forciblyRetrieveCurrentTextToImageServer as forciblyRetrieveCurrent,
 };

--- a/src/features/TextToImage/webAPI/index.ts
+++ b/src/features/TextToImage/webAPI/index.ts
@@ -1,1 +1,1 @@
-export * as Server from './server';
+export * as Server from './Server';

--- a/src/library/customTypes/NonTrivialString/NonTrivialStringParsingError.ts
+++ b/src/library/customTypes/NonTrivialString/NonTrivialStringParsingError.ts
@@ -1,0 +1,8 @@
+class NonTrivialStringParsingError extends Error {
+  public constructor(givenCulprit: string) {
+    super(`Expected string to contain something beyond just whitespace, got "${givenCulprit}"`);
+    this.name = 'NonTrivialStringParsingError';
+  }
+}
+
+export default NonTrivialStringParsingError;

--- a/src/library/customTypes/NonTrivialString/index.ts
+++ b/src/library/customTypes/NonTrivialString/index.ts
@@ -8,15 +8,19 @@ import {
   isEmpty,
 } from '@/library/utilitiesByType/string.ts';
 
-import StringSubset from './StringSubset.ts';
+import StringSubset from '../StringSubset.ts';
 
-export default class NonTrivialString
+import NonTrivialStringParsingError from './NonTrivialStringParsingError.ts';
+
+class NonTrivialString
   extends StringSubset<'NonTrivialString'>
   implements StaticStringParser<typeof NonTrivialString> {
   public static forciblyParsedFrom(givenSubject: string): NonTrivialString {
     const trimmedSubject = givenSubject.trim();
 
-    if (isEmpty(trimmedSubject)) throw new Error('Expected a non-trivial string');
+    if (
+      isEmpty(trimmedSubject)
+    ) throw new NonTrivialStringParsingError(givenSubject);
 
     return new NonTrivialString(givenSubject);
   }
@@ -31,3 +35,5 @@ export default class NonTrivialString
     return this.toString() === that.toString();
   }
 }
+
+export default NonTrivialString;

--- a/src/library/customTypes/URLComponent/URLOrigin.ts
+++ b/src/library/customTypes/URLComponent/URLOrigin.ts
@@ -4,6 +4,16 @@ import type {
   StaticStringParser,
 } from '@/library/typeUtilities/StaticStringParser.ts';
 
+export class URLOriginParsingError extends Error {
+  public constructor(given: {
+    expectation: string;
+    reality: string;
+  }) {
+    super(`Expected pure origin "${given.expectation}", got "${given.reality}"`);
+    this.name = 'URLOriginParsingError';
+  }
+}
+
 export class URLOrigin
   extends StringSubset<'URLOrigin'>
   implements StaticStringParser<typeof URLOrigin> {
@@ -12,7 +22,10 @@ export class URLOrigin
 
     if (
       derived.origin !== givenSubject
-    ) throw new Error(`Expected pure origin: ${derived.origin}, got: ${givenSubject}`);
+    ) throw new URLOriginParsingError({
+      expectation: derived.origin,
+      reality    : givenSubject,
+    });
 
     return new URLOrigin(derived.origin);
   }

--- a/src/library/customTypes/URLComponent/URLPath.ts
+++ b/src/library/customTypes/URLComponent/URLPath.ts
@@ -4,6 +4,16 @@ import type {
   StaticStringParser,
 } from '@/library/typeUtilities/StaticStringParser.ts';
 
+export class URLPathParsingError extends Error {
+  public constructor(given: {
+    expectation: string;
+    reality: string;
+  }) {
+    super(`Expected pure path: "${given.expectation}", got "${given.reality}"`);
+    this.name = 'URLPathParsingError';
+  }
+}
+
 export class URLPath
   extends StringSubset<'URLPath'>
   implements StaticStringParser<typeof URLPath> {
@@ -12,7 +22,10 @@ export class URLPath
 
     if (
       exampleURL.pathname !== givenSubject
-    ) throw new Error(`Expected pure path: ${exampleURL.pathname}, got: ${givenSubject}`);
+    ) throw new URLPathParsingError({
+      expectation: exampleURL.pathname,
+      reality    : givenSubject,
+    });
 
     return new URLPath(exampleURL.pathname);
   }

--- a/src/library/customTypes/UniformResourceIdentifier/Data/DataURIParsingError.ts
+++ b/src/library/customTypes/UniformResourceIdentifier/Data/DataURIParsingError.ts
@@ -1,0 +1,8 @@
+class DataURIParsingError extends Error {
+  public constructor(givenMessage: string) {
+    super(givenMessage);
+    this.name = 'URIParsingError';
+  }
+}
+
+export default DataURIParsingError;

--- a/src/library/customTypes/UniformResourceIdentifier/Data/Image/ImageURIParsingError.ts
+++ b/src/library/customTypes/UniformResourceIdentifier/Data/Image/ImageURIParsingError.ts
@@ -1,0 +1,8 @@
+class ImageURIParsingError extends Error {
+  public constructor(givenMessage: string) {
+    super(givenMessage);
+    this.name = 'ImageURIParsingError';
+  }
+}
+
+export default ImageURIParsingError;

--- a/src/library/customTypes/UniformResourceIdentifier/Data/Image/index.ts
+++ b/src/library/customTypes/UniformResourceIdentifier/Data/Image/index.ts
@@ -13,6 +13,8 @@ import {
   type ImageURIFormat,
 } from './ImageURIFormat.ts';
 
+import ImageURIParsingError from './ImageURIParsingError.ts';
+
 export default class ImageURI extends DataURI {
   public static readonly mediaType = 'image';
 
@@ -48,11 +50,15 @@ export default class ImageURI extends DataURI {
   public static override forciblyParsedFrom(givenSubject: string): ImageURI {
     const proposedURI = super.forciblyParsedFrom(givenSubject);
 
-    if (proposedURI.mediaType.fileType !== ImageURI.mediaType) throw new Error(`Expected media type starting with ${ImageURI.mediaType}`);
+    if (
+      proposedURI.mediaType.fileType !== ImageURI.mediaType
+    ) throw new ImageURIParsingError(`Expected media type starting with ${ImageURI.mediaType}`);
 
     const format = allImageURIFormats.find($0 => $0 === proposedURI.mediaType.fileSubtype);
 
-    if (format === undefined) throw new Error(`Expected format to be one of ${allImageURIFormats.toString()}`);
+    if (
+      format === undefined
+    ) throw new ImageURIParsingError(`Expected format to be one of ${allImageURIFormats.toString()}`);
 
     return new ImageURI(
       format,

--- a/src/library/customTypes/UniformResourceIdentifier/Data/MediaType.ts
+++ b/src/library/customTypes/UniformResourceIdentifier/Data/MediaType.ts
@@ -6,6 +6,8 @@ import {
   isEmpty,
 } from '@/library/utilitiesByType/array.ts';
 
+import MediaTypeParsingError from './MediaTypeParsingError';
+
 const allFileTypes = [
   'application',
   'text',
@@ -101,11 +103,13 @@ export default class MediaType implements StaticStringParser<typeof MediaType> {
 
     if (
       !isEmpty(componentsFollowingUnexpectedFileTypeSuffix)
-    ) throw new Error(`Found component sets after extraneous file type suffix(es): ${componentsFollowingUnexpectedFileTypeSuffix.toString()}`);
+    ) throw new MediaTypeParsingError(`Found component sets after extraneous file type suffix(es): ${componentsFollowingUnexpectedFileTypeSuffix.toString()}`);
 
     const fileType = allFileTypes.find($0 => $0 === rawFileType);
 
-    if (fileType === undefined) throw new Error(`Expected file type as one of ${allFileTypes.toString()}`);
+    if (
+      fileType === undefined
+    ) throw new MediaTypeParsingError(`Expected file type as one of ${allFileTypes.toString()}`);
 
     const [
       remainderBeforeParameters,
@@ -121,15 +125,15 @@ export default class MediaType implements StaticStringParser<typeof MediaType> {
 
       if (
         !isEmpty(extraneousComponentsInEachParameter)
-      ) throw new Error(`Found extraneous components in parameter at index ${indexOfEachParameter.toString()}: ${extraneousComponentsInEachParameter.toString()}`);
+      ) throw new MediaTypeParsingError(`Found extraneous components in parameter at index ${indexOfEachParameter.toString()}: ${extraneousComponentsInEachParameter.toString()}`);
 
       if (
         keyOfEachParameter === undefined
-      ) throw new Error(`Expected key for parameter at index ${indexOfEachParameter.toString()}`);
+      ) throw new MediaTypeParsingError(`Expected key for parameter at index ${indexOfEachParameter.toString()}`);
 
       if (
         valueOfEachParameter === undefined
-      ) throw new Error(`Expected value for parameter at index ${indexOfEachParameter.toString()}`);
+      ) throw new MediaTypeParsingError(`Expected value for parameter at index ${indexOfEachParameter.toString()}`);
 
       return [
         keyOfEachParameter,
@@ -145,7 +149,7 @@ export default class MediaType implements StaticStringParser<typeof MediaType> {
 
     if (
       !isEmpty(extraComponentsWithStructureTypePrefix)
-    ) throw new Error(`Unexpected component sets after extraneous structure type prefix(es): ${extraComponentsWithStructureTypePrefix.toString()}`);
+    ) throw new MediaTypeParsingError(`Unexpected component sets after extraneous structure type prefix(es): ${extraComponentsWithStructureTypePrefix.toString()}`);
 
     const structureType = (() => {
       if (rawStructureType === undefined) return null;
@@ -154,20 +158,22 @@ export default class MediaType implements StaticStringParser<typeof MediaType> {
 
       if (
         potentialStructureType === undefined
-      ) throw new Error(`Expected structure type as one of ${allStructuredSyntaxNameSuffix.toString()}`);
+      ) throw new MediaTypeParsingError(`Expected structure type as one of ${allStructuredSyntaxNameSuffix.toString()}`);
 
       return potentialStructureType;
     })();
 
     if (
       serializedTreeBranchesEndingInFileSubtype === undefined
-    ) throw new Error('Expected file subtype');
+    ) throw new MediaTypeParsingError('Expected file subtype');
 
     const treeBranchesEndingInFileSubtype = serializedTreeBranchesEndingInFileSubtype.split(MediaType.treeBranchSuffix);
     const reversedTreeBranchesBeginningWithFileSubtype = treeBranchesEndingInFileSubtype.reverse();
     const fileSubtype = reversedTreeBranchesBeginningWithFileSubtype.shift();
 
-    if (fileSubtype === undefined) throw new Error('Expected file subtype');
+    if (
+      fileSubtype === undefined
+    ) throw new MediaTypeParsingError('Expected file subtype');
 
     const tree = reversedTreeBranchesBeginningWithFileSubtype.reverse();
 

--- a/src/library/customTypes/UniformResourceIdentifier/Data/MediaTypeParsingError.ts
+++ b/src/library/customTypes/UniformResourceIdentifier/Data/MediaTypeParsingError.ts
@@ -1,0 +1,8 @@
+class MediaTypeParsingError extends Error {
+  public constructor(givenMessage: string) {
+    super(givenMessage);
+    this.name = 'MediaTypeParsingError';
+  }
+}
+
+export default MediaTypeParsingError;

--- a/src/library/customTypes/UniformResourceIdentifier/Data/index.ts
+++ b/src/library/customTypes/UniformResourceIdentifier/Data/index.ts
@@ -1,6 +1,6 @@
 import Base64CharacterEncodedByteSequence from '@/library/customTypes/Base64CharacterEncodedByteSequence.ts';
 
-import NonTrivialString from '@/library/customTypes/NonTrivialString.ts';
+import NonTrivialString from '@/library/customTypes/NonTrivialString';
 
 import {
   isEmpty,

--- a/src/library/customTypes/UniformResourceIdentifier/Data/index.ts
+++ b/src/library/customTypes/UniformResourceIdentifier/Data/index.ts
@@ -13,6 +13,7 @@ import {
   type DataURIBinaryEncoding,
 } from './DataURIBinaryEncoding.ts';
 
+import DataURIParsingError from './DataURIParsingError.ts';
 import MediaType from './MediaType.ts';
 
 /** See [RFC 2397](https://datatracker.ietf.org/doc/rfc2397) for more info */
@@ -68,7 +69,9 @@ export default class DataURI extends UniformResourceIdentifier {
   public static override forciblyParsedFrom(givenSubject: string): DataURI {
     const proposedURI = super.forciblyParsedFrom(givenSubject);
 
-    if (!proposedURI.scheme.isEqualTo(DataURI.scheme)) throw new Error(`Expected scheme to be "${DataURI.scheme.toString()}"`);
+    if (
+      !proposedURI.scheme.isEqualTo(DataURI.scheme)
+    ) throw new DataURIParsingError(`Expected scheme to be "${DataURI.scheme.toString()}"`);
 
     const [
       mediaTypeAndEncoding,
@@ -78,9 +81,11 @@ export default class DataURI extends UniformResourceIdentifier {
 
     if (
       !isEmpty(extraComponentsWithDataPrefix)
-    ) throw new Error(`Unexpected components with data prefix: ${extraComponentsWithDataPrefix.toString()}`);
+    ) throw new DataURIParsingError(`Unexpected components with data prefix: ${extraComponentsWithDataPrefix.toString()}`);
 
-    if (rawData === undefined) throw new Error('Expected data portion to be defined');
+    if (
+      rawData === undefined
+    ) throw new DataURIParsingError('Expected data portion to be defined');
 
     const [
       rawMediaType,
@@ -90,13 +95,17 @@ export default class DataURI extends UniformResourceIdentifier {
 
     if (
       !isEmpty(extraComponentsWithEncodingPrefix)
-    ) throw new Error(`Unexpected components with encoding prefix: ${extraComponentsWithEncodingPrefix.toString()}`);
+    ) throw new DataURIParsingError(`Unexpected components with encoding prefix: ${extraComponentsWithEncodingPrefix.toString()}`);
 
-    if (rawMediaType === undefined) throw new Error('Expected `mediaType` portion to be defined');
+    if (
+      rawMediaType === undefined
+    ) throw new DataURIParsingError('Expected `mediaType` portion to be defined');
 
     const coercedEncoding = allDataURIBinaryEncodings.find($0 => $0 === rawEncoding);
 
-    if (coercedEncoding === undefined) throw new Error(`Expected encoding portion to be defined as one of: ${allDataURIBinaryEncodings.toString()}`);
+    if (
+      coercedEncoding === undefined
+    ) throw new DataURIParsingError(`Expected encoding portion to be defined as one of: ${allDataURIBinaryEncodings.toString()}`);
 
     return new DataURI(
       MediaType.forciblyParsedFrom(rawMediaType),

--- a/src/library/customTypes/UniformResourceIdentifier/URIParsingError.ts
+++ b/src/library/customTypes/UniformResourceIdentifier/URIParsingError.ts
@@ -1,0 +1,8 @@
+class URIParsingError extends Error {
+  public constructor(givenMessage: string) {
+    super(givenMessage);
+    this.name = 'URIParsingError';
+  }
+}
+
+export default URIParsingError;

--- a/src/library/customTypes/UniformResourceIdentifier/index.ts
+++ b/src/library/customTypes/UniformResourceIdentifier/index.ts
@@ -8,6 +8,8 @@ import {
   isEmpty,
 } from '@/library/utilitiesByType/array.ts';
 
+import URIParsingError from './URIParsingError';
+
 /**
  * Identifies an abstract or physical resource.
  * See [RFC 3986](https://www.rfc-editor.org/rfc/rfc3986) for more information
@@ -110,9 +112,11 @@ export default class UniformResourceIdentifier implements StaticStringParser<typ
 
     if (
       !isEmpty(componentsFollowingUnexpectedSchemeSuffix)
-    ) throw new Error(`Found components with extra scheme suffix: ${componentsFollowingUnexpectedSchemeSuffix.join()}`);
+    ) throw new URIParsingError(`Found components with extra scheme suffix: ${componentsFollowingUnexpectedSchemeSuffix.join()}`);
 
-    if (scheme === undefined) throw new Error('Expected a scheme');
+    if (
+      scheme === undefined
+    ) throw new URIParsingError('Expected a scheme');
 
     const [
       componentsPrecedingFragment,
@@ -122,7 +126,7 @@ export default class UniformResourceIdentifier implements StaticStringParser<typ
 
     if (
       !isEmpty(unexpectedComponentsWithFragmentPrefix)
-    ) throw new Error(`Found extra components with fragment prefix: ${unexpectedComponentsWithFragmentPrefix.join()}`);
+    ) throw new URIParsingError(`Found extra components with fragment prefix: ${unexpectedComponentsWithFragmentPrefix.join()}`);
 
     const [
       componentsPrecedingQuery,
@@ -132,9 +136,11 @@ export default class UniformResourceIdentifier implements StaticStringParser<typ
 
     if (
       !isEmpty(unexpectedComponentsWithQueryPrefix)
-    ) throw new Error(`Found extra components with query prefix: ${unexpectedComponentsWithQueryPrefix.join()}`);
+    ) throw new URIParsingError(`Found extra components with query prefix: ${unexpectedComponentsWithQueryPrefix.join()}`);
 
-    if (componentsPrecedingQuery === undefined) throw new Error('Expected components preceding query');
+    if (
+      componentsPrecedingQuery === undefined
+    ) throw new URIParsingError('Expected components preceding query');
 
     const pathSegmentDelimiter = '/';
 
@@ -164,7 +170,9 @@ export default class UniformResourceIdentifier implements StaticStringParser<typ
         ...pathSegments
       ] = authorityAndPath.split(pathSegmentDelimiter);
 
-      if (authority === undefined) throw new Error('Expected to find authority between its prefix and the path segments');
+      if (
+        authority === undefined
+      ) throw new URIParsingError('Expected to find authority between its prefix and the path segments');
 
       return {
         authority,

--- a/src/library/customTypes/UniformResourceIdentifier/index.ts
+++ b/src/library/customTypes/UniformResourceIdentifier/index.ts
@@ -1,4 +1,4 @@
-import NonTrivialString from '@/library/customTypes/NonTrivialString.ts';
+import NonTrivialString from '@/library/customTypes/NonTrivialString';
 
 import type {
   StaticStringParser,


### PR DESCRIPTION
- the expectations for thrown errors weren't obvious at a glance:
    - is the error meant to suggest changing our inputs and trying again? Some other means of recovery?
    - or is the error meant to enforce correct implementation?
- this commit establishes that, if we bothered to make a custom `Error`, the error was meant to encourage recovery