### PR TITLE
feature(text-to-image): makes `Server.SpecificationError` feel expected

### DIFF
--- a/src/features/TextToImage/components/TextToImageOutputAlert.vue
+++ b/src/features/TextToImage/components/TextToImageOutputAlert.vue
@@ -1,9 +1,6 @@
 <script setup lang="ts">
-import {
-  computed,
-} from 'vue';
-
 import TextToImageServerConnectionAlert from './TextToImageServerConnectionAlert.vue';
+import TextToImageServerSpecificationAlert from './TextToImageServerSpecificationAlert.vue';
 
 import * as TextToImage from '@/features/TextToImage';
 
@@ -11,32 +8,18 @@ type OutputError =
   | TextToImage.Server.ConnectionError
   | TextToImage.Server.SpecificationError;
 
-const given = defineProps<{
+defineProps<{
   error: OutputError;
 }>();
-
-const narrowedError = computed(() => {
-  if (
-    given.error instanceof TextToImage.Server.SpecificationError
-  ) {
-    const userFacingMessage = [
-      'No text-to-image server was specified!',
-      'Either:',
-      `a) supply it's corresponding environment variable named \`${given.error.environmentKey}\` and rebuild`,
-      `b) specify it within ${given.error.file.toString()}`,
-      'OR',
-      `c) specify it within the response from ${given.error.endpoint.toString()}`,
-    ].join('\n');
-
-    return given.error.throwAnyway(userFacingMessage);
-  }
-
-  return given.error;
-});
 </script>
 
 <template>
+  <TextToImageServerSpecificationAlert
+    v-if="(error instanceof TextToImage.Server.SpecificationError)"
+    :error="error"
+  />
   <TextToImageServerConnectionAlert
-    :error="narrowedError"
+    v-else
+    :error="error"
   />
 </template>

--- a/src/features/TextToImage/components/TextToImageOutputAlert.vue
+++ b/src/features/TextToImage/components/TextToImageOutputAlert.vue
@@ -1,0 +1,18 @@
+<script setup lang="ts">
+import TextToImageServerConnectionAlert from './TextToImageServerConnectionAlert.vue';
+
+import * as TextToImage from '@/features/TextToImage';
+
+type OutputError =
+  | TextToImage.Server.ConnectionError;
+
+defineProps<{
+  error: OutputError;
+}>();
+</script>
+
+<template>
+  <TextToImageServerConnectionAlert
+    :error="error"
+  />
+</template>

--- a/src/features/TextToImage/components/TextToImageOutputAlert.vue
+++ b/src/features/TextToImage/components/TextToImageOutputAlert.vue
@@ -1,18 +1,42 @@
 <script setup lang="ts">
+import {
+  computed,
+} from 'vue';
+
 import TextToImageServerConnectionAlert from './TextToImageServerConnectionAlert.vue';
 
 import * as TextToImage from '@/features/TextToImage';
 
 type OutputError =
-  | TextToImage.Server.ConnectionError;
+  | TextToImage.Server.ConnectionError
+  | TextToImage.Server.SpecificationError;
 
-defineProps<{
+const given = defineProps<{
   error: OutputError;
 }>();
+
+const narrowedError = computed(() => {
+  if (
+    given.error instanceof TextToImage.Server.SpecificationError
+  ) {
+    const userFacingMessage = [
+      'No text-to-image server was specified!',
+      'Either:',
+      `a) supply it's corresponding environment variable named \`${given.error.environmentKey}\` and rebuild`,
+      `b) specify it within ${given.error.file.toString()}`,
+      'OR',
+      `c) specify it within the response from ${given.error.endpoint.toString()}`,
+    ].join('\n');
+
+    return given.error.throwAnyway(userFacingMessage);
+  }
+
+  return given.error;
+});
 </script>
 
 <template>
   <TextToImageServerConnectionAlert
-    :error="error"
+    :error="narrowedError"
   />
 </template>

--- a/src/features/TextToImage/components/TextToImageServerSpecificationAlert.vue
+++ b/src/features/TextToImage/components/TextToImageServerSpecificationAlert.vue
@@ -1,4 +1,8 @@
 <script setup lang="ts">
+import {
+  VAlert,
+} from 'vuetify/components/VAlert';
+
 import * as TextToImage from '@/features/TextToImage';
 
 defineProps<{
@@ -7,14 +11,14 @@ defineProps<{
 </script>
 
 <template>
-  {{
-    error.throwAnyway([
-      'No text-to-image server was specified!\n',
-      'Either:\n',
-      `a) supply it's corresponding environment variable named \`${error.environmentKey}\` and rebuild\n`,
-      `b) specify it within ${error.file.toString()}\n`,
-      'OR\n',
-      `c) specify it within the response from ${error.endpoint.toString()}\n`,
-    ].join(''))
-  }}
+  <VAlert
+    type="error"
+    title="No text-to-image server was specified!"
+  >
+    Either:<br>
+    a) supply it's corresponding environment variable named `{{ error.environmentKey }}` and rebuild<br>
+    b) specify it within {{ error.file.toString() }}<br>
+    OR<br>
+    c) specify it within the response from {{ error.endpoint.toString() }}<br>
+  </VAlert>
 </template>

--- a/src/features/TextToImage/components/TextToImageServerSpecificationAlert.vue
+++ b/src/features/TextToImage/components/TextToImageServerSpecificationAlert.vue
@@ -1,0 +1,20 @@
+<script setup lang="ts">
+import * as TextToImage from '@/features/TextToImage';
+
+const given = defineProps<{
+  error: TextToImage.Server.SpecificationError;
+}>();
+
+(() => {
+  const userFacingMessage = [
+    'No text-to-image server was specified!',
+    'Either:',
+    `a) supply it's corresponding environment variable named \`${given.error.environmentKey}\` and rebuild`,
+    `b) specify it within ${given.error.file.toString()}`,
+    'OR',
+    `c) specify it within the response from ${given.error.endpoint.toString()}`,
+  ].join('\n');
+
+  return given.error.throwAnyway(userFacingMessage);
+})();
+</script>

--- a/src/features/TextToImage/components/TextToImageServerSpecificationAlert.vue
+++ b/src/features/TextToImage/components/TextToImageServerSpecificationAlert.vue
@@ -9,12 +9,12 @@ defineProps<{
 <template>
   {{
     error.throwAnyway([
-      'No text-to-image server was specified!',
-      'Either:',
-      `a) supply it's corresponding environment variable named \`${error.environmentKey}\` and rebuild`,
-      `b) specify it within ${error.file.toString()}`,
-      'OR',
-      `c) specify it within the response from ${error.endpoint.toString()}`,
-    ].join('\n'))
+      'No text-to-image server was specified!\n',
+      'Either:\n',
+      `a) supply it's corresponding environment variable named \`${error.environmentKey}\` and rebuild\n`,
+      `b) specify it within ${error.file.toString()}\n`,
+      'OR\n',
+      `c) specify it within the response from ${error.endpoint.toString()}\n`,
+    ].join(''))
   }}
 </template>

