### PR TITLE
linter: helps minimize diffs by regulating exports

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -2,9 +2,13 @@ import {
   defineConfig,
 } from 'cypress';
 
-export default defineConfig({
+const cypressConfig = defineConfig({
   e2e: {
     specPattern: 'cypress/e2e/**/*.{cy,spec}.{js,jsx,ts,tsx}',
     baseUrl    : 'http://localhost:4173',
   },
 });
+
+export {
+  cypressConfig as default,
+};

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -32,6 +32,9 @@ const importPluginConfigs: ConfigWithExtends[] = [
       },
     },
     rules: {
+      'import/exports-last': [
+        'error', // Encourages decoupling the export of a module from its declaration, which leads to cleaner diffs
+      ],
       'import/order': [
         'error',
         {
@@ -93,6 +96,11 @@ const configWithVueTS = defineConfigWithVueTs(
       'no-implicit-coercion': [
         'error', // Using constructors, factories, and parsers for coercion rather than operators leads to less confusing behavior
       ],
+      'no-restricted-exports': ['error', {
+        restrictDefaultExports: {
+          direct: true, // Keeping the export of something separate from its declaration leads to cleaner diffs. Prefer using `export { Foo as default }`
+        },
+      }],
       'no-restricted-syntax': [
         'error',
         {
@@ -171,7 +179,7 @@ const configWithVueTS = defineConfigWithVueTs(
   },
 );
 
-export default tseslint.config([
+const completeConfig = tseslint.config([
   ...configWithVueTS,
   {
     name : 'shark-ui/safety-override',
@@ -187,3 +195,7 @@ export default tseslint.config([
     },
   },
 ]);
+
+export {
+  completeConfig as default,
+};

--- a/lint-staged.config.ts
+++ b/lint-staged.config.ts
@@ -2,6 +2,10 @@ import type {
   Configuration,
 } from 'lint-staged';
 
-export default {
+const lintStagedConfig = {
   '*': 'npm run lint',
 } satisfies Configuration;
+
+export {
+  lintStagedConfig as default,
+};

--- a/src/features/TextToImage/config/utilities/DynamicConfig/EndpointResponseError.ts
+++ b/src/features/TextToImage/config/utilities/DynamicConfig/EndpointResponseError.ts
@@ -14,4 +14,6 @@ class DynamicConfig_EndpointResponseError extends Attempt.ActionableError<'Dynam
   }
 }
 
-export default DynamicConfig_EndpointResponseError;
+export {
+  DynamicConfig_EndpointResponseError as default,
+};

--- a/src/features/TextToImage/config/utilities/DynamicConfig/FetchingError.ts
+++ b/src/features/TextToImage/config/utilities/DynamicConfig/FetchingError.ts
@@ -11,4 +11,6 @@ class DynamicConfig_FetchingError extends Attempt.ActionableError<'DynamicConfig
   }
 }
 
-export default DynamicConfig_FetchingError;
+export {
+  DynamicConfig_FetchingError as default,
+};

--- a/src/features/TextToImage/config/utilities/StaticConfig/StaticConfigReadingError.ts
+++ b/src/features/TextToImage/config/utilities/StaticConfig/StaticConfigReadingError.ts
@@ -11,4 +11,6 @@ class StaticConfigReadingError extends Attempt.ActionableError<'StaticConfigRead
   }
 }
 
-export default StaticConfigReadingError;
+export {
+  StaticConfigReadingError as default,
+};

--- a/src/features/TextToImage/models/SDXL/client/index.ts
+++ b/src/features/TextToImage/models/SDXL/client/index.ts
@@ -44,7 +44,7 @@ type OutcomeOfGeneratingTextToImageOutput = Attempt.Outcome<Output,
   | Server.ConnectionError
 >;
 
-export const generateOutputFrom = async (
+const generateOutputFrom = async (
   given: {
     textToImageRequestBody: Pick<GenerateFromTextRequest['textToImageRequestBody'],
     | 'textPrompts'
@@ -136,4 +136,6 @@ const SDXLTextToImageClient = {
   generateOutputFrom,
 };
 
-export default SDXLTextToImageClient;
+export {
+  SDXLTextToImageClient as default,
+};

--- a/src/features/TextToImage/webAPI/Server/ServerConnectionError.ts
+++ b/src/features/TextToImage/webAPI/Server/ServerConnectionError.ts
@@ -12,4 +12,6 @@ class TextToImage_Server_ConnectionError extends Attempt.ActionableError<'TextTo
   }
 }
 
-export default TextToImage_Server_ConnectionError;
+export {
+  TextToImage_Server_ConnectionError as default,
+};

--- a/src/features/TextToImage/webAPI/Server/ServerSpecificationError.ts
+++ b/src/features/TextToImage/webAPI/Server/ServerSpecificationError.ts
@@ -26,4 +26,6 @@ class TextToImage_Server_SpecificationError extends Attempt.ActionableError<'Tex
   }
 }
 
-export default TextToImage_Server_SpecificationError;
+export {
+  TextToImage_Server_SpecificationError as default,
+};

--- a/src/features/TextToImage/webAPI/Server/index.ts
+++ b/src/features/TextToImage/webAPI/Server/index.ts
@@ -10,10 +10,6 @@ import {
   emptyConfig,
 } from '../../config';
 
-export {
-  default as ConnectionError,
-} from './ServerConnectionError';
-
 import TextToImage_Server_SpecificationError from './ServerSpecificationError';
 
 const environmentKeyForOriginOfTextToImageServer = 'VITE__TEXT_TO_IMAGE__API__SERVER__ORIGIN';
@@ -57,6 +53,10 @@ const retrieveCurrentTextToImageServer = (): Promise<
 
   return ends.inFailureDueTo(newSpecificationError);
 });
+
+export {
+  default as ConnectionError,
+} from './ServerConnectionError';
 
 export {
   textToImageServerAccordingToEnvironment as accordingToEnvironment,

--- a/src/library/Attempt/Outcome.ts
+++ b/src/library/Attempt/Outcome.ts
@@ -133,7 +133,9 @@ type Outcome<
   | Success<SomeProduct>
   | Failure<SomeActionableError>;
 
-export default Outcome;
+export {
+  Outcome as default,
+};
 
 export type ProductOf<
   SomeOutcome extends Outcome<unknown, ActionableError<string>>,

--- a/src/library/Attempt/error/ActionableError.ts
+++ b/src/library/Attempt/error/ActionableError.ts
@@ -22,4 +22,6 @@ abstract class ActionableError<SomeBrand extends string>
   }
 }
 
