### PR TITLE
linter: separates exports from declarations for cleaner diffs

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -35,6 +35,9 @@ const importPluginConfigs: ConfigWithExtends[] = [
       'import/exports-last': [
         'error', // Encourages decoupling the export of a module from its declaration, which leads to cleaner diffs
       ],
+      'import/group-exports': [
+        'error', // Encourages decoupling the export of a module from its declaration, which leads to cleaner diffs
+      ],
       'import/order': [
         'error',
         {

--- a/src/features/TextToImage/config/types/Config.ts
+++ b/src/features/TextToImage/config/types/Config.ts
@@ -1,9 +1,13 @@
 import * as WebAPI from '@/library/WebAPI';
 
 /** The user-provided settings for the text-to-image feature */
-export class TextToImage_Config {
+class TextToImage_Config {
   public constructor(
     /** The details of the server that's providing text-to-image generation */
     public readonly server: WebAPI.Server | null,
   ) {}
 }
+
+export {
+  TextToImage_Config,
+};

--- a/src/features/TextToImage/config/utilities/emptyConfig.ts
+++ b/src/features/TextToImage/config/utilities/emptyConfig.ts
@@ -2,6 +2,10 @@ import type {
   Config,
 } from '../types';
 
-export const emptyConfig: Config = {
+const emptyConfig: Config = {
   server: null,
+};
+
+export {
+  emptyConfig,
 };

--- a/src/features/TextToImage/types/Input.ts
+++ b/src/features/TextToImage/types/Input.ts
@@ -3,6 +3,10 @@ import type {
 } from 'stabilityai-client-typescript/models/components';
 
 /** The information that's eventually ingested by some text-to-image model */
-export interface TextToImage_Input {
+interface TextToImage_Input {
   text: TextToImageRequestBody['textPrompts'];
 }
+
+export {
+  type TextToImage_Input,
+};

--- a/src/features/TextToImage/types/Output/index.ts
+++ b/src/features/TextToImage/types/Output/index.ts
@@ -1,6 +1,10 @@
 import type TextToImage_Output_Image from './Image';
 
 /** The resulting information after a text-to-image model has ingested some input with some configuration */
-export interface TextToImage_Output {
+interface TextToImage_Output {
   image: TextToImage_Output_Image;
 }
+
+export {
+  type TextToImage_Output,
+};

--- a/src/features/reporting.ts
+++ b/src/features/reporting.ts
@@ -1,6 +1,6 @@
 import * as Repository from '@/utilities/Repository.ts';
 
-export const promptUserToReport = (givenErrorMessage: string) => {
+const promptUserToReport = (givenErrorMessage: string) => {
   const userDidPermitDraftingNewIssue = window.confirm([
     'Unexpected Error:',
     '"""',
@@ -16,4 +16,8 @@ export const promptUserToReport = (givenErrorMessage: string) => {
 
   const draftOfNewIssue = Repository.draftIssueFor(givenErrorMessage);
   window.open(draftOfNewIssue);
+};
+
+export {
+  promptUserToReport,
 };

--- a/src/library/Attempt/Outcome.ts
+++ b/src/library/Attempt/Outcome.ts
@@ -138,18 +138,20 @@ type Outcome<
   | Success<SomeProduct>
   | Failure<SomeActionableError>;
 
-export {
-  Outcome as default,
-};
-
-export type ProductOf<
+type ProductOf<
   SomeOutcome extends Outcome<unknown, ActionableError<string>>,
 > = SomeOutcome extends Success<infer NestedProduct>
   ? NestedProduct
   : never;
 
-export type CauseOf<
+type CauseOf<
   SomeOutcome extends Outcome<unknown, ActionableError<string>>,
 > = SomeOutcome extends Failure<infer NestedError>
   ? NestedError
   : never;
+
+export {
+  Outcome as default,
+  type ProductOf,
+  type CauseOf,
+};

--- a/src/library/Attempt/adapter/asynchronous.ts
+++ b/src/library/Attempt/adapter/asynchronous.ts
@@ -8,7 +8,7 @@ import {
   outcomeOfFailedAttempt,
 } from '../utilities/outcomeOfFailedAttempt';
 
-export const attemptToEventually = async <
+const attemptToEventually = async <
   SomeProduct,
   SomeActionableError extends ActionableError<string>,
 >(
@@ -26,7 +26,7 @@ export const attemptToEventually = async <
   }
 };
 
-export const attemptToSettle = async <
+const attemptToSettle = async <
   SomeProduct,
   SomeActionableError extends ActionableError<string>,
 >(
@@ -34,4 +34,9 @@ export const attemptToSettle = async <
 ): Promise<Outcome<SomeProduct, SomeActionableError>> => {
   const getPromisedProduct = () => promisedProduct;
   return attemptToEventually(getPromisedProduct);
+};
+
+export {
+  attemptToEventually,
+  attemptToSettle,
 };

--- a/src/library/Attempt/adapter/synchronous.ts
+++ b/src/library/Attempt/adapter/synchronous.ts
@@ -8,7 +8,7 @@ import {
   outcomeOfFailedAttempt,
 } from '../utilities/outcomeOfFailedAttempt';
 
-export const attemptTo = <
+const attemptTo = <
   SomeProduct,
   SomeActionableError extends ActionableError<string>,
 >(
@@ -24,4 +24,8 @@ export const attemptTo = <
       basedOn: whateverThatWasThrown,
     });
   }
+};
+
+export {
+  attemptTo,
 };

--- a/src/library/Attempt/ended.ts
+++ b/src/library/Attempt/ended.ts
@@ -10,11 +10,15 @@ import {
  * - an error from which execution can be recovered
  * - an error from which execution cannot be recovered
 */
-export const Attempt_ended = {
+const Attempt_ended = {
   /** Call this when the attempt has completed and was considered successful */
   inSuccessWith  : Outcome.successThatYielded,
   /** Call this when the attempt has completed and was considered a failure */
   inFailureDueTo : Outcome.failureDueTo,
   /** Call this when it's not possible to complete the attempt */
   inFlamesBecause: NonActionableError.throw,
+};
+
+export {
+  Attempt_ended,
 };

--- a/src/library/Attempt/error/modifier/PotentiallyActionable.ts
+++ b/src/library/Attempt/error/modifier/PotentiallyActionable.ts
@@ -1,11 +1,11 @@
 import HonoraryNonActionableError from '../HonoraryNonActionableError';
 import NonActionableError from '../NonActionableError';
 
-export type PotentiallyActionable<
+type PotentiallyActionable<
   SomeError extends Error,
 > = Exclude<SomeError, NonActionableError | HonoraryNonActionableError>;
 
-export const assertPotentiallyActionable = <
+const assertPotentiallyActionable = <
   SomeError extends Error,
 >(
   givenError: SomeError,
@@ -19,4 +19,9 @@ export const assertPotentiallyActionable = <
   ) throw givenError; // eslint-disable-line no-restricted-syntax
 
   return givenError as PotentiallyActionable<SomeError>;
+};
+
+export {
+  type PotentiallyActionable,
+  assertPotentiallyActionable,
 };

--- a/src/library/Attempt/error/modifier/SafelyPropagated.ts
+++ b/src/library/Attempt/error/modifier/SafelyPropagated.ts
@@ -11,7 +11,7 @@ type SafelyPropagated<
   ActionableError<string>
 >;
 
-export const assertSafelyPropagated = <
+const assertSafelyPropagated = <
   SomePotentiallyActionableError extends PotentiallyActionable<Error>,
 >(
   givenError: SomePotentiallyActionableError,
@@ -21,4 +21,8 @@ export const assertSafelyPropagated = <
   ) return givenError.throwAnyway('Unexpected raw `throw` of some `ActionableError`. If this was intentional, use `.throwAnyway(...)` on the instance instead.');
 
   return givenError as SafelyPropagated<SomePotentiallyActionableError>;
+};
+
+export {
+  assertSafelyPropagated,
 };

--- a/src/library/Attempt/exports.ts
+++ b/src/library/Attempt/exports.ts
@@ -2,7 +2,11 @@ import {
   Attempt_ended,
 } from './ended';
 
-export const abandon = Attempt_ended.inFlamesBecause;
+const abandon = Attempt_ended.inFlamesBecause;
+
+export {
+  abandon,
+};
 
 export {
   default as Outcome,

--- a/src/library/Attempt/factory/asynchronous.ts
+++ b/src/library/Attempt/factory/asynchronous.ts
@@ -13,17 +13,22 @@ import type {
   ActionableError,
 } from '../error';
 
-export type Attempt_EndRetriever<
+type Attempt_EndRetriever<
   InferredOutcome extends Outcome<unknown, ActionableError<string>>,
 > = (
   givenHandles: typeof handles
 ) => Promise<InferredOutcome>;
 
-export const Attempt_thatEventually = async <
+const Attempt_thatEventually = async <
   InferredOutcome extends Outcome<unknown, ActionableError<string>>,
 >(
   endsAccordingTo: Attempt_EndRetriever<InferredOutcome>,
 ) => {
   type EquivalentOutcome = Outcome<ProductOf<InferredOutcome>, CauseOf<InferredOutcome>>;
   return await endsAccordingTo(handles) as EquivalentOutcome;
+};
+
+export {
+  type Attempt_EndRetriever,
+  Attempt_thatEventually,
 };

--- a/src/library/Attempt/factory/synchronous.ts
+++ b/src/library/Attempt/factory/synchronous.ts
@@ -12,17 +12,22 @@ import {
   ActionableError,
 } from '../error';
 
-export type Attempt_EndGetter<
+type Attempt_EndGetter<
   InferredOutcome extends Outcome<unknown, ActionableError<string>>,
 > = (
   givenHandles: typeof handles
 ) => InferredOutcome;
 
-export const Attempt_that = <
+const Attempt_that = <
   InferredOutcome extends Outcome<unknown, ActionableError<string>>,
 >(
   endsAccordingTo: Attempt_EndGetter<InferredOutcome>,
 ) => {
   type EquivalentOutcome = Outcome<ProductOf<InferredOutcome>, CauseOf<InferredOutcome>>;
   return endsAccordingTo(handles) as EquivalentOutcome;
+};
+
+export {
+  type Attempt_EndGetter,
+  Attempt_that,
 };

--- a/src/library/Attempt/utilities/outcomeOfFailedAttempt.ts
+++ b/src/library/Attempt/utilities/outcomeOfFailedAttempt.ts
@@ -14,7 +14,7 @@ import {
   assertSafelyPropagated,
 } from '../error/modifier';
 
-export const outcomeOfFailedAttempt = <
+const outcomeOfFailedAttempt = <
   SomeProduct,
   SomeActionableError extends ActionableError<string>,
 >(
@@ -31,4 +31,8 @@ export const outcomeOfFailedAttempt = <
   return NonActionableError.rethrow(safelyPropagatedError, {
     message: 'Expected error to be either interpreted or prevented altogether',
   });
+};
+
+export {
+  outcomeOfFailedAttempt,
 };

--- a/src/library/HTTPClient/HTTPRequest.ts
+++ b/src/library/HTTPClient/HTTPRequest.ts
@@ -1,5 +1,5 @@
 /** [MDN Reference](https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods) */
-export enum Method {
+enum Method {
   CREATE /**/ = 'PUT',
   FETCH /* */ = 'GET',
   UPDATE /**/ = 'PATCH',
@@ -7,4 +7,9 @@ export enum Method {
   SUBMIT /**/ = 'POST',
 }
 
-export type HeaderMap = Record<string, string>;
+type HeaderMap = Record<string, string>;
+
+export {
+  Method,
+  type HeaderMap,
+};

--- a/src/library/HTTPClient/HTTPResponse.ts
+++ b/src/library/HTTPClient/HTTPResponse.ts
@@ -1,29 +1,37 @@
 /** See [MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status#successful_responses) */
-export enum SuccessStatusCode {
+enum SuccessStatusCode {
   OK /*                */ = 200,
   Created /*           */ = 201,
   Accepted /*          */ = 202,
   NoContent /*         */ = 204,
 }
 /** See [MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status#client_error_responses) */
-export enum ClientErrorStatusCode {
+enum ClientErrorStatusCode {
   BadRequest /*        */ = 400,
   Unauthorized /*      */ = 401,
   Forbidden /*         */ = 403,
   NotFound /*          */ = 404,
 }
 /** See [MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status#server_error_responses) */
-export enum ServerErrorStatusCode {
+enum ServerErrorStatusCode {
   Internal /*          */ = 500,
   NotImplemented /*    */ = 501,
   BadGateway /*        */ = 502,
   ServiceUnavailable /**/ = 503,
 }
 
-export type ErrorStatusCode =
+type ErrorStatusCode =
   | ClientErrorStatusCode
   | ServerErrorStatusCode;
 
-export type StatusCode =
+type StatusCode =
   | SuccessStatusCode
   | ErrorStatusCode;
+
+export {
+  SuccessStatusCode,
+  ClientErrorStatusCode,
+  ServerErrorStatusCode,
+  type ErrorStatusCode,
+  type StatusCode,
+};

--- a/src/library/WebAPI/ServerSchema.ts
+++ b/src/library/WebAPI/ServerSchema.ts
@@ -5,6 +5,10 @@ import {
 import Server from './Server';
 
 /** Defines how to parse into an instance of {@link Server} */
-export const ServerSchema = z.object({
+const ServerSchema = z.object({
   origin: z.string(),
 }).transform($0 => Server.from($0));
+
+export {
+  ServerSchema,
+};

--- a/src/library/customTypes/UniformResourceIdentifier/Data/DataURIBinaryEncoding.ts
+++ b/src/library/customTypes/UniformResourceIdentifier/Data/DataURIBinaryEncoding.ts
@@ -1,6 +1,11 @@
-export const allDataURIBinaryEncodings = [
+const allDataURIBinaryEncodings = [
   'base64',
   'utf8',
 ] as const;
 
-export type DataURIBinaryEncoding = (typeof allDataURIBinaryEncodings)[number];
+type DataURIBinaryEncoding = (typeof allDataURIBinaryEncodings)[number];
+
+export {
+  allDataURIBinaryEncodings,
+  type DataURIBinaryEncoding,
+};

--- a/src/library/customTypes/UniformResourceIdentifier/Data/Image/ImageURIFormat.ts
+++ b/src/library/customTypes/UniformResourceIdentifier/Data/Image/ImageURIFormat.ts
@@ -1,8 +1,13 @@
-export const allImageURIFormats = [
+const allImageURIFormats = [
   'png',
   'jpeg',
   'gif',
   'webp',
 ] as const;
 
-export type ImageURIFormat = (typeof allImageURIFormats)[number];
+type ImageURIFormat = (typeof allImageURIFormats)[number];
+
+export {
+  allImageURIFormats,
+  type ImageURIFormat,
+};

--- a/src/library/math/aggregators.ts
+++ b/src/library/math/aggregators.ts
@@ -1,9 +1,14 @@
 type Aggregator = (...givenValues: [number, ...number[]]) => number;
 
-export const sumOf: Aggregator = (
+const sumOf: Aggregator = (
   ...givenAddends
 ) => givenAddends.reduce(($0, $1) => $0 + $1);
 
-export const arithmeticMeanOf: Aggregator = (
+const arithmeticMeanOf: Aggregator = (
   ...givenValues
 ) => sumOf(...givenValues) / givenValues.length;
+
+export {
+  sumOf,
+  arithmeticMeanOf,
+};

--- a/src/library/math/operators.ts
+++ b/src/library/math/operators.ts
@@ -1,4 +1,4 @@
-export const greatestCommonFactor = (a: number, b: number): number => {
+const greatestCommonFactor = (a: number, b: number): number => {
   let nextDividend = a;
   let previousRemainder = b;
 
@@ -11,11 +11,11 @@ export const greatestCommonFactor = (a: number, b: number): number => {
   return nextDividend;
 };
 
-export const leastCommonMultiple = (a: number, b: number): number => {
+const leastCommonMultiple = (a: number, b: number): number => {
   return (a * b) / greatestCommonFactor(a, b);
 };
 
-export const cofactor = (
+const cofactor = (
   {
     to: givenCofactor,
     forLCMWith: givenValue,
@@ -25,4 +25,10 @@ export const cofactor = (
   },
 ): number => {
   return leastCommonMultiple(givenValue, givenCofactor) / givenCofactor;
+};
+
+export {
+  greatestCommonFactor,
+  leastCommonMultiple,
+  cofactor,
 };

--- a/src/library/typeUtilities/Boolean.ts
+++ b/src/library/typeUtilities/Boolean.ts
@@ -1,4 +1,4 @@
-export type Is<
+type Is<
   LeftHandOperand,
   RightHandOperand,
 > =
@@ -8,7 +8,7 @@ export type Is<
       false :
     false;
 
-export type If<
+type If<
   Condition extends boolean,
   WhenTrue,
   WhenFalse,
@@ -17,8 +17,14 @@ export type If<
     ? WhenTrue
     : WhenFalse;
 
-export type Not<
+type Not<
   SomeBoolean extends boolean,
 > = SomeBoolean extends true
   ? false
   : true;
+
+export type {
+  Is,
+  If,
+  Not,
+};

--- a/src/library/typeUtilities/Branded.ts
+++ b/src/library/typeUtilities/Branded.ts
@@ -4,9 +4,13 @@
  * When implemented by a class, makes subclasses structurally different from each other such that
  * the type-checker will complain if you try to assign a subclass to a variable of a different subclass.
  */
-export interface Branded<SomeBrand extends string> {
+interface Branded<SomeBrand extends string> {
   /**
    * Allows the type-checker to discern between subclasses and complain about mismatched types.
    */
   readonly brand: SomeBrand;
 }
+
+export {
+  type Branded,
+};

--- a/src/library/typeUtilities/StaticStringParser.ts
+++ b/src/library/typeUtilities/StaticStringParser.ts
@@ -1,7 +1,7 @@
 import type Static from '@/library/typeUtilities/Static.ts';
 import type StringParser from '@/library/typeUtilities/StringParser.ts';
 
-export type StaticStringParser<
+type StaticStringParser<
   SomeClassType extends
   & Static<
     SomeClassType['prototype']
@@ -10,3 +10,7 @@ export type StaticStringParser<
     SomeClassType['prototype']
   >,
 > = SomeClassType['prototype'];
+
+export type {
+  StaticStringParser,
+};

--- a/src/library/utilitiesByType/array.ts
+++ b/src/library/utilitiesByType/array.ts
@@ -1,3 +1,7 @@
-export const isEmpty = (givenSubject: unknown[]): givenSubject is [] => {
+const isEmpty = (givenSubject: unknown[]): givenSubject is [] => {
   return givenSubject.length === 0;
+};
+
+export {
+  isEmpty,
 };

--- a/src/library/utilitiesByType/error.ts
+++ b/src/library/utilitiesByType/error.ts
@@ -2,15 +2,20 @@ import {
   asString,
 } from './string';
 
-export const isError = (givenSubject: unknown): givenSubject is Error => {
+const isError = (givenSubject: unknown): givenSubject is Error => {
   return (givenSubject instanceof Error);
 };
 
-export const asError = (givenSubject: unknown): Error => {
+const asError = (givenSubject: unknown): Error => {
   if (
     isError(givenSubject)
   ) return givenSubject;
 
   const castedMessage = asString(givenSubject);
   return new Error(castedMessage);
+};
+
+export {
+  isError,
+  asError,
 };

--- a/src/library/utilitiesByType/record.ts
+++ b/src/library/utilitiesByType/record.ts
@@ -1,4 +1,4 @@
-export const shallowlyMerged = <
+const shallowlyMerged = <
   SomeRecord extends Record<string, unknown>,
 >(
   ...givenRecords: (SomeRecord | null)[]
@@ -9,4 +9,8 @@ export const shallowlyMerged = <
       ...eachRecord,
     };
   }, {} as SomeRecord);
+};
+
+export {
+  shallowlyMerged,
 };

--- a/src/library/utilitiesByType/reference.ts
+++ b/src/library/utilitiesByType/reference.ts
@@ -1,6 +1,10 @@
 import cloneDeep from 'lodash.clonedeep';
 
 /** Copies the value at this reference all the way down to the deepest nesting */
-export const cloneOf = <Any>(givenReference: Any): Any => {
+const cloneOf = <Any>(givenReference: Any): Any => {
   return cloneDeep(givenReference);
+};
+
+export {
+  cloneOf,
 };

--- a/src/library/utilitiesByType/string.ts
+++ b/src/library/utilitiesByType/string.ts
@@ -1,8 +1,8 @@
-export const isString = (givenSubject: unknown): givenSubject is string => {
+const isString = (givenSubject: unknown): givenSubject is string => {
   return (typeof givenSubject === 'string');
 };
 
-export const asString = (givenSubject: unknown): string => {
+const asString = (givenSubject: unknown): string => {
   if (
     isString(givenSubject)
   ) return givenSubject;
@@ -10,18 +10,28 @@ export const asString = (givenSubject: unknown): string => {
   return JSON.stringify(givenSubject);
 };
 
-export const emptyString = '';
+const emptyString = '';
 
-export type EmptyString = typeof emptyString;
+type EmptyString = typeof emptyString;
 
-export const isEmpty = (givenSubject: string): givenSubject is EmptyString => {
+const isEmpty = (givenSubject: string): givenSubject is EmptyString => {
   return givenSubject === emptyString;
 };
 
-export const lastCharacterOf = (givenCharacters: string): string | null => {
+const lastCharacterOf = (givenCharacters: string): string | null => {
   return givenCharacters[givenCharacters.length - 1] ?? null;
 };
 
-export const droppingLastCharacter = (givenCharacters: string): string => {
+const droppingLastCharacter = (givenCharacters: string): string => {
   return givenCharacters.substring(0, givenCharacters.length - 1);
+};
+
+export {
+  isString,
+  asString,
+  emptyString,
+  type EmptyString,
+  isEmpty,
+  lastCharacterOf,
+  droppingLastCharacter,
 };

--- a/src/library/vue/reactivity.ts
+++ b/src/library/vue/reactivity.ts
@@ -5,9 +5,9 @@ import {
 } from 'vue';
 
 /** Wraps an instance to make it reactive */
-export const ref = _ref;
+const ref = _ref;
 
-export type Ref<
+type Ref<
   GetterResult,
   SetterParameter = GetterResult,
 > = _Ref<
@@ -16,9 +16,16 @@ export type Ref<
 >;
 
 /** Unwraps a reactive instance */
-export const get = unref;
+const get = unref;
 
 /** Updates the wrapped instance */
-export const set = <Any>(givenSubject: Ref<Any>, givenValue: Any): void => {
+const set = <Any>(givenSubject: Ref<Any>, givenValue: Any): void => {
   givenSubject.value = givenValue;
+};
+
+export {
+  ref,
+  type Ref,
+  get,
+  set,
 };

--- a/src/library/vue/statefulAttempt.ts
+++ b/src/library/vue/statefulAttempt.ts
@@ -17,7 +17,7 @@ interface StatefulAttempt<
 }
 
 /** Useful when state of UI is dependent on some async operation and the outcome upon completion */
-export const useStatefulAttemptThatEventually = <
+const useStatefulAttemptThatEventually = <
   SomeProduct,
   SomeActionableError extends Attempt.ActionableError<string>,
 >(
@@ -57,4 +57,8 @@ export const useStatefulAttemptThatEventually = <
       return get(capturedOutcome);
     },
   };
+};
+
+export {
+  useStatefulAttemptThatEventually,
 };

--- a/src/utilities/Repository.ts
+++ b/src/utilities/Repository.ts
@@ -5,7 +5,7 @@ import {
 const emptyDraftOfNewIssue = new URL('https://github.com/nod-ai/shark-ui/issues/new');
 
 /** Creates a URL that drafts a new issue with pre-populated fields  */
-export const draftIssueFor = (givenErrorMessage: string): URL => {
+const draftIssueFor = (givenErrorMessage: string): URL => {
   const mutableDraft = cloneOf(emptyDraftOfNewIssue);
 
   const referencedParameters = mutableDraft.searchParams;
@@ -18,4 +18,8 @@ export const draftIssueFor = (givenErrorMessage: string): URL => {
   referencedParameters.set('type', 'Bug');
 
   return mutableDraft;
+};
+
+export {
+  draftIssueFor,
 };


### PR DESCRIPTION
- `export` next to declarations can add noise to diffs depending on the scenario:
    - `const`: renames
    - `class`: renames, modifying generics, `extends` or `implements`
    - `enum`: renames, modifying cases
    - `type`/`interface`: renames, modifying generics
- keeping exports at the bottom:
    - establishes an easy-to-follow convention
    - balances out "imports at the top"
    - ensures they only show up on diffs when they're actually changed