### PR TITLE
fix(utility): avoids reference race in `Byte`

### DIFF
--- a/src/library/Byte/Sequence/EncodingCompatibilityError.ts
+++ b/src/library/Byte/Sequence/EncodingCompatibilityError.ts
@@ -1,8 +1,10 @@
-import * as Byte from '@/library/Byte';
+import {
+  cofactorTo as Byte_cofactorTo,
+} from '..';
 
 class Byte_Sequence_EncodingCompatibilityError extends Error {
   public constructor(givenBitWidth: number) {
-    const byteCofactor = Byte.cofactorTo(givenBitWidth);
+    const byteCofactor = Byte_cofactorTo(givenBitWidth);
     super(`Character count for ${givenBitWidth.toString()}-bit sequence must be a multiple of ${byteCofactor.toString()} to be byte encodable`);
     this.name = 'Byte_Sequence_CompatibilityError';
   }


### PR DESCRIPTION
Introduced in #220