-export default ActionableError;
+export {
+  ActionableError as default,
+};

--- a/src/library/Attempt/error/HonoraryNonActionableError.ts
+++ b/src/library/Attempt/error/HonoraryNonActionableError.ts
@@ -65,4 +65,6 @@ const HonoraryNonActionableError = {
   },
 };
 
-export default HonoraryNonActionableError;
+export {
+  HonoraryNonActionableError as default,
+};

--- a/src/library/Attempt/error/NonActionableError.ts
+++ b/src/library/Attempt/error/NonActionableError.ts
@@ -52,4 +52,6 @@ class NonActionableError
   };
 }
 
-export default NonActionableError;
+export {
+  NonActionableError as default,
+};

--- a/src/library/Attempt/index.ts
+++ b/src/library/Attempt/index.ts
@@ -1,3 +1,5 @@
 import * as Attempt from './exports';
 
-export default Attempt;
+export {
+  Attempt as default,
+};

--- a/src/library/Base64/Alphabet.ts
+++ b/src/library/Base64/Alphabet.ts
@@ -4,4 +4,6 @@ const Base64_Alphabet = {
   pattern: /A-Za-z\d\+\//,
 };
 
-export default Base64_Alphabet;
+export {
+  Base64_Alphabet as default,
+};

--- a/src/library/Base64/CharacterSequence/ConformanceError.ts
+++ b/src/library/Base64/CharacterSequence/ConformanceError.ts
@@ -9,4 +9,6 @@ class Base64_CharacterSequence_ConformanceError extends Attempt.ActionableError<
   }
 }
 
