### PR TITLE
refactor(dx): guides propagation of "non-actionable" errors

### DIFF
--- a/src/features/TextToImage/models/SDXL/client/index.ts
+++ b/src/features/TextToImage/models/SDXL/client/index.ts
@@ -66,7 +66,7 @@ export const forciblyGenerateOutputFrom = async (
 
     if (
       outcomeOfSettlingTextToImageResponse.isFailure
-    ) throw outcomeOfSettlingTextToImageResponse.causeOfFailure;
+    ) return NonActionableError.rethrow(outcomeOfSettlingTextToImageResponse.causeOfFailure);
 
     textToImageResponse = outcomeOfSettlingTextToImageResponse.productOfSuccess;
   }
@@ -76,7 +76,7 @@ export const forciblyGenerateOutputFrom = async (
 
     if (
       !clientFailedToReachServer
-    ) throw someError;
+    ) return NonActionableError.rethrow(someError);
 
     return new Server.ConnectionError().throwAnyway();
   }

--- a/src/library/Attempt/Outcome.ts
+++ b/src/library/Attempt/Outcome.ts
@@ -52,7 +52,7 @@ interface Failure extends SemanticallySugarfreeFailure {
    *   someOutcome.isSuccess
    * ) return;
    *
-   * throw someOutcome.causeOfFailure;
+   * return NonActionableError.rethrow(someOutcome.causeOfFailure);
    * ```
    */
   readonly causeOfFailure: this['cause'];

--- a/src/library/Attempt/error/NonActionableError.ts
+++ b/src/library/Attempt/error/NonActionableError.ts
@@ -20,6 +20,35 @@ class NonActionableError
     super(givenMessage, givenOptions);
     this.name = 'NonActionableError';
   }
+
+  public throw(): never {
+    throw this;
+  }
+
+  public static throw = (
+    givenMessage: NonActionableError['message'],
+    givenOptions?: ErrorOptions,
+  ): never => {
+    const newError = new NonActionableError(givenMessage, givenOptions);
+
+    if (
+      ('captureStackTrace' in Error)
+      && (Error.captureStackTrace instanceof Function)
+    ) {
+      Error.captureStackTrace.call(undefined, newError, NonActionableError.throw);
+    }
+
+    return newError.throw();
+  };
+
+  public static rethrow = (givenError: Error): never => {
+    return this.throw(
+      'Expected error to be either re-interpreted or handled altogether',
+      {
+        cause: givenError,
+      },
+    );
+  };
 }
 
 export default NonActionableError;

--- a/src/library/Attempt/index.ts
+++ b/src/library/Attempt/index.ts
@@ -21,7 +21,7 @@ const outcomeOfFailedAttempt = <
   },
 ): Outcome<SomeProduct> => {
   const someError = asError(givenSubject);
-  throw someError;
+  return NonActionableError.rethrow(someError);
 };
 
 const attemptTo = <


### PR DESCRIPTION
- forces devs to explicit state that they're delegating the handling of an error to a caller further up the stack