### PR TITLE
prefeature: generalizes use of `NonActionableError.rethrow`

### DIFF
--- a/src/features/TextToImage/models/SDXL/client/index.ts
+++ b/src/features/TextToImage/models/SDXL/client/index.ts
@@ -78,7 +78,9 @@ const generateOutputFrom = async (
 
     if (
       outcomeOfSettlingTextToImageResponse.isFailure
-    ) return Attempt.NonActionableError.rethrow(outcomeOfSettlingTextToImageResponse.causeOfFailure);
+    ) return Attempt.NonActionableError.rethrow(outcomeOfSettlingTextToImageResponse.causeOfFailure, {
+      message: 'Unreachable since `Attempt.toSettle` still throws everything',
+    });
 
     textToImageResponse = outcomeOfSettlingTextToImageResponse.unwrapped;
   }
@@ -90,7 +92,9 @@ const generateOutputFrom = async (
 
     if (
       !clientFailedToReachServer
-    ) return Attempt.NonActionableError.rethrow(someError);
+    ) return Attempt.NonActionableError.rethrow(someError, {
+      message: 'Text-to-image client failed to generate image due to an unexpected error',
+    });
 
     return ends.inFailureDueTo(new Server.ConnectionError());
   }

--- a/src/library/Attempt/error/NonActionableError.ts
+++ b/src/library/Attempt/error/NonActionableError.ts
@@ -43,7 +43,9 @@ class NonActionableError
     return newError.throw();
   };
 
-  public static rethrow = (givenError: Error): never => {
+  public static rethrow = (
+    givenError: Error,
+  ): never => {
     return this.throw(
       'Expected error to be either re-interpreted or handled altogether',
       {

--- a/src/library/Attempt/error/NonActionableError.ts
+++ b/src/library/Attempt/error/NonActionableError.ts
@@ -45,9 +45,12 @@ class NonActionableError
 
   public static rethrow = (
     givenError: Error,
+    given?: {
+      message: NonActionableError['message'];
+    },
   ): never => {
     return this.throw(
-      'Expected error to be either re-interpreted or handled altogether',
+      given?.message ?? 'Expected error to be either re-interpreted or handled altogether',
       {
         cause: givenError,
       },

--- a/src/library/Attempt/error/NonActionableError.ts
+++ b/src/library/Attempt/error/NonActionableError.ts
@@ -45,12 +45,12 @@ class NonActionableError
 
   public static rethrow = (
     givenError: Error,
-    given?: {
+    given: {
       message: NonActionableError['message'];
     },
   ): never => {
     return this.throw(
-      given?.message ?? 'Expected error to be either re-interpreted or handled altogether',
+      given.message,
       {
         cause: givenError,
       },

--- a/src/library/Attempt/utilities/outcomeOfFailedAttempt.ts
+++ b/src/library/Attempt/utilities/outcomeOfFailedAttempt.ts
@@ -27,5 +27,8 @@ export const outcomeOfFailedAttempt = <
   const someError = asError(givenSubject);
   const potentiallyActionableError = assertPotentiallyActionable(someError);
   const safelyPropagatedError = assertSafelyPropagated(potentiallyActionableError);
-  return NonActionableError.rethrow(safelyPropagatedError);
+
+  return NonActionableError.rethrow(safelyPropagatedError, {
+    message: 'Expected error to be either interpreted or prevented altogether',
+  });
 };


### PR DESCRIPTION
- messaging for rethrows should be contextual
- before, it was hard coded within the `NonActionableError` model so we weren't using it anywhere else