-export default Base64_CharacterSequence_ConformanceError;
+export {
+  Base64_CharacterSequence_ConformanceError as default,
+};

--- a/src/library/Byte/Sequence/EncodingCompatibilityError.ts
+++ b/src/library/Byte/Sequence/EncodingCompatibilityError.ts
@@ -12,4 +12,6 @@ class Byte_Sequence_EncodingCompatibilityError extends Attempt.ActionableError<'
   }
 }
 
-export default Byte_Sequence_EncodingCompatibilityError;
+export {
+  Byte_Sequence_EncodingCompatibilityError as default,
+};

--- a/src/library/Byte/index.ts
+++ b/src/library/Byte/index.ts
@@ -2,8 +2,6 @@ import {
   cofactor,
 } from '@/library/math/operators';
 
-export * as Sequence from './Sequence';
-
 const Byte_bitWidth = 8 as const;
 
 const Byte_cofactorTo = (givenBitWidth: number): number => {
@@ -12,6 +10,8 @@ const Byte_cofactorTo = (givenBitWidth: number): number => {
     forLCMWith: Byte_bitWidth,
   });
 };
+
+export * as Sequence from './Sequence';
 
 export {
   Byte_cofactorTo as cofactorTo,

--- a/src/library/HTTPClient/HTTPResponseError.ts
+++ b/src/library/HTTPClient/HTTPResponseError.ts
@@ -2,7 +2,7 @@ import Attempt from '@/library/Attempt';
 
 import * as HTTPResponse from './HTTPResponse';
 
-export default class HTTPResponseError extends Attempt.ActionableError<'HTTPResponseError'> {
+class HTTPResponseError extends Attempt.ActionableError<'HTTPResponseError'> {
   public readonly status: HTTPResponse.ErrorStatusCode;
 
   public constructor(givenMessage: string, givenStatus: HTTPResponse.ErrorStatusCode) {
@@ -11,3 +11,7 @@ export default class HTTPResponseError extends Attempt.ActionableError<'HTTPResp
     this.status = givenStatus;
   }
 }
+
+export {
+  HTTPResponseError as default,
+};

--- a/src/library/HTTPClient/index.ts
+++ b/src/library/HTTPClient/index.ts
@@ -8,7 +8,7 @@ import type {
 import * as HTTPRequest from './HTTPRequest.ts';
 import HTTPResponseError from './HTTPResponseError.ts';
 
-export default class HTTPClient {
+class HTTPClient {
   public readonly origin: URLOrigin;
   public readonly headers: HTTPRequest.HeaderMap;
 
@@ -122,3 +122,7 @@ export default class HTTPClient {
     });
   }
 }
+
+export {
+  HTTPClient as default,
+};

--- a/src/library/Range/DiscreteRange.ts
+++ b/src/library/Range/DiscreteRange.ts
@@ -2,7 +2,7 @@ import Attempt from '@/library/Attempt';
 
 import Range from './index.ts';
 
-export default class DiscreteRange extends Range implements Iterable<number> {
+class DiscreteRange extends Range implements Iterable<number> {
   public constructor(
     lowerBound: Range['lowerBound'],
     upperBound: Range['upperBound'],
@@ -90,3 +90,7 @@ export default class DiscreteRange extends Range implements Iterable<number> {
     ];
   }
 }
+
+export {
+  DiscreteRange as default,
+};

--- a/src/library/Range/index.ts
+++ b/src/library/Range/index.ts
@@ -6,7 +6,7 @@ import {
 
 type RangeBound = 'exclusive' | 'inclusive';
 
-export default class Range {
+class Range {
   public constructor(
     public readonly lowerBound: number,
     public readonly upperBound: number,
@@ -78,3 +78,7 @@ export default class Range {
     return `[${this.lowerBound.toString()}, ${this.upperBound.toString()}]`;
   }
 }
+
+export {
+  Range as default,
+};

--- a/src/library/ShimmedStabilityAIClient/index.ts
+++ b/src/library/ShimmedStabilityAIClient/index.ts
@@ -145,7 +145,7 @@ class Version1Client extends HTTPClient {
   }
 }
 
-export default class ShimmedStabilityAIClient extends HTTPClient {
+class ShimmedStabilityAIClient extends HTTPClient {
   public constructor(given: {
     serverURL: string;
   }) {
@@ -164,3 +164,7 @@ export default class ShimmedStabilityAIClient extends HTTPClient {
     return this._version1;
   }
 }
+
+export {
+  ShimmedStabilityAIClient as default,
+};

--- a/src/library/ShimmedStabilityAIClient/models/SDXLDiffusionStepCount.ts
+++ b/src/library/ShimmedStabilityAIClient/models/SDXLDiffusionStepCount.ts
@@ -5,10 +5,14 @@ import DiscreteRange from '@/library/Range/DiscreteRange.ts';
  *
  * Defined at "components.schemas.Steps"
  */
-export default abstract class SDXLDiffusionStepCount { // eslint-disable-line @typescript-eslint/no-extraneous-class
+abstract class SDXLDiffusionStepCount { // eslint-disable-line @typescript-eslint/no-extraneous-class
   public static range = DiscreteRange.spanning({
     from: 10,
     to  : 50,
     by  : 1,
   });
 }
+
+export {
+  SDXLDiffusionStepCount as default,
+};

--- a/src/library/WebAPI/Server.ts
+++ b/src/library/WebAPI/Server.ts
@@ -3,7 +3,7 @@
  * - listens for requests
  * - responds to those requests
  */
-export default class Server {
+class Server {
   public constructor(
     /**
      * The web location of the server, which is the base URL of the API.
@@ -18,3 +18,7 @@ export default class Server {
     );
   }
 }
+
+export {
+  Server as default,
+};

--- a/src/library/customTypes/Base64CharacterEncodedByteSequence.ts
+++ b/src/library/customTypes/Base64CharacterEncodedByteSequence.ts
@@ -13,7 +13,7 @@ import {
 import StringSubset from './StringSubset.ts';
 
 /** See [RFC 4648 Section 4](https://www.rfc-editor.org/rfc/rfc4648.html#section-4) for more information */
-export default class Base64CharacterEncodedByteSequence
+class Base64CharacterEncodedByteSequence
   extends StringSubset<'Base64CharacterEncodedByteSequence'>
   implements StaticStringParser<typeof Base64CharacterEncodedByteSequence> {
   public static paddingCharacter = '=';
@@ -51,3 +51,7 @@ export default class Base64CharacterEncodedByteSequence
     return new this(base64CharacterEncodedByteSequence);
   }
 }
+
+export {
+  Base64CharacterEncodedByteSequence as default,
+};

--- a/src/library/customTypes/NonTrivialString/NonTrivialStringParsingError.ts
+++ b/src/library/customTypes/NonTrivialString/NonTrivialStringParsingError.ts
@@ -9,4 +9,6 @@ class NonTrivialStringParsingError extends ActionableError<'NonTrivialStringPars
   }
 }
 
-export default NonTrivialStringParsingError;
+export {
+  NonTrivialStringParsingError as default,
+};

--- a/src/library/customTypes/NonTrivialString/index.ts
+++ b/src/library/customTypes/NonTrivialString/index.ts
@@ -37,4 +37,6 @@ class NonTrivialString
   }
 }
 
-export default NonTrivialString;
+export {
+  NonTrivialString as default,
+};

--- a/src/library/customTypes/StringSubset.ts
+++ b/src/library/customTypes/StringSubset.ts
@@ -11,4 +11,6 @@ abstract class StringSubset<SomeBrand extends string>
   public readonly brand!: SomeBrand;
 }
 
-export default StringSubset;
+export {
+  StringSubset as default,
+};

--- a/src/library/customTypes/UniformResourceIdentifier/Data/DataURIParsingError.ts
+++ b/src/library/customTypes/UniformResourceIdentifier/Data/DataURIParsingError.ts
@@ -9,4 +9,6 @@ class DataURIParsingError extends ActionableError<'DataURIParsingError'> {
   }
 }
 
-export default DataURIParsingError;
+export {
+  DataURIParsingError as default,
+};

--- a/src/library/customTypes/UniformResourceIdentifier/Data/Image/ImageURIParsingError.ts
+++ b/src/library/customTypes/UniformResourceIdentifier/Data/Image/ImageURIParsingError.ts
@@ -9,4 +9,6 @@ class ImageURIParsingError extends ActionableError<'ImageURIParsingError'> {
   }
 }
 
-export default ImageURIParsingError;
+export {
+  ImageURIParsingError as default,
+};

--- a/src/library/customTypes/UniformResourceIdentifier/Data/Image/index.ts
+++ b/src/library/customTypes/UniformResourceIdentifier/Data/Image/index.ts
@@ -15,7 +15,7 @@ import {
 
 import ImageURIParsingError from './ImageURIParsingError.ts';
 
-export default class ImageURI extends DataURI {
+class ImageURI extends DataURI {
   public static readonly mediaType = 'image';
 
   private readonly _format: ImageURIFormat;
@@ -67,3 +67,7 @@ export default class ImageURI extends DataURI {
     );
   }
 }
+
+export {
+  ImageURI as default,
+};

--- a/src/library/customTypes/UniformResourceIdentifier/Data/MediaType.ts
+++ b/src/library/customTypes/UniformResourceIdentifier/Data/MediaType.ts
@@ -35,7 +35,7 @@ const allStructuredSyntaxNameSuffix = [
 type StructuredSyntaxNameSuffix = (typeof allStructuredSyntaxNameSuffix)[number];
 
 /** See [RFC 2045](https://datatracker.ietf.org/doc/html/rfc2045) for more information */
-export default class MediaType implements StaticStringParser<typeof MediaType> {
+class MediaType implements StaticStringParser<typeof MediaType> {
   public constructor(
     public fileType: FileType,
     public tree: string[] | null,
@@ -186,3 +186,7 @@ export default class MediaType implements StaticStringParser<typeof MediaType> {
     );
   }
 }
+
+export {
+  MediaType as default,
+};

--- a/src/library/customTypes/UniformResourceIdentifier/Data/MediaTypeParsingError.ts
+++ b/src/library/customTypes/UniformResourceIdentifier/Data/MediaTypeParsingError.ts
@@ -9,4 +9,6 @@ class MediaTypeParsingError extends ActionableError<'MediaTypeParsingError'> {
   }
 }
 
-export default MediaTypeParsingError;
+export {
+  MediaTypeParsingError as default,
+};

--- a/src/library/customTypes/UniformResourceIdentifier/Data/index.ts
+++ b/src/library/customTypes/UniformResourceIdentifier/Data/index.ts
@@ -19,7 +19,7 @@ import DataURIParsingError from './DataURIParsingError.ts';
 import MediaType from './MediaType.ts';
 
 /** See [RFC 2397](https://datatracker.ietf.org/doc/rfc2397) for more info */
-export default class DataURI extends UniformResourceIdentifier {
+class DataURI extends UniformResourceIdentifier {
   public static readonly scheme = NonTrivialString.forciblyParsedFrom('data');
   public static readonly encodingPrefix = ';';
   public static readonly dataPrefix = ',';
@@ -118,3 +118,7 @@ export default class DataURI extends UniformResourceIdentifier {
     );
   }
 }
+
+export {
+  DataURI as default,
+};

--- a/src/library/customTypes/UniformResourceIdentifier/URIParsingError.ts
+++ b/src/library/customTypes/UniformResourceIdentifier/URIParsingError.ts
@@ -9,4 +9,6 @@ class URIParsingError extends ActionableError<'URIParsingError'> {
   }
 }
 
-export default URIParsingError;
+export {
+  URIParsingError as default,
+};

--- a/src/library/customTypes/UniformResourceIdentifier/index.ts
+++ b/src/library/customTypes/UniformResourceIdentifier/index.ts
@@ -16,7 +16,7 @@ import URIParsingError from './URIParsingError';
  * Identifies an abstract or physical resource.
  * See [RFC 3986](https://www.rfc-editor.org/rfc/rfc3986) for more information
  */
-export default class UniformResourceIdentifier implements StaticStringParser<typeof UniformResourceIdentifier> {
+class UniformResourceIdentifier implements StaticStringParser<typeof UniformResourceIdentifier> {
   private readonly _scheme: /*   */ NonTrivialString;
   private readonly _authority: /**/ NonTrivialString | null;
   private readonly _path: /*     */ NonTrivialString | null;
@@ -193,3 +193,7 @@ export default class UniformResourceIdentifier implements StaticStringParser<typ
     );
   }
 }
+
+export {
+  UniformResourceIdentifier as default,
+};

--- a/src/library/typeUtilities/Static.ts
+++ b/src/library/typeUtilities/Static.ts
@@ -1,4 +1,8 @@
 /** The base shape of the _type_ of some class, rather than the class itself */
-export default interface Static<Any> {
+interface Static<Any> {
   prototype: Any;
 }
+
+export {
+  type Static as default,
+};

--- a/src/library/typeUtilities/StringParser.ts
+++ b/src/library/typeUtilities/StringParser.ts
@@ -1,3 +1,7 @@
-export default interface StringParser<ParsedOutput> {
+interface StringParser<ParsedOutput> {
   forciblyParsedFrom(givenSubject: string): ParsedOutput;
 }
+
+export {
+  type StringParser as default,
+};

--- a/src/plugins/vuetify.ts
+++ b/src/plugins/vuetify.ts
@@ -30,4 +30,6 @@ const vuetify = createVuetify({
   },
 });
 
-export default vuetify;
+export {
+  vuetify as default,
+};

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -17,4 +17,6 @@ const router = createRouter({
   ],
 });
 
-export default router;
+export {
+  router as default,
+};

--- a/src/shims-vue.d.ts
+++ b/src/shims-vue.d.ts
@@ -4,5 +4,8 @@ declare module '*.vue' {
   } from 'vue';
 
   const component: DefineComponent;
-  export default component;
+
+  export {
+    component as default,
+  };
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -13,7 +13,7 @@ import vueDevTools from 'vite-plugin-vue-devtools';
 import vuetify from 'vite-plugin-vuetify';
 
 // https://vite.dev/config/
-export default defineConfig({
+const viteConfig = defineConfig({
   plugins: [
     vue(),
     vueDevTools(),
@@ -31,3 +31,7 @@ export default defineConfig({
     },
   },
 });
+
+export {
+  viteConfig as default,
+};

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -10,7 +10,7 @@ import {
 
 import viteConfig from './vite.config';
 
-export default mergeConfig(
+const vitestConfig = mergeConfig(
   viteConfig,
   defineConfig({
     test: {
@@ -20,3 +20,7 @@ export default mergeConfig(
     },
   }),
 );
+
+export {
+  vitestConfig as default,
+};


### PR DESCRIPTION
 - enforces separation of exports from their declarations
 - enforces placement at the end of files

This has two effects:
- Less keywords surrounding class decorations:
  - after: `default export class ... extends ... implements {}`
  - before: `class ... extends ... implements {}`
- Easier to see defaults relate to non-defaults since they're all at the bottom of each file