### PR TITLE
feature(reporting): exposes nested error messages to fallback error dialog

### DIFF
--- a/src/features/reporting.ts
+++ b/src/features/reporting.ts
@@ -13,8 +13,8 @@ const formatted = (
 };
 
 const promptUserToReport = (givenError: Error) => {
-  const defaultMessage = 'Unexpected Error';
-  const formattedErrorDetails = formatted(givenError, defaultMessage);
+  const unexpectedError_message = 'Unexpected Error';
+  const formattedErrorDetails = formatted(givenError, unexpectedError_message);
 
   const userDidPermitDraftingNewIssue = window.confirm([
     formattedErrorDetails,

--- a/src/features/reporting.ts
+++ b/src/features/reporting.ts
@@ -1,8 +1,10 @@
 import Repository from '@/utilities/Repository.ts';
 
 const promptUserToReport = (givenError: Error) => {
+  const defaultMessage = 'Unexpected Error';
+
   const formattedErrorDetails = [
-    'Unexpected Error:',
+    `${defaultMessage}:`,
     '"""',
     givenError.message,
     '"""',

--- a/src/features/reporting.ts
+++ b/src/features/reporting.ts
@@ -14,12 +14,7 @@ const formatted = (
 };
 
 const promptUserToReport = (givenError: Error) => {
-  const unexpectedError = Contextualized.assume(
-    new Error('Unexpected Error', {
-      cause: givenError,
-    }),
-  );
-
+  const unexpectedError = Contextualized.cast(givenError, 'Unexpected Error');
   const formattedErrorDetails = formatted(unexpectedError);
 
   const userDidPermitDraftingNewIssue = window.confirm([

--- a/src/features/reporting.ts
+++ b/src/features/reporting.ts
@@ -1,10 +1,9 @@
+import Contextualized from '@/library/modifiersByType/error/Contextualized';
+
 import Repository from '@/utilities/Repository.ts';
 
 const formatted = (
-  givenError: {
-    message: string;
-    cause: Error;
-  },
+  givenError: Contextualized<Error, Error>,
 ): string => {
   return [
     `${givenError.message}:`,
@@ -15,10 +14,11 @@ const formatted = (
 };
 
 const promptUserToReport = (givenError: Error) => {
-  const unexpectedError = {
-    message: 'Unexpected Error',
-    cause  : givenError,
-  };
+  const unexpectedError = Contextualized.assume(
+    new Error('Unexpected Error', {
+      cause: givenError,
+    }),
+  );
 
   const formattedErrorDetails = formatted(unexpectedError);
 

--- a/src/features/reporting.ts
+++ b/src/features/reporting.ts
@@ -3,12 +3,14 @@ import Repository from '@/utilities/Repository.ts';
 const promptUserToReport = (givenError: Error) => {
   const defaultMessage = 'Unexpected Error';
 
-  const formattedErrorDetails = [
-    `${defaultMessage}:`,
-    '"""',
-    givenError.message,
-    '"""',
-  ].join('\n');
+  const formattedErrorDetails = ((): string => {
+    return [
+      `${defaultMessage}:`,
+      '"""',
+      givenError.message,
+      '"""',
+    ].join('\n');
+  })();
 
   const userDidPermitDraftingNewIssue = window.confirm([
     formattedErrorDetails,

--- a/src/features/reporting.ts
+++ b/src/features/reporting.ts
@@ -3,14 +3,16 @@ import Repository from '@/utilities/Repository.ts';
 const promptUserToReport = (givenError: Error) => {
   const defaultMessage = 'Unexpected Error';
 
-  const formattedErrorDetails = ((): string => {
+  const formattedErrorDetails = ((
+    givenError: Error,
+  ): string => {
     return [
       `${defaultMessage}:`,
       '"""',
       givenError.message,
       '"""',
     ].join('\n');
-  })();
+  })(givenError);
 
   const userDidPermitDraftingNewIssue = window.confirm([
     formattedErrorDetails,

--- a/src/features/reporting.ts
+++ b/src/features/reporting.ts
@@ -5,14 +5,15 @@ const promptUserToReport = (givenError: Error) => {
 
   const formattedErrorDetails = ((
     givenError: Error,
+    givenMessage: string,
   ): string => {
     return [
-      `${defaultMessage}:`,
+      `${givenMessage}:`,
       '"""',
       givenError.message,
       '"""',
     ].join('\n');
-  })(givenError);
+  })(givenError, defaultMessage);
 
   const userDidPermitDraftingNewIssue = window.confirm([
     formattedErrorDetails,

--- a/src/features/reporting.ts
+++ b/src/features/reporting.ts
@@ -2,12 +2,12 @@ import Repository from '@/utilities/Repository.ts';
 
 const formatted = (
   givenError: {
+    message: string;
     cause: Error;
   },
-  givenMessage: string,
 ): string => {
   return [
-    `${givenMessage}:`,
+    `${givenError.message}:`,
     '"""',
     givenError.cause.message,
     '"""',
@@ -20,7 +20,7 @@ const promptUserToReport = (givenError: Error) => {
     cause  : givenError,
   };
 
-  const formattedErrorDetails = formatted(unexpectedError, unexpectedError.message);
+  const formattedErrorDetails = formatted(unexpectedError);
 
   const userDidPermitDraftingNewIssue = window.confirm([
     formattedErrorDetails,

--- a/src/features/reporting.ts
+++ b/src/features/reporting.ts
@@ -1,20 +1,19 @@
 import Repository from '@/utilities/Repository.ts';
 
+const formatted = (
+  givenError: Error,
+  givenMessage: string,
+): string => {
+  return [
+    `${givenMessage}:`,
+    '"""',
+    givenError.message,
+    '"""',
+  ].join('\n');
+};
+
 const promptUserToReport = (givenError: Error) => {
   const defaultMessage = 'Unexpected Error';
-
-  const formatted = (
-    givenError: Error,
-    givenMessage: string,
-  ): string => {
-    return [
-      `${givenMessage}:`,
-      '"""',
-      givenError.message,
-      '"""',
-    ].join('\n');
-  };
-
   const formattedErrorDetails = formatted(givenError, defaultMessage);
 
   const userDidPermitDraftingNewIssue = window.confirm([

--- a/src/features/reporting.ts
+++ b/src/features/reporting.ts
@@ -14,7 +14,8 @@ const formatted = (
 
 const promptUserToReport = (givenError: Error) => {
   const unexpectedError_message = 'Unexpected Error';
-  const formattedErrorDetails = formatted(givenError, unexpectedError_message);
+  const unexpectedError_cause = givenError;
+  const formattedErrorDetails = formatted(unexpectedError_cause, unexpectedError_message);
 
   const userDidPermitDraftingNewIssue = window.confirm([
     formattedErrorDetails,

--- a/src/features/reporting.ts
+++ b/src/features/reporting.ts
@@ -1,10 +1,10 @@
 import Repository from '@/utilities/Repository.ts';
 
-const promptUserToReport = (givenErrorMessage: string) => {
+const promptUserToReport = (givenError: Error) => {
   const formattedErrorDetails = [
     'Unexpected Error:',
     '"""',
-    givenErrorMessage,
+    givenError.message,
     '"""',
   ].join('\n');
 

--- a/src/features/reporting.ts
+++ b/src/features/reporting.ts
@@ -13,9 +13,12 @@ const formatted = (
 };
 
 const promptUserToReport = (givenError: Error) => {
-  const unexpectedError_message = 'Unexpected Error';
-  const unexpectedError_cause = givenError;
-  const formattedErrorDetails = formatted(unexpectedError_cause, unexpectedError_message);
+  const unexpectedError = {
+    message: 'Unexpected Error',
+    cause  : givenError,
+  };
+
+  const formattedErrorDetails = formatted(unexpectedError.cause, unexpectedError.message);
 
   const userDidPermitDraftingNewIssue = window.confirm([
     formattedErrorDetails,

--- a/src/features/reporting.ts
+++ b/src/features/reporting.ts
@@ -3,7 +3,7 @@ import Repository from '@/utilities/Repository.ts';
 const promptUserToReport = (givenError: Error) => {
   const defaultMessage = 'Unexpected Error';
 
-  const formattedErrorDetails = ((
+  const formatted = (
     givenError: Error,
     givenMessage: string,
   ): string => {
@@ -13,7 +13,9 @@ const promptUserToReport = (givenError: Error) => {
       givenError.message,
       '"""',
     ].join('\n');
-  })(givenError, defaultMessage);
+  };
+
+  const formattedErrorDetails = formatted(givenError, defaultMessage);
 
   const userDidPermitDraftingNewIssue = window.confirm([
     formattedErrorDetails,

--- a/src/features/reporting.ts
+++ b/src/features/reporting.ts
@@ -1,13 +1,15 @@
 import Repository from '@/utilities/Repository.ts';
 
 const formatted = (
-  givenError: Error,
+  givenError: {
+    cause: Error;
+  },
   givenMessage: string,
 ): string => {
   return [
     `${givenMessage}:`,
     '"""',
-    givenError.message,
+    givenError.cause.message,
     '"""',
   ].join('\n');
 };
@@ -18,7 +20,7 @@ const promptUserToReport = (givenError: Error) => {
     cause  : givenError,
   };
 
-  const formattedErrorDetails = formatted(unexpectedError.cause, unexpectedError.message);
+  const formattedErrorDetails = formatted(unexpectedError, unexpectedError.message);
 
   const userDidPermitDraftingNewIssue = window.confirm([
     formattedErrorDetails,

--- a/src/library/modifiersByType/error/Contextualized.ts
+++ b/src/library/modifiersByType/error/Contextualized.ts
@@ -37,10 +37,30 @@ const assertContextualized = <
   return Attempt.abandon('Expected error to have a cause');
 };
 
+const asContextualized = <
+  SomeError extends Error,
+  SomeCause extends Error,
+>(
+  givenError: SomeError,
+  givenFallbackMessage: string,
+  GivenCause: Instantiable<SomeCause> | ErrorConstructor = Error,
+): Contextualized<SomeError, SomeCause> | Contextualized<Error, SomeError> => {
+  if (
+    isContextualized<SomeError, SomeCause>(givenError, GivenCause)
+  ) return givenError;
+
+  const contextualizedError = new Error(givenFallbackMessage, {
+    cause: givenError,
+  });
+
+  return assertContextualized<Error, SomeError>(contextualizedError, Error);
+};
+
 /** Utilities for identifying and casting `Error` instances as "contextualized" */
 const Contextualized = {
   describes: isContextualized,
   assume   : assertContextualized,
+  cast     : asContextualized,
 };
 
 export {

--- a/src/library/modifiersByType/error/Contextualized.ts
+++ b/src/library/modifiersByType/error/Contextualized.ts
@@ -1,0 +1,48 @@
+import Attempt from '@/library/Attempt';
+
+type Contextualized<
+  SomeError extends Error,
+  SomeCause extends Error,
+> =
+  & SomeError
+  & {
+    cause: SomeCause;
+  };
+
+interface Instantiable<Any> {
+  [Symbol.hasInstance]: (value: unknown) => value is Any;
+}
+
+const isContextualized = <
+  SomeError extends Error,
+  SomeCause extends Error,
+>(
+  givenError: SomeError,
+  GivenCause: Instantiable<SomeCause> | ErrorConstructor = Error,
+): givenError is Contextualized<SomeError, SomeCause> => {
+  return givenError.cause instanceof GivenCause;
+};
+
+const assertContextualized = <
+  SomeError extends Error,
+  SomeCause extends Error,
+>(
+  givenError: SomeError,
+  GivenCause: Instantiable<SomeCause> | ErrorConstructor = Error,
+): Contextualized<SomeError, SomeCause> => {
+  if (
+    isContextualized<SomeError, SomeCause>(givenError, GivenCause)
+  ) return givenError;
+
+  return Attempt.abandon('Expected error to have a cause');
+};
+
+/** Utilities for identifying and casting `Error` instances as "contextualized" */
+const Contextualized = {
+  describes: isContextualized,
+  assume   : assertContextualized,
+};
+
+export {
+  Contextualized as default,
+};

--- a/src/main.ts
+++ b/src/main.ts
@@ -21,8 +21,8 @@ app.use(vuetify);
 app.mount('#app');
 
 window.onunhandledrejection = (someEvent) => {
-  const rejectionReason = String(someEvent.reason);
-  promptUserToReport(rejectionReason);
+  const rejectionReason = asError(someEvent.reason);
+  promptUserToReport(rejectionReason.message);
   someEvent.preventDefault();
 };
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -22,12 +22,12 @@ app.mount('#app');
 
 window.onunhandledrejection = (someEvent) => {
   const rejectionReason = asError(someEvent.reason);
-  promptUserToReport(rejectionReason.message);
+  promptUserToReport(rejectionReason);
   someEvent.preventDefault();
 };
 
 // In production version (post build/bundling), errors that originate from Vue components bypass the listeners on the current `Window` instance
 app.config.errorHandler = (whateverThatWasThrown) => {
   const someError = asError(whateverThatWasThrown);
-  promptUserToReport(someError.message);
+  promptUserToReport(someError);
 };


### PR DESCRIPTION
- before, the error dialog only displayed the top-level error message
- this isn't ideal since rethrown errors are usually wrapped by the reason they were rethrown, especially if they were perfectly actionable, but we neglected to embody them with custom UI