### PR TITLE
fix(library): avoids nested stack trace when using `NonActionableError.rethrow`

### DIFF
--- a/src/library/Attempt/error/NonActionableError.ts
+++ b/src/library/Attempt/error/NonActionableError.ts
@@ -49,6 +49,7 @@ class NonActionableError
       {
         cause: givenError,
       },
+      NonActionableError.rethrow,
     );
   };
 }

--- a/src/library/Attempt/error/NonActionableError.ts
+++ b/src/library/Attempt/error/NonActionableError.ts
@@ -29,6 +29,7 @@ class NonActionableError
   public static throw = (
     givenMessage: NonActionableError['message'],
     givenOptions?: ErrorOptions,
+    givenCaller?: (...parameters: any[]) => unknown, // eslint-disable-line @typescript-eslint/no-explicit-any
   ): never => {
     const newError = new NonActionableError(givenMessage, givenOptions);
 
@@ -36,7 +37,7 @@ class NonActionableError
       ('captureStackTrace' in Error)
       && (Error.captureStackTrace instanceof Function)
     ) {
-      Error.captureStackTrace.call(undefined, newError, NonActionableError.throw);
+      Error.captureStackTrace.call(undefined, newError, givenCaller ?? NonActionableError.throw);
     }
 
     return newError.throw();


### PR DESCRIPTION
- stack traces were ending up at the point of error instantiation rather than "point of throw"
- this added unnecessary entries to logs