### PR TITLE
refactor(text-to-image): makes it obvious that generation errors need to be handled

### DIFF
--- a/src/features/TextToImage/models/SDXL/client/index.ts
+++ b/src/features/TextToImage/models/SDXL/client/index.ts
@@ -5,6 +5,7 @@ import type {
 
 import Attempt, {
   NonActionableError,
+  Outcome,
 } from '@/library/Attempt';
 
 import ShimmedStabilityAIClient from '@/library/ShimmedStabilityAIClient/index.ts';
@@ -24,12 +25,22 @@ import {
   Server,
 } from '@/features/TextToImage/webAPI';
 
-const forciblyInitializeShimmedStabilityAIClient = async (): Promise<ShimmedStabilityAIClient> => {
-  const textToImageServer = (await Server.retrieveCurrent()).forciblyUnwrap();
+const initializeShimmedStabilityAIClient = async (): Promise<
+  Outcome<ShimmedStabilityAIClient, Server.SpecificationError>
+> => {
+  const outcomeOfRetrievingCurrentServer = await Server.retrieveCurrent();
 
-  return new ShimmedStabilityAIClient({
+  if (
+    outcomeOfRetrievingCurrentServer.isFailure
+  ) return outcomeOfRetrievingCurrentServer;
+
+  const textToImageServer = outcomeOfRetrievingCurrentServer.unwrapped;
+
+  const newClient = new ShimmedStabilityAIClient({
     serverURL: textToImageServer.origin,
   });
+
+  return Outcome.successThatYielded(newClient);
 };
 
 export const forciblyGenerateOutputFrom = async (
@@ -44,7 +55,7 @@ export const forciblyGenerateOutputFrom = async (
     >;
   },
 ): Promise<Output> => {
-  const shimmedStabilityAIClient = await forciblyInitializeShimmedStabilityAIClient();
+  const shimmedStabilityAIClient = (await initializeShimmedStabilityAIClient()).forciblyUnwrap();
 
   const promisedTextToImageResponse = shimmedStabilityAIClient.version1.image.forciblyGenerateFromText({
     engineId              : 'stable-diffusion-xl-1024-v1-0',

--- a/src/features/TextToImage/models/SDXL/client/index.ts
+++ b/src/features/TextToImage/models/SDXL/client/index.ts
@@ -43,7 +43,11 @@ const initializeShimmedStabilityAIClient = async (): Promise<
   return Outcome.successThatYielded(newClient);
 };
 
-export const forciblyGenerateOutputFrom = async (
+type OutcomeOfGeneratingTextToImageOutput = Outcome<Output,
+  | Server.ConnectionError
+>;
+
+export const generateOutputFrom = async (
   given: {
     textToImageRequestBody: Pick<GenerateFromTextRequest['textToImageRequestBody'],
     | 'textPrompts'
@@ -54,7 +58,7 @@ export const forciblyGenerateOutputFrom = async (
     | 'seed'
     >;
   },
-): Promise<Output> => {
+): Promise<OutcomeOfGeneratingTextToImageOutput> => {
   const shimmedStabilityAIClient = (await initializeShimmedStabilityAIClient()).forciblyUnwrap();
 
   const promisedTextToImageResponse = shimmedStabilityAIClient.version1.image.forciblyGenerateFromText({
@@ -91,7 +95,7 @@ export const forciblyGenerateOutputFrom = async (
       !clientFailedToReachServer
     ) return NonActionableError.rethrow(someError);
 
-    return new Server.ConnectionError().throwAnyway();
+    return Outcome.failureDueTo(new Server.ConnectionError());
   }
 
   if (
@@ -126,13 +130,13 @@ export const forciblyGenerateOutputFrom = async (
       .join(', '),
   };
 
-  return {
+  return Outcome.successThatYielded({
     image: newImage,
-  };
+  });
 };
 
 const SDXLTextToImageClient = {
-  forciblyGenerateOutputFrom,
+  generateOutputFrom,
 };
 
 export default SDXLTextToImageClient;

--- a/src/features/TextToImage/models/SDXL/client/index.ts
+++ b/src/features/TextToImage/models/SDXL/client/index.ts
@@ -25,7 +25,7 @@ import {
 } from '@/features/TextToImage/webAPI';
 
 const forciblyInitializeShimmedStabilityAIClient = async (): Promise<ShimmedStabilityAIClient> => {
-  const textToImageServer = await Server.forciblyRetrieveCurrent();
+  const textToImageServer = (await Server.retrieveCurrent()).forciblyUnwrap();
 
   return new ShimmedStabilityAIClient({
     serverURL: textToImageServer.origin,

--- a/src/features/TextToImage/webAPI/Server/index.ts
+++ b/src/features/TextToImage/webAPI/Server/index.ts
@@ -1,4 +1,8 @@
 import {
+  Outcome,
+} from '@/library/Attempt';
+
+import {
   Server,
 } from '@/library/WebAPI';
 
@@ -28,32 +32,36 @@ const textToImageServerAccordingToEnvironment = ((): Server | null => {
   });
 })();
 
-const forciblyRetrieveCurrentTextToImageServer = async (): Promise<Server> => {
+const retrieveCurrentTextToImageServer = async (): Promise<
+  Outcome<Server, TextToImage_Server_SpecificationError>
+> => {
   if (
     textToImageServerAccordingToEnvironment !== null
-  ) return textToImageServerAccordingToEnvironment;
+  ) return Outcome.successThatYielded(textToImageServerAccordingToEnvironment);
 
   const staticConfig = (await StaticConfig.read()).optionallyUnwrap() ?? emptyConfig;
 
   if (
     staticConfig.server !== null
-  ) return staticConfig.server;
+  ) return Outcome.successThatYielded(staticConfig.server);
 
   const dynamicConfig = (await DynamicConfig.fetch()).optionallyUnwrap() ?? emptyConfig;
 
   if (
     dynamicConfig.server !== null
-  ) return dynamicConfig.server;
+  ) return Outcome.successThatYielded(dynamicConfig.server);
 
-  return new TextToImage_Server_SpecificationError({
+  const newSpecificationError = new TextToImage_Server_SpecificationError({
     environmentKey: environmentKeyForOriginOfTextToImageServer,
     file          : StaticConfig.file,
     endpoint      : DynamicConfig.endpoint,
-  }).throwAnyway();
+  });
+
+  return Outcome.failureDueTo(newSpecificationError);
 };
 
 export {
   textToImageServerAccordingToEnvironment as accordingToEnvironment,
-  forciblyRetrieveCurrentTextToImageServer as forciblyRetrieveCurrent,
+  retrieveCurrentTextToImageServer as retrieveCurrent,
   TextToImage_Server_SpecificationError as SpecificationError,
 };

--- a/src/library/HTTPClient/index.ts
+++ b/src/library/HTTPClient/index.ts
@@ -1,3 +1,7 @@
+import {
+  Outcome,
+} from '@/library/Attempt';
+
 import type {
   URLOrigin,
   URLPath,
@@ -29,7 +33,7 @@ export default class HTTPClient {
     );
   }
 
-  public async forciblySend(
+  public async send(
     givenRequestBody: unknown,
     {
       to: givenPath,
@@ -38,32 +42,34 @@ export default class HTTPClient {
       to: URLPath;
       using: HTTPRequest.Method;
     },
-  ): Promise<unknown> {
+  ): Promise<Outcome<unknown, HTTPResponseError>> {
     const response = await fetch(this.originAt(givenPath), {
       method : givenMethod,
       headers: this.headers,
       body   : JSON.stringify(givenRequestBody),
     });
 
-    if (!response.ok) return new HTTPResponseError(response.statusText, response.status).throwAnyway();
+    if (
+      !response.ok
+    ) return Outcome.failureDueTo(new HTTPResponseError(response.statusText, response.status));
 
-    return await response.json();
+    return Outcome.successThatYielded(await response.json());
   }
 
-  public async forciblyFetchResource(
+  public async fetchResource(
     {
       from: givenPath,
     }: {
       from: URLPath;
     },
-  ): Promise<unknown> {
-    return await this.forciblySend(null, {
+  ): Promise<Outcome<unknown, HTTPResponseError>> {
+    return await this.send(null, {
       to   : givenPath,
       using: HTTPRequest.Method.FETCH,
     });
   }
 
-  public async forciblySubmitResource(
+  public async submitResource(
     {
       bySending: givenSubmission,
       to: givenPath,
@@ -71,14 +77,14 @@ export default class HTTPClient {
       bySending: unknown;
       to: URLPath;
     },
-  ): Promise<unknown> {
-    return await this.forciblySend(givenSubmission, {
+  ): Promise<Outcome<unknown, HTTPResponseError>> {
+    return await this.send(givenSubmission, {
       to   : givenPath,
       using: HTTPRequest.Method.SUBMIT,
     });
   }
 
-  public async forciblyCreateResource(
+  public async createResource(
     {
       bySending: givenProperties,
       to: givenPath,
@@ -86,14 +92,14 @@ export default class HTTPClient {
       bySending: unknown;
       to: URLPath;
     },
-  ): Promise<unknown> {
-    return await this.forciblySend(givenProperties, {
+  ): Promise<Outcome<unknown, HTTPResponseError>> {
+    return await this.send(givenProperties, {
       to   : givenPath,
       using: HTTPRequest.Method.CREATE,
     });
   }
 
-  public async forciblyUpdateResource(
+  public async updateResource(
     {
       bySending: givenChanges,
       to: givenPath,
@@ -101,15 +107,17 @@ export default class HTTPClient {
       bySending: unknown;
       to: URLPath;
     },
-  ): Promise<unknown> {
-    return await this.forciblySend(givenChanges, {
+  ): Promise<Outcome<unknown, HTTPResponseError>> {
+    return await this.send(givenChanges, {
       to   : givenPath,
       using: HTTPRequest.Method.UPDATE,
     });
   }
 
-  public async forciblyDeleteResourceAt(givenPath: URLPath): Promise<unknown> {
-    return await this.forciblySend(null, {
+  public async deleteResourceAt(
+    givenPath: URLPath,
+  ): Promise<Outcome<unknown, HTTPResponseError>> {
+    return await this.send(null, {
       to   : givenPath,
       using: HTTPRequest.Method.DELETE,
     });

--- a/src/library/ShimmedStabilityAIClient/index.ts
+++ b/src/library/ShimmedStabilityAIClient/index.ts
@@ -106,12 +106,14 @@ class ImageClient extends HTTPClient {
   public async forciblyGenerateFromText(
     givenRequest: GenerateFromTextRequest,
   ): Promise<GenerateFromTextResponse> {
-    const newResource = await this.forciblySubmitResource({
+    const outcomeOfSubmittingResource = await this.submitResource({
       bySending: toBatchGenerationRequestBody([
         givenRequest.textToImageRequestBody,
       ]),
       to: generationEndpoint,
     });
+
+    const newResource = outcomeOfSubmittingResource.forciblyUnwrap();
 
     const {
       images,

--- a/src/library/ShimmedStabilityAIClient/index.ts
+++ b/src/library/ShimmedStabilityAIClient/index.ts
@@ -100,6 +100,8 @@ const z_imageGenerationResponseBody = z.object({
   images: z.tuple([z_image]).rest(z_image),
 });
 
+const generationEndpoint = URLPath.forciblyParsedFrom('/generate');
+
 class ImageClient extends HTTPClient {
   public async forciblyGenerateFromText(
     givenRequest: GenerateFromTextRequest,
@@ -108,7 +110,7 @@ class ImageClient extends HTTPClient {
       bySending: toBatchGenerationRequestBody([
         givenRequest.textToImageRequestBody,
       ]),
-      to: URLPath.forciblyParsedFrom('/generate'),
+      to: generationEndpoint,
     });
 
     const {

--- a/src/pages/TextToImagePage.vue
+++ b/src/pages/TextToImagePage.vue
@@ -54,7 +54,7 @@ const imageGeneration = useStatefulProcess(async () => {
     proposedPrompt === null
   ) return NonActionableError.throw('Prompt was not set before submission');
 
-  const generatedOutput = await TextToImage.Client.SDXL.forciblyGenerateOutputFrom({
+  const outcomeOfGeneratingOutput = await TextToImage.Client.SDXL.generateOutputFrom({
     textToImageRequestBody: {
       textPrompts: proposedPrompt,
       height     : 1024,
@@ -65,6 +65,7 @@ const imageGeneration = useStatefulProcess(async () => {
     },
   });
 
+  const generatedOutput = outcomeOfGeneratingOutput.forciblyUnwrap();
   return generatedOutput.image;
 });
 </script>


### PR DESCRIPTION
- the default error propagation in JS/TS won't inherently force us to acknowledge that a function can throw exceptions
- by switching to `Outcome`s, this is way more obvious because we can see where we "forcibly unwrap" outcomes rather than handling the errors