### PR TITLE
fix(library): avoids nesting built-in non-actionable errors in `Attempt` utility

### DIFF
--- a/src/library/Attempt/error/modifier/PotentiallyActionable.ts
+++ b/src/library/Attempt/error/modifier/PotentiallyActionable.ts
@@ -16,7 +16,7 @@ export const assertPotentiallyActionable = <
 
   if (
     givenError instanceof HonoraryNonActionableError
-  ) return NonActionableError.rethrow(givenError);
+  ) throw givenError; // eslint-disable-line no-restricted-syntax
 
   return givenError as PotentiallyActionable<SomeError>;
 };


### PR DESCRIPTION
- the built-in JS errors considered "non-actionable" hold enough context on their own
- nesting them ends with in new `NonActionableError` instances just needlessly obfuscates the reason for failure