### PR TITLE
fix(library/Attempt): ensures built-in non-actionable errors can be identified post build

### DIFF
--- a/src/library/Attempt/error/HonoraryNonActionableError.ts
+++ b/src/library/Attempt/error/HonoraryNonActionableError.ts
@@ -46,6 +46,19 @@ type HonoraryNonActionableError =
   | EvalError // Something illegal was done with `eval` or `Function` constructor.
   | SyntaxError; // The JS engine couldn't even parse the code.
 
+const isHonoraryNonActionableError = (
+  givenError: Error,
+): givenError is HonoraryNonActionableError => {
+  return (
+    (givenError instanceof ReferenceError)
+    || (givenError instanceof TypeError)
+    || (givenError instanceof RangeError)
+    || (givenError instanceof URIError)
+    || (givenError instanceof EvalError)
+    || (givenError instanceof SyntaxError)
+  );
+};
+
 const HonoraryNonActionableError = {
   [Symbol.hasInstance]: (givenSubject: unknown): givenSubject is HonoraryNonActionableError => {
     if (
@@ -53,15 +66,7 @@ const HonoraryNonActionableError = {
     ) return false;
 
     const givenError = givenSubject;
-
-    return (
-      (givenError instanceof ReferenceError)
-      || (givenError instanceof TypeError)
-      || (givenError instanceof RangeError)
-      || (givenError instanceof URIError)
-      || (givenError instanceof EvalError)
-      || (givenError instanceof SyntaxError)
-    );
+    return isHonoraryNonActionableError(givenError);
   },
 };
 

--- a/src/library/Attempt/error/HonoraryNonActionableError.ts
+++ b/src/library/Attempt/error/HonoraryNonActionableError.ts
@@ -2,10 +2,6 @@ import type {
   Branded,
 } from '@/library/typeUtilities/Branded';
 
-import {
-  isError,
-} from '@/library/utilitiesByType/error';
-
 // These augmentations allow TypeScript to distinguish these error types from `Error` at the annotation level.
 declare global {
   interface ReferenceError extends Branded<'ReferenceError'> {
@@ -61,14 +57,6 @@ const isHonoraryNonActionableError = (
 
 const HonoraryNonActionableError = {
   describes: isHonoraryNonActionableError,
-  [Symbol.hasInstance](givenSubject: unknown): givenSubject is HonoraryNonActionableError {
-    if (
-      !isError(givenSubject)
-    ) return false;
-
-    const givenError = givenSubject;
-    return this.describes(givenError);
-  },
 };
 
 export {

--- a/src/library/Attempt/error/HonoraryNonActionableError.ts
+++ b/src/library/Attempt/error/HonoraryNonActionableError.ts
@@ -60,13 +60,14 @@ const isHonoraryNonActionableError = (
 };
 
 const HonoraryNonActionableError = {
-  [Symbol.hasInstance]: (givenSubject: unknown): givenSubject is HonoraryNonActionableError => {
+  describes: isHonoraryNonActionableError,
+  [Symbol.hasInstance](givenSubject: unknown): givenSubject is HonoraryNonActionableError {
     if (
       !isError(givenSubject)
     ) return false;
 
     const givenError = givenSubject;
-    return isHonoraryNonActionableError(givenError);
+    return this.describes(givenError);
   },
 };
 

--- a/src/library/Attempt/error/modifier/PotentiallyActionable.ts
+++ b/src/library/Attempt/error/modifier/PotentiallyActionable.ts
@@ -15,7 +15,7 @@ const assertPotentiallyActionable = <
   ) return givenError.throw();
 
   if (
-    givenError instanceof HonoraryNonActionableError
+    HonoraryNonActionableError.describes(givenError)
   ) throw givenError; // eslint-disable-line no-restricted-syntax
 
   return givenError as PotentiallyActionable<SomeError>;


### PR DESCRIPTION
- [Symbol.hasInstance] doesn't make it past tree-shaking upon bundling since it's only reached through instanceof
- can't use class because then the namespace won't be merged as desired