### PR TITLE
ci: adds new commit type for features that affect devs and not users

### DIFF
--- a/.github/workflows/conventional-commit.yml
+++ b/.github/workflows/conventional-commit.yml
@@ -17,4 +17,4 @@ jobs:
       - name: Ensure PR Title Conforms To Conventional Commit Message
         uses:  ytanikin/pr-conventional-commits@1.4.0
         with:
-         task_types: '["feature","fix","docs","tests","build","ci","refactor","chore","revert","linter","types"]'
+          task_types: '["feature","pre-feature","fix","docs","tests","build","ci","refactor","chore","revert","linter","types"]'


### PR DESCRIPTION
- needed a term that means "something new for devs that users won't directly notice"
- slightly beyond a "refactor" because those result in new functionality for devs
- slightly short of a "feature" because the functionality isn't user-facing
- usually denotes a conducive precursor to a user-facing feature, hence "pre-feature"