--- a/src/features/TextToImage/components/TextToImageServerSpecificationAlert.vue
+++ b/src/features/TextToImage/components/TextToImageServerSpecificationAlert.vue
@@ -6,15 +6,13 @@ const given = defineProps<{
 }>();
 
 (() => {
-  const userFacingMessage = [
+  return given.error.throwAnyway([
     'No text-to-image server was specified!',
     'Either:',
     `a) supply it's corresponding environment variable named \`${given.error.environmentKey}\` and rebuild`,
     `b) specify it within ${given.error.file.toString()}`,
     'OR',
     `c) specify it within the response from ${given.error.endpoint.toString()}`,
-  ].join('\n');
-
-  return given.error.throwAnyway(userFacingMessage);
+  ].join('\n'));
 })();
 </script>

--- a/src/features/TextToImage/components/TextToImageServerSpecificationAlert.vue
+++ b/src/features/TextToImage/components/TextToImageServerSpecificationAlert.vue
@@ -1,18 +1,20 @@
 <script setup lang="ts">
 import * as TextToImage from '@/features/TextToImage';
 
-const given = defineProps<{
+defineProps<{
   error: TextToImage.Server.SpecificationError;
 }>();
-
-(() => {
-  return given.error.throwAnyway([
-    'No text-to-image server was specified!',
-    'Either:',
-    `a) supply it's corresponding environment variable named \`${given.error.environmentKey}\` and rebuild`,
-    `b) specify it within ${given.error.file.toString()}`,
-    'OR',
-    `c) specify it within the response from ${given.error.endpoint.toString()}`,
-  ].join('\n'));
-})();
 </script>
+
+<template>
+  {{
+    error.throwAnyway([
+      'No text-to-image server was specified!',
+      'Either:',
+      `a) supply it's corresponding environment variable named \`${error.environmentKey}\` and rebuild`,
+      `b) specify it within ${error.file.toString()}`,
+      'OR',
+      `c) specify it within the response from ${error.endpoint.toString()}`,
+    ].join('\n'))
+  }}
+</template>

--- a/src/features/TextToImage/models/SDXL/client/index.ts
+++ b/src/features/TextToImage/models/SDXL/client/index.ts
@@ -29,7 +29,23 @@ const initializeShimmedStabilityAIClient = (): Promise<
 
   if (
     outcomeOfRetrievingCurrentServer.isFailure
-  ) return outcomeOfRetrievingCurrentServer;
+  ) {
+    const {
+      causeOfFailure,
+    } = outcomeOfRetrievingCurrentServer;
+
+    const userFacingMessage = [
+      'No text-to-image server was specified!',
+      'Either:',
+      `a) supply it's corresponding environment variable named \`${causeOfFailure.environmentKey}\` and rebuild`,
+      `b) specify it within ${causeOfFailure.file.toString()}`,
+      'OR',
+      `c) specify it within the response from ${causeOfFailure.endpoint.toString()}`,
+    ].join('\n');
+
+    causeOfFailure.message = userFacingMessage;
+    return outcomeOfRetrievingCurrentServer;
+  }
 
   const textToImageServer = outcomeOfRetrievingCurrentServer.unwrapped;
 

