### PR TITLE
fix(library/vue): ensures that results are indeterminate for ongoing process

### DIFF
--- a/src/library/vue/statefulProcess.ts
+++ b/src/library/vue/statefulProcess.ts
@@ -21,13 +21,14 @@ export const useStatefulProcess = <
 
   const forciblyPerformFlaggedProcess = async (): Promise<void> => {
     using cleanup = new DisposableStack();
+
+    set(capturedResult, null);
     set(flagIsRaised, true);
 
     cleanup.defer(() => {
       set(flagIsRaised, false);
     });
 
-    set(capturedResult, null);
     const resultOfProcess = await forciblyPerformFlaggableProcess();
     set(capturedResult, resultOfProcess);
   };
@@ -38,6 +39,10 @@ export const useStatefulProcess = <
       return get(flagIsRaised);
     },
     get result() {
+      if (
+        this.isInProgress
+      ) return null;
+
       return get(capturedResult);
     },
   };


### PR DESCRIPTION
Clarifies that `null` is contextual according to the UI states:
- "empty": `result: null` because the process has never been initiated since last reset
- "loading": `result: null` because it isn't done yet, regardless of whether we have something in `result`
- "complete": `result: SomeProduct` when successful