### PR TITLE
feature(text-to-image): reports offending origin in `Server.ConnectionError`

### DIFF
--- a/src/features/TextToImage/models/SDXL/client/index.ts
+++ b/src/features/TextToImage/models/SDXL/client/index.ts
@@ -92,7 +92,7 @@ const generateOutputFrom = async (
       message: 'Text-to-image client failed to generate image due to an unexpected error',
     });
 
-    return ends.inFailureDueTo(new Server.ConnectionError());
+    return ends.inFailureDueTo(new Server.ConnectionError(shimmedStabilityAIClient.origin));
   }
 
   if (

--- a/src/features/TextToImage/webAPI/Server/ServerConnectionError.ts
+++ b/src/features/TextToImage/webAPI/Server/ServerConnectionError.ts
@@ -1,9 +1,15 @@
 import Attempt from '@/library/Attempt';
 
+import type {
+  URLOrigin,
+} from '@/library/customTypes/URLComponent';
+
 class TextToImage_Server_ConnectionError extends Attempt.ActionableError<'TextToImage_ServerConnectionError'> {
-  public constructor() {
+  public constructor(
+    public readonly origin: URLOrigin,
+  ) {
     const message = [
-      'Failed to reach the text-to-image server.',
+      `Failed to reach the text-to-image server at "${origin.toString()}".`,
       `Are you sure it's running?`,
     ].join('\n');
 


### PR DESCRIPTION
- surfaces failing origin to global error handler