--- a/src/features/TextToImage/models/SDXL/client/index.ts
+++ b/src/features/TextToImage/models/SDXL/client/index.ts
@@ -58,6 +58,7 @@ const initializeShimmedStabilityAIClient = (): Promise<
 
 type OutcomeOfGeneratingTextToImageOutput = Attempt.Outcome<Output,
   | Server.ConnectionError
+  | Server.SpecificationError
 >;
 
 const generateOutputFrom = async (
@@ -76,7 +77,7 @@ const generateOutputFrom = async (
 
   if (
     outcomeOfInitializingClient.isFailure
-  ) return outcomeOfInitializingClient.causeOfFailure.throwAnyway('Neglected to handle server specification error');
+  ) return outcomeOfInitializingClient;
 
   const shimmedStabilityAIClient = outcomeOfInitializingClient.unwrapped;
 

--- a/src/features/TextToImage/models/SDXL/client/index.ts
+++ b/src/features/TextToImage/models/SDXL/client/index.ts
@@ -72,7 +72,8 @@ const generateOutputFrom = async (
     >;
   },
 ): Promise<OutcomeOfGeneratingTextToImageOutput> => Attempt.thatEventually(async (ends) => {
-  const shimmedStabilityAIClient = (await initializeShimmedStabilityAIClient()).forciblyUnwrap();
+  const outcomeOfInitializingClient = await initializeShimmedStabilityAIClient();
+  const shimmedStabilityAIClient = outcomeOfInitializingClient.forciblyUnwrap();
 
   const promisedTextToImageResponse = shimmedStabilityAIClient.version1.image.forciblyGenerateFromText({
     engineId              : 'stable-diffusion-xl-1024-v1-0',

--- a/src/features/TextToImage/models/SDXL/client/index.ts
+++ b/src/features/TextToImage/models/SDXL/client/index.ts
@@ -29,23 +29,7 @@ const initializeShimmedStabilityAIClient = (): Promise<
 
   if (
     outcomeOfRetrievingCurrentServer.isFailure
-  ) {
-    const {
-      causeOfFailure,
-    } = outcomeOfRetrievingCurrentServer;
-
-    const userFacingMessage = [
-      'No text-to-image server was specified!',
-      'Either:',
-      `a) supply it's corresponding environment variable named \`${causeOfFailure.environmentKey}\` and rebuild`,
-      `b) specify it within ${causeOfFailure.file.toString()}`,
-      'OR',
-      `c) specify it within the response from ${causeOfFailure.endpoint.toString()}`,
-    ].join('\n');
-
-    causeOfFailure.message = userFacingMessage;
-    return outcomeOfRetrievingCurrentServer;
-  }
+  ) return outcomeOfRetrievingCurrentServer;
 
   const textToImageServer = outcomeOfRetrievingCurrentServer.unwrapped;
 

--- a/src/features/TextToImage/models/SDXL/client/index.ts
+++ b/src/features/TextToImage/models/SDXL/client/index.ts
@@ -73,7 +73,12 @@ const generateOutputFrom = async (
   },
 ): Promise<OutcomeOfGeneratingTextToImageOutput> => Attempt.thatEventually(async (ends) => {
   const outcomeOfInitializingClient = await initializeShimmedStabilityAIClient();
-  const shimmedStabilityAIClient = outcomeOfInitializingClient.forciblyUnwrap();
+
+  if (
+    outcomeOfInitializingClient.isFailure
+  ) return outcomeOfInitializingClient.causeOfFailure.throwAnyway('Neglected to handle server specification error');
+
+  const shimmedStabilityAIClient = outcomeOfInitializingClient.unwrapped;
 
   const promisedTextToImageResponse = shimmedStabilityAIClient.version1.image.forciblyGenerateFromText({
     engineId              : 'stable-diffusion-xl-1024-v1-0',

--- a/src/features/TextToImage/webAPI/Server/ServerSpecificationError.ts
+++ b/src/features/TextToImage/webAPI/Server/ServerSpecificationError.ts
@@ -10,16 +10,7 @@ class TextToImage_Server_SpecificationError extends Attempt.ActionableError<'Tex
     public readonly file: URLPath,
     public readonly endpoint: URLPath,
   ) {
-    const userFacingMessage = [
-      'No text-to-image server was specified!',
-      'Either:',
-      `a) supply it's corresponding environment variable named \`${environmentKey}\` and rebuild`,
-      `b) specify it within ${file.toString()}`,
-      'OR',
-      `c) specify it within the response from ${endpoint.toString()}`,
-    ].join('\n');
-
-    super(userFacingMessage);
+    super('Failed to determine text-to-image server');
     this.name = 'TextToImage_Server_SpecificationError';
   }
 }

--- a/src/features/TextToImage/webAPI/Server/ServerSpecificationError.ts
+++ b/src/features/TextToImage/webAPI/Server/ServerSpecificationError.ts
@@ -6,19 +6,17 @@ import type {
 
 class TextToImage_Server_SpecificationError extends Attempt.ActionableError<'TextToImage_Server_SpecificationError'> {
   public constructor(
-    given: {
-      environmentKey: string;
-      file: URLPath;
-      endpoint: URLPath;
-    },
+    public readonly environmentKey: string,
+    public readonly file: URLPath,
+    public readonly endpoint: URLPath,
   ) {
     const userFacingMessage = [
       'No text-to-image server was specified!',
       'Either:',
-      `a) supply it's corresponding environment variable named \`${given.environmentKey}\` and rebuild`,
-      `b) specify it within ${given.file.toString()}`,
+      `a) supply it's corresponding environment variable named \`${environmentKey}\` and rebuild`,
+      `b) specify it within ${file.toString()}`,
       'OR',
-      `c) specify it within the response from ${given.endpoint.toString()}`,
+      `c) specify it within the response from ${endpoint.toString()}`,
     ].join('\n');
 
     super(userFacingMessage);

--- a/src/features/TextToImage/webAPI/Server/ServerSpecificationError.ts
+++ b/src/features/TextToImage/webAPI/Server/ServerSpecificationError.ts
@@ -12,7 +12,7 @@ class TextToImage_Server_SpecificationError extends Attempt.ActionableError<'Tex
       endpoint: URLPath;
     },
   ) {
-    const serverNotSpecifiedErrorMessage = [
+    const userFacingMessage = [
       'No text-to-image server was specified!',
       'Either:',
       `a) supply it's corresponding environment variable named \`${given.environmentKey}\` and rebuild`,
@@ -21,7 +21,7 @@ class TextToImage_Server_SpecificationError extends Attempt.ActionableError<'Tex
       `c) specify it within the response from ${given.endpoint.toString()}`,
     ].join('\n');
 
-    super(serverNotSpecifiedErrorMessage);
+    super(userFacingMessage);
     this.name = 'TextToImage_Server_SpecificationError';
   }
 }

--- a/src/features/TextToImage/webAPI/Server/index.ts
+++ b/src/features/TextToImage/webAPI/Server/index.ts
@@ -45,11 +45,11 @@ const retrieveCurrentTextToImageServer = (): Promise<
     dynamicConfig.server !== null
   ) return ends.inSuccessWith(dynamicConfig.server);
 
-  const newSpecificationError = new TextToImage_Server_SpecificationError({
-    environmentKey: environmentKeyForOriginOfTextToImageServer,
-    file          : StaticConfig.file,
-    endpoint      : DynamicConfig.endpoint,
-  });
+  const newSpecificationError = new TextToImage_Server_SpecificationError(
+    environmentKeyForOriginOfTextToImageServer,
+    StaticConfig.file,
+    DynamicConfig.endpoint,
+  );
 
   return ends.inFailureDueTo(newSpecificationError);
 });

--- a/src/pages/TextToImagePage.vue
+++ b/src/pages/TextToImagePage.vue
@@ -30,8 +30,8 @@ import DiscreteSlider from '@/components/DiscreteSlider.vue';
 import NavigationPanel from '@/components/NavigationPanel.vue';
 
 import TextToImageInputSection from '@/features/TextToImage/components/TextToImageInputSection.vue';
+import TextToImageOutputAlert from '@/features/TextToImage/components/TextToImageOutputAlert.vue';
 import TextToImageOutputImg from '@/features/TextToImage/components/TextToImageOutputImg.vue';
-import TextToImageServerConnectionAlert from '@/features/TextToImage/components/TextToImageServerConnectionAlert.vue';
 import * as TextToImage from '@/features/TextToImage/index.ts';
 
 const currentPrompt: Ref<TextToImage.Input['text'] | null> = ref(null);
@@ -152,7 +152,7 @@ const imageGeneration = useStatefulAttemptThatEventually(async (ends) => {
         v-else-if="imageGeneration.outcome.isSuccess"
         :model-value="imageGeneration.outcome.unwrapped"
       />
-      <TextToImageServerConnectionAlert
+      <TextToImageOutputAlert
         v-else
         :error="imageGeneration.outcome.causeOfFailure"
       />

--- a/src/pages/TextToImagePage.vue
+++ b/src/pages/TextToImagePage.vue
@@ -65,7 +65,22 @@ const imageGeneration = useStatefulAttemptThatEventually(async (ends) => {
   ) {
     if (
       outcomeOfGeneratingOutput.causeOfFailure instanceof TextToImage.Server.SpecificationError
-    ) return outcomeOfGeneratingOutput.causeOfFailure.throwAnyway('Neglected to handle server specification error');
+    ) {
+      const {
+        causeOfFailure,
+      } = outcomeOfGeneratingOutput;
+
+      const userFacingMessage = [
+        'No text-to-image server was specified!',
+        'Either:',
+        `a) supply it's corresponding environment variable named \`${causeOfFailure.environmentKey}\` and rebuild`,
+        `b) specify it within ${causeOfFailure.file.toString()}`,
+        'OR',
+        `c) specify it within the response from ${causeOfFailure.endpoint.toString()}`,
+      ].join('\n');
+
+      return causeOfFailure.throwAnyway(userFacingMessage);
+    }
 
     return ends.inFailureDueTo(outcomeOfGeneratingOutput.causeOfFailure);
   }

--- a/src/pages/TextToImagePage.vue
+++ b/src/pages/TextToImagePage.vue
@@ -62,7 +62,13 @@ const imageGeneration = useStatefulAttemptThatEventually(async (ends) => {
 
   if (
     outcomeOfGeneratingOutput.isFailure
-  ) return outcomeOfGeneratingOutput;
+  ) {
+    if (
+      outcomeOfGeneratingOutput.causeOfFailure instanceof TextToImage.Server.SpecificationError
+    ) return outcomeOfGeneratingOutput.causeOfFailure.throwAnyway('Neglected to handle server specification error');
+
+    return ends.inFailureDueTo(outcomeOfGeneratingOutput.causeOfFailure);
+  }
 
   const generatedOutput = outcomeOfGeneratingOutput.unwrapped;
   return ends.inSuccessWith(generatedOutput.image);

--- a/src/pages/TextToImagePage.vue
+++ b/src/pages/TextToImagePage.vue
@@ -62,28 +62,7 @@ const imageGeneration = useStatefulAttemptThatEventually(async (ends) => {
 
   if (
     outcomeOfGeneratingOutput.isFailure
-  ) {
-    if (
-      outcomeOfGeneratingOutput.causeOfFailure instanceof TextToImage.Server.SpecificationError
-    ) {
-      const {
-        causeOfFailure,
-      } = outcomeOfGeneratingOutput;
-
-      const userFacingMessage = [
-        'No text-to-image server was specified!',
-        'Either:',
-        `a) supply it's corresponding environment variable named \`${causeOfFailure.environmentKey}\` and rebuild`,
-        `b) specify it within ${causeOfFailure.file.toString()}`,
-        'OR',
-        `c) specify it within the response from ${causeOfFailure.endpoint.toString()}`,
-      ].join('\n');
-
-      return causeOfFailure.throwAnyway(userFacingMessage);
-    }
-
-    return ends.inFailureDueTo(outcomeOfGeneratingOutput.causeOfFailure);
-  }
+  ) return outcomeOfGeneratingOutput;
 
   const generatedOutput = outcomeOfGeneratingOutput.unwrapped;
   return ends.inSuccessWith(generatedOutput.image);


### PR DESCRIPTION
- Before, this error would be thrown and then caught by the global error handler, which prompts the user to file an issue
- But this error is within the user's power to address, so there's no need to file an issue
- To address this, a new alert was added to embody this error within the UI itself