### PR TITLE
prefeature(library/vue): makes it more obvious that error UI is missing

### DIFF
--- a/src/library/vue/statefulAttempt.ts
+++ b/src/library/vue/statefulAttempt.ts
@@ -7,7 +7,7 @@ import {
 
 import Attempt from '@/library/Attempt';
 
-interface StatefulProcess<
+interface StatefulAttempt<
   SomeProduct,
   SomeActionableError extends Attempt.ActionableError<string>,
 > {
@@ -17,14 +17,14 @@ interface StatefulProcess<
 }
 
 /** Useful when state of UI is dependent on some async operation and the outcome upon completion */
-export const useStatefulProcess = <
+export const useStatefulAttemptThatEventually = <
   SomeProduct,
   SomeActionableError extends Attempt.ActionableError<string>,
 >(
   retrieveOutcome: Attempt.EndRetriever<
     Attempt.Outcome<SomeProduct, SomeActionableError>
   >,
-): StatefulProcess<SomeProduct, SomeActionableError> => {
+): StatefulAttempt<SomeProduct, SomeActionableError> => {
   const flagIsRaised = ref(false);
 
   type CapturedOutcome = Attempt.Outcome<SomeProduct, SomeActionableError>;

--- a/src/library/vue/statefulProcess.ts
+++ b/src/library/vue/statefulProcess.ts
@@ -6,35 +6,35 @@ import {
 } from '@/library/vue/reactivity.ts';
 
 interface StatefulProcess<
-  SomeResult,
+  SomeProduct,
 > {
   initiate: () => Promise<void>;
   isInProgress: boolean;
-  result: SomeResult | null;
+  product: SomeProduct | null;
 }
 
-/** Useful when state of UI is dependent on some async operation and its result */
+/** Useful when state of UI is dependent on some async operation and the product it produces */
 export const useStatefulProcess = <
-  SomeResult,
+  SomeProduct,
 >(
-  forciblyPerformFlaggableProcess: () => Promise<SomeResult>,
-): StatefulProcess<SomeResult> => {
+  forciblyPerformFlaggableProcess: () => Promise<SomeProduct>,
+): StatefulProcess<SomeProduct> => {
   const flagIsRaised = ref(false);
 
-  const capturedResult: Ref<SomeResult | null> = ref(null);
+  const capturedProduct: Ref<SomeProduct | null> = ref(null);
 
   const forciblyPerformFlaggedProcess = async (): Promise<void> => {
     using cleanup = new DisposableStack();
 
-    set(capturedResult, null);
+    set(capturedProduct, null);
     set(flagIsRaised, true);
 
     cleanup.defer(() => {
       set(flagIsRaised, false);
     });
 
-    const resultOfProcess = await forciblyPerformFlaggableProcess();
-    set(capturedResult, resultOfProcess);
+    const productOfProcess = await forciblyPerformFlaggableProcess();
+    set(capturedProduct, productOfProcess);
   };
 
   return {
@@ -42,12 +42,12 @@ export const useStatefulProcess = <
     get isInProgress() {
       return get(flagIsRaised);
     },
-    get result() {
+    get product() {
       if (
         this.isInProgress
       ) return null;
 
-      return get(capturedResult);
+      return get(capturedProduct);
     },
   };
 };

--- a/src/library/vue/statefulProcess.ts
+++ b/src/library/vue/statefulProcess.ts
@@ -17,13 +17,13 @@ interface StatefulProcess<
 export const useStatefulProcess = <
   SomeProduct,
 >(
-  forciblyPerformFlaggableProcess: () => Promise<SomeProduct>,
+  forciblyRetrieveProduct: () => Promise<SomeProduct>,
 ): StatefulProcess<SomeProduct> => {
   const flagIsRaised = ref(false);
 
   const capturedProduct: Ref<SomeProduct | null> = ref(null);
 
-  const forciblyPerformFlaggedProcess = async (): Promise<void> => {
+  const forciblyCaptureProduct = async (): Promise<void> => {
     using cleanup = new DisposableStack();
 
     set(capturedProduct, null);
@@ -33,12 +33,12 @@ export const useStatefulProcess = <
       set(flagIsRaised, false);
     });
 
-    const productOfProcess = await forciblyPerformFlaggableProcess();
-    set(capturedProduct, productOfProcess);
+    const retrievedProduct = await forciblyRetrieveProduct();
+    set(capturedProduct, retrievedProduct);
   };
 
   return {
-    initiate: forciblyPerformFlaggedProcess,
+    initiate: forciblyCaptureProduct,
     get isInProgress() {
       return get(flagIsRaised);
     },

--- a/src/library/vue/statefulProcess.ts
+++ b/src/library/vue/statefulProcess.ts
@@ -5,16 +5,20 @@ import {
   type Ref,
 } from '@/library/vue/reactivity.ts';
 
+interface StatefulProcess<
+  SomeResult,
+> {
+  initiate: () => Promise<void>;
+  isInProgress: boolean;
+  result: SomeResult | null;
+}
+
 /** Useful when state of UI is dependent on some async operation and its result */
 export const useStatefulProcess = <
   SomeResult,
 >(
   forciblyPerformFlaggableProcess: () => Promise<SomeResult>,
-): ({
-  initiate: () => Promise<void>;
-  isInProgress: boolean;
-  result: SomeResult | null;
-}) => {
+): StatefulProcess<SomeResult> => {
   const flagIsRaised = ref(false);
 
   const capturedResult: Ref<SomeResult | null> = ref(null);

--- a/src/library/vue/statefulProcess.ts
+++ b/src/library/vue/statefulProcess.ts
@@ -5,49 +5,56 @@ import {
   type Ref,
 } from '@/library/vue/reactivity.ts';
 
+import Attempt from '@/library/Attempt';
+
 interface StatefulProcess<
   SomeProduct,
+  SomeActionableError extends Attempt.ActionableError<string>,
 > {
   initiate: () => Promise<void>;
   isInProgress: boolean;
-  product: SomeProduct | null;
+  outcome: Attempt.Outcome<SomeProduct, SomeActionableError> | null;
 }
 
-/** Useful when state of UI is dependent on some async operation and the product it produces */
+/** Useful when state of UI is dependent on some async operation and the outcome upon completion */
 export const useStatefulProcess = <
   SomeProduct,
+  SomeActionableError extends Attempt.ActionableError<string>,
 >(
-  forciblyRetrieveProduct: () => Promise<SomeProduct>,
-): StatefulProcess<SomeProduct> => {
+  retrieveOutcome: Attempt.EndRetriever<
+    Attempt.Outcome<SomeProduct, SomeActionableError>
+  >,
+): StatefulProcess<SomeProduct, SomeActionableError> => {
   const flagIsRaised = ref(false);
 
-  const capturedProduct: Ref<SomeProduct | null> = ref(null);
+  type CapturedOutcome = Attempt.Outcome<SomeProduct, SomeActionableError>;
+  const capturedOutcome: Ref<CapturedOutcome | null> = ref(null);
 
-  const forciblyCaptureProduct = async (): Promise<void> => {
+  const captureOutcome = async (): Promise<void> => {
     using cleanup = new DisposableStack();
 
-    set(capturedProduct, null);
+    set(capturedOutcome, null);
     set(flagIsRaised, true);
 
     cleanup.defer(() => {
       set(flagIsRaised, false);
     });
 
-    const retrievedProduct = await forciblyRetrieveProduct();
-    set(capturedProduct, retrievedProduct);
+    const retrievedOutcome = await Attempt.thatEventually(retrieveOutcome);
+    set(capturedOutcome, retrievedOutcome);
   };
 
   return {
-    initiate: forciblyCaptureProduct,
+    initiate: captureOutcome,
     get isInProgress() {
       return get(flagIsRaised);
     },
-    get product() {
+    get outcome() {
       if (
         this.isInProgress
       ) return null;
 
-      return get(capturedProduct);
+      return get(capturedOutcome);
     },
   };
 };

--- a/src/pages/TextToImagePage.vue
+++ b/src/pages/TextToImagePage.vue
@@ -5,8 +5,8 @@ import {
   type Ref,
 } from '@/library/vue/reactivity.ts';
 import {
-  useStatefulProcess,
-} from '@/library/vue/statefulProcess.ts';
+  useStatefulAttemptThatEventually,
+} from '@/library/vue/statefulAttempt';
 
 import {
   VBtn,
@@ -41,7 +41,7 @@ const {
 
 const currentNumberOfDiffusionSteps = ref<number>(range.midpoint);
 
-const imageGeneration = useStatefulProcess(async (ends) => {
+const imageGeneration = useStatefulAttemptThatEventually(async (ends) => {
   const proposedPrompt = get(currentPrompt);
 
   if (

--- a/src/pages/TextToImagePage.vue
+++ b/src/pages/TextToImagePage.vue
@@ -24,8 +24,6 @@ import {
   VSkeletonLoader,
 } from 'vuetify/components/VSkeletonLoader';
 
-import Attempt from '@/library/Attempt';
-
 import SDXLDiffusionStepCount from '@/library/ShimmedStabilityAIClient/models/SDXLDiffusionStepCount.ts';
 
 import DiscreteSlider from '@/components/DiscreteSlider.vue';
@@ -43,12 +41,12 @@ const {
 
 const currentNumberOfDiffusionSteps = ref<number>(range.midpoint);
 
-const imageGeneration = useStatefulProcess(async () => {
+const imageGeneration = useStatefulProcess(async (ends) => {
   const proposedPrompt = get(currentPrompt);
 
   if (
     proposedPrompt === null
-  ) return Attempt.abandon('Prompt was not set before submission');
+  ) return ends.inFlamesBecause('Prompt was not set before submission');
 
   const outcomeOfGeneratingOutput = await TextToImage.Client.SDXL.generateOutputFrom({
     textToImageRequestBody: {
@@ -62,7 +60,7 @@ const imageGeneration = useStatefulProcess(async () => {
   });
 
   const generatedOutput = outcomeOfGeneratingOutput.forciblyUnwrap();
-  return generatedOutput.image;
+  return ends.inSuccessWith(generatedOutput.image);
 });
 </script>
 
@@ -117,7 +115,7 @@ const imageGeneration = useStatefulProcess(async () => {
       class="fill-height"
     >
       <VSkeletonLoader
-        v-if="imageGeneration.product === null"
+        v-if="imageGeneration.outcome === null"
         :boilerplate="!imageGeneration.isInProgress"
         width="100vh"
         :style="{
@@ -126,7 +124,7 @@ const imageGeneration = useStatefulProcess(async () => {
       />
       <TextToImageOutputImg
         v-else
-        :model-value="imageGeneration.product"
+        :model-value="imageGeneration.outcome.forciblyUnwrap()"
       />
     </VContainer>
   </VMain>

--- a/src/pages/TextToImagePage.vue
+++ b/src/pages/TextToImagePage.vue
@@ -117,7 +117,7 @@ const imageGeneration = useStatefulProcess(async () => {
       class="fill-height"
     >
       <VSkeletonLoader
-        v-if="imageGeneration.result === null"
+        v-if="imageGeneration.product === null"
         :boilerplate="!imageGeneration.isInProgress"
         width="100vh"
         :style="{
@@ -126,7 +126,7 @@ const imageGeneration = useStatefulProcess(async () => {
       />
       <TextToImageOutputImg
         v-else
-        :model-value="imageGeneration.result"
+        :model-value="imageGeneration.product"
       />
     </VContainer>
   </VMain>


### PR DESCRIPTION
- replaces `useStatefulProcess` composable with error-safe version
- the benefit: template-level "force unwrap" that just _begs_ for an error UI