### PR TITLE
fix(library): ensures adapters propagate errors according to their category

### DIFF
--- a/src/library/Attempt/error/HonoraryNonActionableError.ts
+++ b/src/library/Attempt/error/HonoraryNonActionableError.ts
@@ -1,0 +1,68 @@
+import type {
+  Branded,
+} from '@/library/typeUtilities/Branded';
+
+import {
+  isError,
+} from '@/library/utilitiesByType/error';
+
+// These augmentations allow TypeScript to distinguish these error types from `Error` at the annotation level.
+declare global {
+  interface ReferenceError extends Branded<'ReferenceError'> {
+    readonly brand: this['name'];
+  }
+
+  interface TypeError extends Branded<'TypeError'> {
+    readonly brand: this['name'];
+  }
+
+  interface RangeError extends Branded<'RangeError'> {
+    readonly brand: this['name'];
+  }
+
+  interface URIError extends Branded<'URIError'> {
+    readonly brand: this['name'];
+  }
+
+  interface EvalError extends Branded<'EvalError'> {
+    readonly brand: this['name'];
+  }
+
+  interface SyntaxError extends Branded<'SyntaxError'> {
+    readonly brand: this['name'];
+  }
+}
+
+/**
+ * Error classes whose only plausible cause is a programmer bug or a violated language/runtime invariant.
+ *
+ * These errors are not expected to be caught or handled in any way.
+ */
+type HonoraryNonActionableError =
+  | ReferenceError // Something was referenced that doesn't exist in scope.
+  | TypeError // Something was called/iterated/assigned that can’t possibly support that operation.
+  | RangeError // Runtime was asked to create an impossible value.
+  | URIError // An illegal escape sequence was passed to decodeURI/encodeURI.
+  | EvalError // Something illegal was done with `eval` or `Function` constructor.
+  | SyntaxError; // The JS engine couldn't even parse the code.
+
+const HonoraryNonActionableError = {
+  [Symbol.hasInstance]: (givenSubject: unknown): givenSubject is HonoraryNonActionableError => {
+    if (
+      !isError(givenSubject)
+    ) return false;
+
+    const givenError = givenSubject;
+
+    return (
+      (givenError instanceof ReferenceError)
+      || (givenError instanceof TypeError)
+      || (givenError instanceof RangeError)
+      || (givenError instanceof URIError)
+      || (givenError instanceof EvalError)
+      || (givenError instanceof SyntaxError)
+    );
+  },
+};
+
+export default HonoraryNonActionableError;

--- a/src/library/Attempt/error/modifier/PotentiallyActionable.ts
+++ b/src/library/Attempt/error/modifier/PotentiallyActionable.ts
@@ -1,8 +1,9 @@
+import HonoraryNonActionableError from '../HonoraryNonActionableError';
 import NonActionableError from '../NonActionableError';
 
 export type PotentiallyActionable<
   SomeError extends Error,
-> = Exclude<SomeError, NonActionableError>;
+> = Exclude<SomeError, NonActionableError | HonoraryNonActionableError>;
 
 export const assertPotentiallyActionable = <
   SomeError extends Error,
@@ -12,6 +13,10 @@ export const assertPotentiallyActionable = <
   if (
     givenError instanceof NonActionableError
   ) return givenError.throw();
+
+  if (
+    givenError instanceof HonoraryNonActionableError
+  ) return NonActionableError.rethrow(givenError);
 
   return givenError as PotentiallyActionable<SomeError>;
 };

--- a/src/library/Attempt/error/modifier/PotentiallyActionable.ts
+++ b/src/library/Attempt/error/modifier/PotentiallyActionable.ts
@@ -1,0 +1,17 @@
+import NonActionableError from '../NonActionableError';
+
+export type PotentiallyActionable<
+  SomeError extends Error,
+> = Exclude<SomeError, NonActionableError>;
+
+export const assertPotentiallyActionable = <
+  SomeError extends Error,
+>(
+  givenError: SomeError,
+): PotentiallyActionable<SomeError> => {
+  if (
+    givenError instanceof NonActionableError
+  ) return givenError.throw();
+
+  return givenError as PotentiallyActionable<SomeError>;
+};

--- a/src/library/Attempt/error/modifier/SafelyPropagated.ts
+++ b/src/library/Attempt/error/modifier/SafelyPropagated.ts
@@ -1,0 +1,26 @@
+import ActionableError from '../ActionableError';
+
+import type {
+  PotentiallyActionable,
+} from './PotentiallyActionable';
+
+type SafelyPropagated<
+  SomePotentiallyActionableError extends PotentiallyActionable<Error>,
+> = Exclude<
+  SomePotentiallyActionableError,
+  ActionableError<string>
+>;
+
+export const assertSafelyPropagated = <
+  SomePotentiallyActionableError extends PotentiallyActionable<Error>,
+>(
+  givenError: SomePotentiallyActionableError,
+): SafelyPropagated<SomePotentiallyActionableError> => {
+  // Propagated beyond confines of type system
+  // i.e. with raw `throw` instead of `.throwAnyway()` method
+  if (
+    givenError instanceof ActionableError
+  ) return givenError.throwAnyway();
+
+  return givenError as SafelyPropagated<SomePotentiallyActionableError>;
+};

--- a/src/library/Attempt/error/modifier/index.ts
+++ b/src/library/Attempt/error/modifier/index.ts
@@ -1,3 +1,7 @@
 export {
   assertPotentiallyActionable,
 } from './PotentiallyActionable';
+
+export {
+  assertSafelyPropagated,
+} from './SafelyPropagated';

--- a/src/library/Attempt/error/modifier/index.ts
+++ b/src/library/Attempt/error/modifier/index.ts
@@ -1,0 +1,3 @@
+export {
+  assertPotentiallyActionable,
+} from './PotentiallyActionable';

--- a/src/library/Attempt/index.ts
+++ b/src/library/Attempt/index.ts
@@ -13,6 +13,7 @@ import {
 
 import {
   assertPotentiallyActionable,
+  assertSafelyPropagated,
 } from './error/modifier';
 
 const outcomeOfFailedAttempt = <
@@ -26,7 +27,8 @@ const outcomeOfFailedAttempt = <
 ): Outcome<SomeProduct> => {
   const someError = asError(givenSubject);
   const potentiallyActionableError = assertPotentiallyActionable(someError);
-  return NonActionableError.rethrow(potentiallyActionableError);
+  const safelyPropagatedError = assertSafelyPropagated(potentiallyActionableError);
+  return NonActionableError.rethrow(safelyPropagatedError);
 };
 
 const attemptTo = <

--- a/src/library/Attempt/index.ts
+++ b/src/library/Attempt/index.ts
@@ -11,6 +11,10 @@ import {
   ActionableError,
 } from './error';
 
+import {
+  assertPotentiallyActionable,
+} from './error/modifier';
+
 const outcomeOfFailedAttempt = <
   SomeProduct,
 >(
@@ -21,7 +25,8 @@ const outcomeOfFailedAttempt = <
   },
 ): Outcome<SomeProduct> => {
   const someError = asError(givenSubject);
-  return NonActionableError.rethrow(someError);
+  const potentiallyActionableError = assertPotentiallyActionable(someError);
+  return NonActionableError.rethrow(potentiallyActionableError);
 };
 
 const attemptTo = <


### PR DESCRIPTION
- before, every error was rethrown as is, and we couldn't tell whether it was expected to be "actionable"
- but now we can tell when an error is
  - defined by the runtime to be non-actionable
  - defined by an author to be non-actionable
  - defined by an author to be actionable but improperly propagated