### PR TITLE
fix(library/Attempt): avoids nesting stack traces when using `.throwAnyway()`

### DIFF
--- a/src/features/TextToImage/models/SDXL/client/index.ts
+++ b/src/features/TextToImage/models/SDXL/client/index.ts
@@ -78,9 +78,7 @@ const generateOutputFrom = async (
 
     if (
       outcomeOfSettlingTextToImageResponse.isFailure
-    ) return Attempt.NonActionableError.rethrow(outcomeOfSettlingTextToImageResponse.causeOfFailure, {
-      message: 'Unreachable since `Attempt.toSettle` still throws everything',
-    });
+    ) return outcomeOfSettlingTextToImageResponse.causeOfFailure.throwAnyway('Unreachable since `Attempt.toSettle` still throws everything');
 
     textToImageResponse = outcomeOfSettlingTextToImageResponse.unwrapped;
   }

--- a/src/library/Attempt/error/ActionableError.ts
+++ b/src/library/Attempt/error/ActionableError.ts
@@ -16,7 +16,8 @@ abstract class ActionableError<SomeBrand extends string>
     givenJustification: string,
   ): never => {
     return NonActionableError.throw(givenJustification, {
-      cause: this,
+      cause  : this,
+      thrower: this.throwAnyway,
     });
   };
 }

--- a/src/library/Attempt/error/ActionableError.ts
+++ b/src/library/Attempt/error/ActionableError.ts
@@ -12,13 +12,13 @@ abstract class ActionableError<SomeBrand extends string>
   implements Branded<SomeBrand> {
   public readonly brand!: SomeBrand;
 
-  public throwAnyway(
+  public throwAnyway = (
     givenJustification: string,
-  ): never {
+  ): never => {
     return NonActionableError.throw(givenJustification, {
       cause: this,
     });
-  }
+  };
 }
 
 export {

--- a/src/library/Attempt/error/NonActionableError.ts
+++ b/src/library/Attempt/error/NonActionableError.ts
@@ -2,7 +2,7 @@ import type {
   Branded,
 } from '@/library/typeUtilities/Branded';
 
-interface NonActionableError_Options {
+interface NonActionableError_Options extends ErrorOptions {
   /** A function that's acting as an alternative to raw `throw` */
   thrower?: (...parameters: any[]) => unknown; // eslint-disable-line @typescript-eslint/no-explicit-any
 }
@@ -33,7 +33,7 @@ class NonActionableError
 
   public static throw = (
     givenMessage: NonActionableError['message'],
-    givenOptions?: ErrorOptions,
+    givenOptions?: Omit<NonActionableError_Options, 'thrower'>,
     givenCaller?: NonActionableError_Options['thrower'],
   ): never => {
     const newError = new NonActionableError(givenMessage, givenOptions);

--- a/src/library/Attempt/error/NonActionableError.ts
+++ b/src/library/Attempt/error/NonActionableError.ts
@@ -54,13 +54,10 @@ class NonActionableError
       message: NonActionableError['message'];
     },
   ): never => {
-    return this.throw(
-      given.message,
-      {
-        cause  : givenError,
-        thrower: NonActionableError.rethrow,
-      },
-    );
+    return this.throw(given.message, {
+      cause  : givenError,
+      thrower: NonActionableError.rethrow,
+    });
   };
 }
 

--- a/src/library/Attempt/error/NonActionableError.ts
+++ b/src/library/Attempt/error/NonActionableError.ts
@@ -34,7 +34,6 @@ class NonActionableError
   public static throw = (
     givenMessage: NonActionableError['message'],
     givenOptions?: NonActionableError_Options,
-    givenCaller?: NonActionableError_Options['thrower'],
   ): never => {
     const newError = new NonActionableError(givenMessage, givenOptions);
 
@@ -42,7 +41,7 @@ class NonActionableError
       ('captureStackTrace' in Error)
       && (Error.captureStackTrace instanceof Function)
     ) {
-      Error.captureStackTrace.call(undefined, newError, givenOptions?.thrower ?? givenCaller ?? NonActionableError.throw);
+      Error.captureStackTrace.call(undefined, newError, givenOptions?.thrower ?? NonActionableError.throw);
     }
 
     return newError.throw();

--- a/src/library/Attempt/error/NonActionableError.ts
+++ b/src/library/Attempt/error/NonActionableError.ts
@@ -2,6 +2,11 @@ import type {
   Branded,
 } from '@/library/typeUtilities/Branded';
 
+interface NonActionableError_Options {
+  /** A function that's acting as an alternative to raw `throw` */
+  thrower?: (...parameters: any[]) => unknown; // eslint-disable-line @typescript-eslint/no-explicit-any
+}
+
 /**
  * Errors from which normal execution cannot be recovered.
  *
@@ -29,7 +34,7 @@ class NonActionableError
   public static throw = (
     givenMessage: NonActionableError['message'],
     givenOptions?: ErrorOptions,
-    givenCaller?: (...parameters: any[]) => unknown, // eslint-disable-line @typescript-eslint/no-explicit-any
+    givenCaller?: NonActionableError_Options['thrower'],
   ): never => {
     const newError = new NonActionableError(givenMessage, givenOptions);
 

--- a/src/library/Attempt/error/NonActionableError.ts
+++ b/src/library/Attempt/error/NonActionableError.ts
@@ -33,7 +33,7 @@ class NonActionableError
 
   public static throw = (
     givenMessage: NonActionableError['message'],
-    givenOptions?: Omit<NonActionableError_Options, 'thrower'>,
+    givenOptions?: NonActionableError_Options,
     givenCaller?: NonActionableError_Options['thrower'],
   ): never => {
     const newError = new NonActionableError(givenMessage, givenOptions);
@@ -42,7 +42,7 @@ class NonActionableError
       ('captureStackTrace' in Error)
       && (Error.captureStackTrace instanceof Function)
     ) {
-      Error.captureStackTrace.call(undefined, newError, givenCaller ?? NonActionableError.throw);
+      Error.captureStackTrace.call(undefined, newError, givenOptions?.thrower ?? givenCaller ?? NonActionableError.throw);
     }
 
     return newError.throw();

--- a/src/library/Attempt/error/NonActionableError.ts
+++ b/src/library/Attempt/error/NonActionableError.ts
@@ -57,9 +57,9 @@ class NonActionableError
     return this.throw(
       given.message,
       {
-        cause: givenError,
+        cause  : givenError,
+        thrower: NonActionableError.rethrow,
       },
-      NonActionableError.rethrow,
     );
   };
 }


### PR DESCRIPTION
- stack traces were ending up at the point of error instantiation rather than "point of throw"
- this added unnecessary entries to logs
- it also prevented us from using in spots that would benefit from the terseness but be hurt by the messy stack trace