### PR TITLE
types(text-to-image): avoids resolving `TextToImage.Output['image']` to an object literal 

### DIFF
--- a/src/features/TextToImage/types/Input.ts
+++ b/src/features/TextToImage/types/Input.ts
@@ -3,6 +3,6 @@ import type {
 } from 'stabilityai-client-typescript/models/components';
 
 /** The information that's eventually ingested by some text-to-image model */
-export interface TextToImageInput {
+export interface TextToImage_Input {
   text: TextToImageRequestBody['textPrompts'];
 }

--- a/src/features/TextToImage/types/Output.ts
+++ b/src/features/TextToImage/types/Output.ts
@@ -1,7 +1,7 @@
 import type ImageURI from '@/library/customTypes/UniformResourceIdentifier/Data/Image';
 
 /** The resulting information after a text-to-image model has ingested some input with some configuration */
-export interface TextToImageOutput {
+export interface TextToImage_Output {
   image: {
     uri: ImageURI;
     description: string;

--- a/src/features/TextToImage/types/Output/Image.ts
+++ b/src/features/TextToImage/types/Output/Image.ts
@@ -1,0 +1,10 @@
+import type ImageURI from '@/library/customTypes/UniformResourceIdentifier/Data/Image';
+
+interface TextToImage_Output_Image {
+  uri: ImageURI;
+  description: string;
+}
+
+export {
+  type TextToImage_Output_Image as default,
+};

--- a/src/features/TextToImage/types/Output/index.ts
+++ b/src/features/TextToImage/types/Output/index.ts
@@ -1,9 +1,6 @@
-import type ImageURI from '@/library/customTypes/UniformResourceIdentifier/Data/Image';
+import type TextToImage_Output_Image from './Image';
 
 /** The resulting information after a text-to-image model has ingested some input with some configuration */
 export interface TextToImage_Output {
-  image: {
-    uri: ImageURI;
-    description: string;
-  };
+  image: TextToImage_Output_Image;
 }

--- a/src/features/TextToImage/types/index.ts
+++ b/src/features/TextToImage/types/index.ts
@@ -1,6 +1,6 @@
 export type {
   TextToImage_Input as Input,
-} from './Input.ts';
+} from './Input';
 export type {
   TextToImage_Output as Output,
-} from './Output.ts';
+} from './Output';

--- a/src/features/TextToImage/types/index.ts
+++ b/src/features/TextToImage/types/index.ts
@@ -1,6 +1,6 @@
 export type {
-  TextToImageInput as Input,
+  TextToImage_Input as Input,
 } from './Input.ts';
 export type {
-  TextToImageOutput as Output,
+  TextToImage_Output as Output,
 } from './Output.ts';


### PR DESCRIPTION
- allows intellisense to display type name rather just its structure upon hover