### PR TITLE
refactor(library): makes `Attempt` utility simpler to use

### DIFF
--- a/src/features/TextToImage/config/utilities/DynamicConfig/EndpointResponseError.ts
+++ b/src/features/TextToImage/config/utilities/DynamicConfig/EndpointResponseError.ts
@@ -1,12 +1,10 @@
-import {
-  ActionableError,
-} from '@/library/Attempt';
+import Attempt from '@/library/Attempt';
 
 import type {
   URLPath,
 } from '@/library/customTypes/URLComponent';
 
-class DynamicConfig_EndpointResponseError extends ActionableError<'DynamicConfig_EndpointResponseError'> {
+class DynamicConfig_EndpointResponseError extends Attempt.ActionableError<'DynamicConfig_EndpointResponseError'> {
   public constructor(given: {
     endpoint: URLPath;
     response: Response;

--- a/src/features/TextToImage/config/utilities/DynamicConfig/FetchingError.ts
+++ b/src/features/TextToImage/config/utilities/DynamicConfig/FetchingError.ts
@@ -1,12 +1,10 @@
-import {
-  ActionableError,
-} from '@/library/Attempt';
+import Attempt from '@/library/Attempt';
 
 import type {
   URLPath,
 } from '@/library/customTypes/URLComponent';
 
-class DynamicConfig_FetchingError extends ActionableError<'DynamicConfigFetchError'> {
+class DynamicConfig_FetchingError extends Attempt.ActionableError<'DynamicConfigFetchError'> {
   public constructor(givenEndpoint: URLPath) {
     super(`Failed to fetch text-to-image config from endpoint: ${givenEndpoint.toString()}`);
     this.name = 'DynamicConfig_FetchingError';

--- a/src/features/TextToImage/config/utilities/StaticConfig/StaticConfigReadingError.ts
+++ b/src/features/TextToImage/config/utilities/StaticConfig/StaticConfigReadingError.ts
@@ -1,12 +1,10 @@
-import {
-  ActionableError,
-} from '@/library/Attempt';
+import Attempt from '@/library/Attempt';
 
 import type {
   URLPath,
 } from '@/library/customTypes/URLComponent';
 
-class StaticConfigReadingError extends ActionableError<'StaticConfigReadingError'> {
+class StaticConfigReadingError extends Attempt.ActionableError<'StaticConfigReadingError'> {
   public constructor(givenFile: URLPath, givenResponse: Response) {
     super(`Failed to read config at "${givenFile.toString()}". Cause: "${givenResponse.statusText}"`);
     this.name = 'StaticConfigReadError';

--- a/src/features/TextToImage/models/SDXL/client/index.ts
+++ b/src/features/TextToImage/models/SDXL/client/index.ts
@@ -4,7 +4,6 @@ import type {
 } from 'stabilityai-client-typescript/models/operations';
 
 import Attempt, {
-  NonActionableError,
   Outcome,
 } from '@/library/Attempt';
 
@@ -81,7 +80,7 @@ export const generateOutputFrom = async (
 
     if (
       outcomeOfSettlingTextToImageResponse.isFailure
-    ) return NonActionableError.rethrow(outcomeOfSettlingTextToImageResponse.causeOfFailure);
+    ) return Attempt.NonActionableError.rethrow(outcomeOfSettlingTextToImageResponse.causeOfFailure);
 
     textToImageResponse = outcomeOfSettlingTextToImageResponse.unwrapped;
   }
@@ -93,30 +92,30 @@ export const generateOutputFrom = async (
 
     if (
       !clientFailedToReachServer
-    ) return NonActionableError.rethrow(someError);
+    ) return Attempt.NonActionableError.rethrow(someError);
 
     return Outcome.failureDueTo(new Server.ConnectionError());
   }
 
   if (
     !('artifacts' in textToImageResponse.result)
-  ) return NonActionableError.throw('Expected response rather than readable stream');
+  ) return Attempt.abandon('Expected response rather than readable stream');
 
   const generatedArtifacts = textToImageResponse.result.artifacts;
 
   if (
     generatedArtifacts === undefined
-  ) return NonActionableError.throw('Expected artifacts in response result');
+  ) return Attempt.abandon('Expected artifacts in response result');
 
   const [soleGeneratedArtifact] = generatedArtifacts;
 
   if (
     soleGeneratedArtifact === undefined
-  ) return NonActionableError.throw('Expected at least one artifact in response');
+  ) return Attempt.abandon('Expected at least one artifact in response');
 
   if (
     soleGeneratedArtifact.base64 === undefined
-  ) return NonActionableError.throw('Expected image data from sole artifact');
+  ) return Attempt.abandon('Expected image data from sole artifact');
 
   const base64DataOfNewImage = Base64CharacterEncodedByteSequence.forciblyParsedFrom(soleGeneratedArtifact.base64);
 

--- a/src/features/TextToImage/webAPI/Server/ServerConnectionError.ts
+++ b/src/features/TextToImage/webAPI/Server/ServerConnectionError.ts
@@ -1,8 +1,6 @@
-import {
-  ActionableError,
-} from '@/library/Attempt';
+import Attempt from '@/library/Attempt';
 
-class TextToImage_Server_ConnectionError extends ActionableError<'TextToImage_ServerConnectionError'> {
+class TextToImage_Server_ConnectionError extends Attempt.ActionableError<'TextToImage_ServerConnectionError'> {
   public constructor() {
     const message = [
       'Failed to reach the text-to-image server.',

--- a/src/features/TextToImage/webAPI/Server/ServerSpecificationError.ts
+++ b/src/features/TextToImage/webAPI/Server/ServerSpecificationError.ts
@@ -1,12 +1,10 @@
-import {
-  ActionableError,
-} from '@/library/Attempt';
+import Attempt from '@/library/Attempt';
 
 import type {
   URLPath,
 } from '@/library/customTypes/URLComponent';
 
-class TextToImage_Server_SpecificationError extends ActionableError<'TextToImage_Server_SpecificationError'> {
+class TextToImage_Server_SpecificationError extends Attempt.ActionableError<'TextToImage_Server_SpecificationError'> {
   public constructor(
     given: {
       environmentKey: string;

--- a/src/library/Attempt/adapter/asynchronous.ts
+++ b/src/library/Attempt/adapter/asynchronous.ts
@@ -1,0 +1,37 @@
+import Outcome from '../Outcome';
+
+import type {
+  ActionableError,
+} from '../error';
+
+import {
+  outcomeOfFailedAttempt,
+} from '../utilities/outcomeOfFailedAttempt';
+
+export const attemptToEventually = async <
+  SomeProduct,
+  SomeActionableError extends ActionableError<string>,
+>(
+  forciblyRetrieveProduct: () => Promise<SomeProduct>,
+): Promise<Outcome<SomeProduct, SomeActionableError>> => {
+  // eslint-disable-next-line no-restricted-syntax
+  try {
+    const retrievedProduct: SomeProduct = await forciblyRetrieveProduct();
+    return Outcome.successThatYielded(retrievedProduct);
+  }
+  catch (whateverThatWasThrown) {
+    return outcomeOfFailedAttempt<SomeProduct, SomeActionableError>({
+      basedOn: whateverThatWasThrown,
+    });
+  }
+};
+
+export const attemptToSettle = async <
+  SomeProduct,
+  SomeActionableError extends ActionableError<string>,
+>(
+  promisedProduct: Promise<SomeProduct>,
+): Promise<Outcome<SomeProduct, SomeActionableError>> => {
+  const getPromisedProduct = () => promisedProduct;
+  return attemptToEventually(getPromisedProduct);
+};

--- a/src/library/Attempt/adapter/index.ts
+++ b/src/library/Attempt/adapter/index.ts
@@ -1,0 +1,8 @@
+export {
+  attemptTo,
+} from './synchronous';
+
+export {
+  attemptToEventually,
+  attemptToSettle,
+} from './asynchronous';

--- a/src/library/Attempt/adapter/synchronous.ts
+++ b/src/library/Attempt/adapter/synchronous.ts
@@ -1,0 +1,27 @@
+import Outcome from '../Outcome';
+
+import type {
+  ActionableError,
+} from '../error';
+
+import {
+  outcomeOfFailedAttempt,
+} from '../utilities/outcomeOfFailedAttempt';
+
+export const attemptTo = <
+  SomeProduct,
+  SomeActionableError extends ActionableError<string>,
+>(
+  forciblyGetProduct: () => SomeProduct,
+): Outcome<SomeProduct, SomeActionableError> => {
+  // eslint-disable-next-line no-restricted-syntax
+  try {
+    const gottenProduct = forciblyGetProduct();
+    return Outcome.successThatYielded(gottenProduct);
+  }
+  catch (whateverThatWasThrown) {
+    return outcomeOfFailedAttempt<SomeProduct, SomeActionableError>({
+      basedOn: whateverThatWasThrown,
+    });
+  }
+};

--- a/src/library/Attempt/attempt.ts
+++ b/src/library/Attempt/attempt.ts
@@ -1,0 +1,20 @@
+import Outcome from './Outcome';
+
+import {
+  NonActionableError,
+} from './error';
+
+/**
+ * (noun) Defines the relationship between:
+ * - a usable product
+ * - an error from which execution can be recovered
+ * - an error from which execution cannot be recovered
+ */
+export const attempt = {
+  /** Call this when the attempt has completed and was considered successful */
+  succeededWith: Outcome.successThatYielded,
+  /** Call this when the attempt has completed and was considered a failure */
+  failedDueTo  : Outcome.failureDueTo,
+  /** Call this when it's not possible to complete the attempt */
+  abandoned    : NonActionableError.throw,
+};

--- a/src/library/Attempt/exports.ts
+++ b/src/library/Attempt/exports.ts
@@ -1,0 +1,19 @@
+export {
+  default as Outcome,
+} from './Outcome';
+
+export {
+  attemptTo as to,
+  attemptToEventually as toEventually,
+  attemptToSettle as toSettle,
+} from './adapter';
+
+export {
+  NonActionableError,
+  ActionableError,
+} from './error';
+
+export {
+  Attempt_sync as new,
+  Attempt_async as promised,
+} from './factory';

--- a/src/library/Attempt/exports.ts
+++ b/src/library/Attempt/exports.ts
@@ -1,3 +1,9 @@
+import {
+  attempt,
+} from './attempt';
+
+export const abandon = attempt.abandoned;
+
 export {
   default as Outcome,
 } from './Outcome';

--- a/src/library/Attempt/factory/asynchronous.ts
+++ b/src/library/Attempt/factory/asynchronous.ts
@@ -1,0 +1,30 @@
+import {
+  attempt,
+} from '../attempt';
+import type {
+  ActionableError,
+} from '../error';
+
+import type {
+  Attempt_SynchronousImplementation,
+} from './synchronous';
+
+export type Attempt_AsynchronousImplementation<
+  SomeProduct,
+  SomeActionableError extends ActionableError<string>,
+> = (
+  ...parameters: Parameters<
+    Attempt_SynchronousImplementation<SomeProduct, SomeActionableError>
+  >
+) => Promise<
+  ReturnType<
+    Attempt_SynchronousImplementation<SomeProduct, SomeActionableError>
+  >
+>;
+
+export const Attempt_async = <
+  SomeProduct,
+  SomeActionableError extends ActionableError<string>,
+>(
+  retrieveOutcomeFor: Attempt_AsynchronousImplementation<SomeProduct, SomeActionableError>,
+) => retrieveOutcomeFor(attempt);

--- a/src/library/Attempt/factory/index.ts
+++ b/src/library/Attempt/factory/index.ts
@@ -1,0 +1,6 @@
+export {
+  Attempt_sync,
+} from './synchronous';
+export {
+  Attempt_async,
+} from './asynchronous';

--- a/src/library/Attempt/factory/synchronous.ts
+++ b/src/library/Attempt/factory/synchronous.ts
@@ -1,0 +1,23 @@
+import Outcome from '../Outcome';
+
+import {
+  attempt,
+} from '../attempt';
+
+import {
+  ActionableError,
+} from '../error';
+
+export type Attempt_SynchronousImplementation<
+  SomeProduct,
+  SomeActionableError extends ActionableError<string>,
+> = (
+  given: typeof attempt,
+) => Outcome<SomeProduct, SomeActionableError>;
+
+export const Attempt_sync = <
+  SomeProduct,
+  SomeActionableError extends ActionableError<string>,
+>(
+  getOutcomeFor: Attempt_SynchronousImplementation<SomeProduct, SomeActionableError>,
+) => getOutcomeFor(attempt);

--- a/src/library/Attempt/index.ts
+++ b/src/library/Attempt/index.ts
@@ -1,7 +1,6 @@
 import Outcome from './Outcome';
 
 import {
-  NonActionableError,
   ActionableError,
 } from './error';
 
@@ -10,7 +9,6 @@ import * as Attempt from './exports';
 export default Attempt;
 
 export {
-  NonActionableError,
   ActionableError,
   Outcome,
 };

--- a/src/library/Attempt/index.ts
+++ b/src/library/Attempt/index.ts
@@ -1,7 +1,3 @@
-import {
-  asError,
-} from '@/library/utilitiesByType/error';
-
 import Outcome from './Outcome';
 
 import {
@@ -9,78 +5,7 @@ import {
   ActionableError,
 } from './error';
 
-import {
-  assertPotentiallyActionable,
-  assertSafelyPropagated,
-} from './error/modifier';
-
-const outcomeOfFailedAttempt = <
-  SomeProduct,
-  SomeActionableError extends ActionableError<string>,
->(
-  {
-    basedOn: givenSubject,
-  }: {
-    basedOn: unknown;
-  },
-): Outcome<SomeProduct, SomeActionableError> => {
-  const someError = asError(givenSubject);
-  const potentiallyActionableError = assertPotentiallyActionable(someError);
-  const safelyPropagatedError = assertSafelyPropagated(potentiallyActionableError);
-  return NonActionableError.rethrow(safelyPropagatedError);
-};
-
-const attemptTo = <
-  SomeProduct,
-  SomeActionableError extends ActionableError<string>,
->(
-  getProductFromSomeProcessThatCanThrow: () => SomeProduct,
-): Outcome<SomeProduct, SomeActionableError> => {
-  // eslint-disable-next-line no-restricted-syntax
-  try {
-    const productFromSomeProcessThatDidNotThrow = getProductFromSomeProcessThatCanThrow();
-    return Outcome.successThatYielded(productFromSomeProcessThatDidNotThrow);
-  }
-  catch (whateverThatWasThrown) {
-    return outcomeOfFailedAttempt<SomeProduct, SomeActionableError>({
-      basedOn: whateverThatWasThrown,
-    });
-  }
-};
-
-const attemptToEventually = async <
-  SomeProduct,
-  SomeActionableError extends ActionableError<string>,
->(
-  getProductFromSomeAsyncProcessThatCanThrow: () => Promise<SomeProduct>,
-): Promise<Outcome<SomeProduct, SomeActionableError>> => {
-  // eslint-disable-next-line no-restricted-syntax
-  try {
-    const productFromSomeSuccessfulAsyncProcess: SomeProduct = await getProductFromSomeAsyncProcessThatCanThrow();
-    return Outcome.successThatYielded(productFromSomeSuccessfulAsyncProcess);
-  }
-  catch (whateverThatWasThrown) {
-    return outcomeOfFailedAttempt<SomeProduct, SomeActionableError>({
-      basedOn: whateverThatWasThrown,
-    });
-  }
-};
-
-const attemptToSettle = async <
-  SomeProduct,
-  SomeActionableError extends ActionableError<string>,
->(
-  promisedProduct: Promise<SomeProduct>,
-): Promise<Outcome<SomeProduct, SomeActionableError>> => {
-  const getPromisedProduct = () => promisedProduct;
-  return attemptToEventually(getPromisedProduct);
-};
-
-const Attempt = {
-  to          : attemptTo,
-  toEventually: attemptToEventually,
-  toSettle    : attemptToSettle,
-};
+import * as Attempt from './exports';
 
 export default Attempt;
 

--- a/src/library/Attempt/index.ts
+++ b/src/library/Attempt/index.ts
@@ -1,14 +1,9 @@
 import Outcome from './Outcome';
 
-import {
-  ActionableError,
-} from './error';
-
 import * as Attempt from './exports';
 
 export default Attempt;
 
 export {
-  ActionableError,
   Outcome,
 };

--- a/src/library/Attempt/utilities/outcomeOfFailedAttempt.ts
+++ b/src/library/Attempt/utilities/outcomeOfFailedAttempt.ts
@@ -1,0 +1,31 @@
+import {
+  asError,
+} from '@/library/utilitiesByType/error';
+
+import type Outcome from '../Outcome';
+
+import {
+  NonActionableError,
+  type ActionableError,
+} from '../error';
+
+import {
+  assertPotentiallyActionable,
+  assertSafelyPropagated,
+} from '../error/modifier';
+
+export const outcomeOfFailedAttempt = <
+  SomeProduct,
+  SomeActionableError extends ActionableError<string>,
+>(
+  {
+    basedOn: givenSubject,
+  }: {
+    basedOn: unknown;
+  },
+): Outcome<SomeProduct, SomeActionableError> => {
+  const someError = asError(givenSubject);
+  const potentiallyActionableError = assertPotentiallyActionable(someError);
+  const safelyPropagatedError = assertSafelyPropagated(potentiallyActionableError);
+  return NonActionableError.rethrow(safelyPropagatedError);
+};

--- a/src/library/Base64/CharacterSequence/ConformanceError.ts
+++ b/src/library/Base64/CharacterSequence/ConformanceError.ts
@@ -1,10 +1,8 @@
-import {
-  ActionableError,
-} from '@/library/Attempt';
+import Attempt from '@/library/Attempt';
 
 import Base64_Alphabet from '../Alphabet';
 
-class Base64_CharacterSequence_ConformanceError extends ActionableError<'Base64_CharacterSequence_ConformanceError'> {
+class Base64_CharacterSequence_ConformanceError extends Attempt.ActionableError<'Base64_CharacterSequence_ConformanceError'> {
   public constructor() {
     super(`Sequence contained 1+ character(s) outside of the Base64 Alphabet: ${Base64_Alphabet.pattern.toString()}`);
     this.name = 'Base64_CharacterSequence_ConformanceError';

--- a/src/library/Byte/Sequence/EncodingCompatibilityError.ts
+++ b/src/library/Byte/Sequence/EncodingCompatibilityError.ts
@@ -1,12 +1,10 @@
-import {
-  ActionableError,
-} from '@/library/Attempt';
+import Attempt from '@/library/Attempt';
 
 import {
   cofactorTo as Byte_cofactorTo,
 } from '..';
 
-class Byte_Sequence_EncodingCompatibilityError extends ActionableError<'Byte_Sequence_EncodingCompatibilityError'> {
+class Byte_Sequence_EncodingCompatibilityError extends Attempt.ActionableError<'Byte_Sequence_EncodingCompatibilityError'> {
   public constructor(givenBitWidth: number) {
     const byteCofactor = Byte_cofactorTo(givenBitWidth);
     super(`Character count for ${givenBitWidth.toString()}-bit sequence must be a multiple of ${byteCofactor.toString()} to be byte encodable`);

--- a/src/library/HTTPClient/HTTPResponseError.ts
+++ b/src/library/HTTPClient/HTTPResponseError.ts
@@ -1,10 +1,8 @@
-import {
-  ActionableError,
-} from '@/library/Attempt';
+import Attempt from '@/library/Attempt';
 
 import * as HTTPResponse from './HTTPResponse';
 
-export default class HTTPResponseError extends ActionableError<'HTTPResponseError'> {
+export default class HTTPResponseError extends Attempt.ActionableError<'HTTPResponseError'> {
   public readonly status: HTTPResponse.ErrorStatusCode;
 
   public constructor(givenMessage: string, givenStatus: HTTPResponse.ErrorStatusCode) {

--- a/src/library/Range/DiscreteRange.ts
+++ b/src/library/Range/DiscreteRange.ts
@@ -1,6 +1,4 @@
-import {
-  NonActionableError,
-} from '@/library/Attempt';
+import Attempt from '@/library/Attempt';
 
 import Range from './index.ts';
 
@@ -17,13 +15,13 @@ export default class DiscreteRange extends Range implements Iterable<number> {
 
     if (
       stepSize < 0
-    ) return NonActionableError.throw('Step size must be positive');
+    ) return Attempt.abandon('Step size must be positive');
 
     const overstep = this.width % stepSize;
 
     if (
       overstep !== 0
-    ) return NonActionableError.throw('Step size must fit evenly into the range');
+    ) return Attempt.abandon('Step size must fit evenly into the range');
 
     this.stepSize = stepSize;
   }
@@ -60,7 +58,7 @@ export default class DiscreteRange extends Range implements Iterable<number> {
 
       if (
         this.upperBound < eachValue
-      ) return NonActionableError.throw(`Unexpected overstep when iterating over ${this.inInclusiveNotation} with step size ${this.stepSize.toString()}`);
+      ) return Attempt.abandon(`Unexpected overstep when iterating over ${this.inInclusiveNotation} with step size ${this.stepSize.toString()}`);
 
       if (this.upperBound === eachValue) {
         return {

--- a/src/library/Range/index.ts
+++ b/src/library/Range/index.ts
@@ -1,6 +1,4 @@
-import {
-  NonActionableError,
-} from '@/library/Attempt';
+import Attempt from '@/library/Attempt';
 
 import {
   arithmeticMeanOf,
@@ -15,7 +13,7 @@ export default class Range {
   ) {
     if (
       upperBound < lowerBound
-    ) return NonActionableError.throw('Upper bound must not be lower than lower bound');
+    ) return Attempt.abandon('Upper bound must not be lower than lower bound');
 
     this.lowerBound = lowerBound;
     this.upperBound = upperBound;

--- a/src/library/customTypes/NonTrivialString/NonTrivialStringParsingError.ts
+++ b/src/library/customTypes/NonTrivialString/NonTrivialStringParsingError.ts
@@ -1,6 +1,6 @@
 import {
   ActionableError,
-} from '@/library/Attempt';
+} from '@/library/Attempt/error';
 
 class NonTrivialStringParsingError extends ActionableError<'NonTrivialStringParsingError'> {
   public constructor(givenCulprit: string) {

--- a/src/library/customTypes/URLComponent/URLOrigin.ts
+++ b/src/library/customTypes/URLComponent/URLOrigin.ts
@@ -1,6 +1,6 @@
 import {
   ActionableError,
-} from '@/library/Attempt';
+} from '@/library/Attempt/error';
 
 import StringSubset from '@/library/customTypes/StringSubset.ts';
 

--- a/src/library/customTypes/URLComponent/URLPath.ts
+++ b/src/library/customTypes/URLComponent/URLPath.ts
@@ -1,6 +1,6 @@
 import {
   ActionableError,
-} from '@/library/Attempt';
+} from '@/library/Attempt/error';
 
 import StringSubset from '@/library/customTypes/StringSubset.ts';
 

--- a/src/library/customTypes/UniformResourceIdentifier/Data/DataURIParsingError.ts
+++ b/src/library/customTypes/UniformResourceIdentifier/Data/DataURIParsingError.ts
@@ -1,6 +1,6 @@
 import {
   ActionableError,
-} from '@/library/Attempt';
+} from '@/library/Attempt/error';
 
 class DataURIParsingError extends ActionableError<'DataURIParsingError'> {
   public constructor(givenMessage: string) {

--- a/src/library/customTypes/UniformResourceIdentifier/Data/Image/ImageURIParsingError.ts
+++ b/src/library/customTypes/UniformResourceIdentifier/Data/Image/ImageURIParsingError.ts
@@ -1,6 +1,6 @@
 import {
   ActionableError,
-} from '@/library/Attempt';
+} from '@/library/Attempt/error';
 
 class ImageURIParsingError extends ActionableError<'ImageURIParsingError'> {
   public constructor(givenMessage: string) {

--- a/src/library/customTypes/UniformResourceIdentifier/Data/MediaTypeParsingError.ts
+++ b/src/library/customTypes/UniformResourceIdentifier/Data/MediaTypeParsingError.ts
@@ -1,6 +1,6 @@
 import {
   ActionableError,
-} from '@/library/Attempt';
+} from '@/library/Attempt/error';
 
 class MediaTypeParsingError extends ActionableError<'MediaTypeParsingError'> {
   public constructor(givenMessage: string) {

--- a/src/library/customTypes/UniformResourceIdentifier/Data/index.ts
+++ b/src/library/customTypes/UniformResourceIdentifier/Data/index.ts
@@ -1,6 +1,4 @@
-import {
-  NonActionableError,
-} from '@/library/Attempt';
+import Attempt from '@/library/Attempt';
 
 import Base64CharacterEncodedByteSequence from '@/library/customTypes/Base64CharacterEncodedByteSequence.ts';
 
@@ -47,7 +45,7 @@ export default class DataURI extends UniformResourceIdentifier {
   public get mediaType(): Exclude<DataURI['_mediaType'], null> {
     if (
       this._mediaType === null
-    ) return NonActionableError.throw('Media type either needs to be initialized or overridden');
+    ) return Attempt.abandon('Media type either needs to be initialized or overridden');
 
     return this._mediaType;
   }

--- a/src/library/customTypes/UniformResourceIdentifier/URIParsingError.ts
+++ b/src/library/customTypes/UniformResourceIdentifier/URIParsingError.ts
@@ -1,6 +1,6 @@
 import {
   ActionableError,
-} from '@/library/Attempt';
+} from '@/library/Attempt/error';
 
 class URIParsingError extends ActionableError<'URIParsingError'> {
   public constructor(givenMessage: string) {

--- a/src/library/customTypes/UniformResourceIdentifier/index.ts
+++ b/src/library/customTypes/UniformResourceIdentifier/index.ts
@@ -1,6 +1,4 @@
-import {
-  NonActionableError,
-} from '@/library/Attempt';
+import Attempt from '@/library/Attempt';
 
 import NonTrivialString from '@/library/customTypes/NonTrivialString';
 
@@ -50,7 +48,7 @@ export default class UniformResourceIdentifier implements StaticStringParser<typ
   public get path(): Exclude<UniformResourceIdentifier['_path'], null> {
     if (
       this._path === null
-    ) return NonActionableError.throw('`path` must either be a) provided via constructor or b) overridden via public getter');
+    ) return Attempt.abandon('`path` must either be a) provided via constructor or b) overridden via public getter');
 
     return this._path;
   }

--- a/src/pages/TextToImagePage.vue
+++ b/src/pages/TextToImagePage.vue
@@ -27,9 +27,7 @@ import {
   VSkeletonLoader,
 } from 'vuetify/components/VSkeletonLoader';
 
-import {
-  NonActionableError,
-} from '@/library/Attempt';
+import Attempt from '@/library/Attempt';
 
 import SDXLDiffusionStepCount from '@/library/ShimmedStabilityAIClient/models/SDXLDiffusionStepCount.ts';
 
@@ -52,7 +50,7 @@ const imageGeneration = useStatefulProcess(async () => {
 
   if (
     proposedPrompt === null
-  ) return NonActionableError.throw('Prompt was not set before submission');
+  ) return Attempt.abandon('Prompt was not set before submission');
 
   const outcomeOfGeneratingOutput = await TextToImage.Client.SDXL.generateOutputFrom({
     textToImageRequestBody: {


### PR DESCRIPTION
- Introduces `Attempt` namespace to encapsulate the idea of "routines that might fail"
- Pairs down the exports to prevent unintentional abstraction leaks