### PR TITLE
fix(text-to-image): broken reference to `generate` function in client

### DIFF
--- a/src/features/TextToImage/client/index.ts
+++ b/src/features/TextToImage/client/index.ts
@@ -1,1 +1,3 @@
-export * as SDXL from '@/features/TextToImage/models/SDXL/client/index.ts';
+export {
+  default as SDXL,
+} from '@/features/TextToImage/models/SDXL/client/index.ts';


### PR DESCRIPTION
Was broken by #255 