### PR TITLE
refactor(text-to-image): preps page to handle error state

### DIFF
--- a/src/features/TextToImage/components/TextToImageOutputImg.vue
+++ b/src/features/TextToImage/components/TextToImageOutputImg.vue
@@ -1,0 +1,18 @@
+<script setup lang="ts">
+import {
+  VImg,
+} from 'vuetify/components/VImg';
+
+import * as TextToImage from '@/features/TextToImage';
+
+defineProps<{
+  modelValue: TextToImage.Output['image'];
+}>();
+</script>
+
+<template>
+  <VImg
+    :src="modelValue.uri.serialized"
+    :alt="modelValue.description"
+  />
+</template>

--- a/src/pages/TextToImagePage.vue
+++ b/src/pages/TextToImagePage.vue
@@ -18,9 +18,6 @@ import {
   VContainer,
 } from 'vuetify/components/VGrid';
 import {
-  VImg,
-} from 'vuetify/components/VImg';
-import {
   VMain,
 } from 'vuetify/components/VMain';
 import {
@@ -35,6 +32,7 @@ import DiscreteSlider from '@/components/DiscreteSlider.vue';
 import NavigationPanel from '@/components/NavigationPanel.vue';
 
 import TextToImageInputSection from '@/features/TextToImage/components/TextToImageInputSection.vue';
+import TextToImageOutputImg from '@/features/TextToImage/components/TextToImageOutputImg.vue';
 import * as TextToImage from '@/features/TextToImage/index.ts';
 
 const currentPrompt: Ref<TextToImage.Input['text'] | null> = ref(null);
@@ -118,10 +116,9 @@ const imageGeneration = useStatefulProcess(async () => {
       max-width="100vh"
       class="fill-height"
     >
-      <VImg
+      <TextToImageOutputImg
         v-if="imageGeneration.result !== null"
-        :src="imageGeneration.result.uri.serialized"
-        :alt="imageGeneration.result.description"
+        :model-value="imageGeneration.result"
       />
       <VSkeletonLoader
         v-else

--- a/src/pages/TextToImagePage.vue
+++ b/src/pages/TextToImagePage.vue
@@ -116,17 +116,17 @@ const imageGeneration = useStatefulProcess(async () => {
       max-width="100vh"
       class="fill-height"
     >
-      <TextToImageOutputImg
-        v-if="imageGeneration.result !== null"
-        :model-value="imageGeneration.result"
-      />
       <VSkeletonLoader
-        v-else
+        v-if="imageGeneration.result === null"
         :boilerplate="!imageGeneration.isInProgress"
         width="100vh"
         :style="{
           'aspect-ratio': 1,
         }"
+      />
+      <TextToImageOutputImg
+        v-else
+        :model-value="imageGeneration.result"
       />
     </VContainer>
   </VMain>


### PR DESCRIPTION
- extracts subcomponent
- orders components according to typical UI states: empty -> loading -> error -> partial -> complete
  - the page handles "empty", "loading", and "complete"
  - "partial" doesn't apply there's only one element: the image
  - "error" is the hole we're trying to plug