### PR TITLE
refactor(library/Attempt): ensures consistent use of raw `try`-`catch`

### DIFF
--- a/src/features/TextToImage/models/SDXL/client/index.ts
+++ b/src/features/TextToImage/models/SDXL/client/index.ts
@@ -4,6 +4,10 @@ import type {
 
 import Attempt from '@/library/Attempt';
 
+import {
+  sanctionedAsync,
+} from '@/library/Attempt/utilities/sanctionedTryCatch';
+
 import ShimmedStabilityAIClient from '@/library/ShimmedStabilityAIClient/index.ts';
 
 import Base64CharacterEncodedByteSequence from '@/library/customTypes/Base64CharacterEncodedByteSequence.ts';
@@ -76,9 +80,8 @@ const generateOutputFrom = async (
     },
   });
 
-  const outcomeOfSettlingTextToImageResponse = await (async () => {
-    // eslint-disable-next-line no-restricted-syntax
-    try {
+  const outcomeOfSettlingTextToImageResponse = await sanctionedAsync({
+    async try() {
       const intermediateOutcome = await Attempt.toSettle(promisedTextToImageResponse);
 
       if (
@@ -86,8 +89,8 @@ const generateOutputFrom = async (
       ) return intermediateOutcome.causeOfFailure.throwAnyway('Unreachable since `Attempt.toSettle` still throws everything');
 
       return intermediateOutcome;
-    }
-    catch (whateverThatWasThrown) {
+    },
+    catch(whateverThatWasThrown) {
       const someError = asError(whateverThatWasThrown);
       const clientFailedToReachServer = someError.message.includes('Failed to fetch');
 
@@ -98,8 +101,8 @@ const generateOutputFrom = async (
       });
 
       return ends.inFailureDueTo(new Server.ConnectionError(shimmedStabilityAIClient.origin));
-    }
-  })();
+    },
+  });
 
   if (
     outcomeOfSettlingTextToImageResponse.isFailure

--- a/src/library/Attempt/adapter/asynchronous.ts
+++ b/src/library/Attempt/adapter/asynchronous.ts
@@ -8,23 +8,26 @@ import {
   outcomeOfFailedAttempt,
 } from '../utilities/outcomeOfFailedAttempt';
 
+import {
+  sanctionedAsync,
+} from '../utilities/sanctionedTryCatch';
+
 const attemptToEventually = async <
   SomeProduct,
   SomeActionableError extends ActionableError<string>,
 >(
   forciblyRetrieveProduct: () => Promise<SomeProduct>,
-): Promise<Outcome<SomeProduct, SomeActionableError>> => {
-  // eslint-disable-next-line no-restricted-syntax
-  try {
+): Promise<Outcome<SomeProduct, SomeActionableError>> => sanctionedAsync({
+  async try() {
     const retrievedProduct: SomeProduct = await forciblyRetrieveProduct();
     return Outcome.successThatYielded(retrievedProduct);
-  }
-  catch (whateverThatWasThrown) {
+  },
+  catch(whateverThatWasThrown) {
     return outcomeOfFailedAttempt<SomeProduct, SomeActionableError>({
       basedOn: whateverThatWasThrown,
     });
-  }
-};
+  },
+});
 
 const attemptToSettle = async <
   SomeProduct,

--- a/src/library/Attempt/adapter/synchronous.ts
+++ b/src/library/Attempt/adapter/synchronous.ts
@@ -8,23 +8,26 @@ import {
   outcomeOfFailedAttempt,
 } from '../utilities/outcomeOfFailedAttempt';
 
+import {
+  sanctioned,
+} from '../utilities/sanctionedTryCatch';
+
 const attemptTo = <
   SomeProduct,
   SomeActionableError extends ActionableError<string>,
 >(
   forciblyGetProduct: () => SomeProduct,
-): Outcome<SomeProduct, SomeActionableError> => {
-  // eslint-disable-next-line no-restricted-syntax
-  try {
+): Outcome<SomeProduct, SomeActionableError> => sanctioned({
+  try() {
     const gottenProduct = forciblyGetProduct();
     return Outcome.successThatYielded(gottenProduct);
-  }
-  catch (whateverThatWasThrown) {
+  },
+  catch(whateverThatWasThrown) {
     return outcomeOfFailedAttempt<SomeProduct, SomeActionableError>({
       basedOn: whateverThatWasThrown,
     });
-  }
-};
+  },
+});
 
 export {
   attemptTo,

--- a/src/library/Attempt/utilities/sanctionedTryCatch.ts
+++ b/src/library/Attempt/utilities/sanctionedTryCatch.ts
@@ -1,0 +1,46 @@
+const sanctioned = <
+  TryBlockOutput,
+  CatchBlockOutput,
+>(
+  {
+    try: getTryBlockOutput,
+    catch: getCatchBlockOutputFor,
+  }: {
+    try: () => TryBlockOutput;
+    catch: ($0: unknown) => CatchBlockOutput;
+  },
+): TryBlockOutput | CatchBlockOutput => {
+  // eslint-disable-next-line no-restricted-syntax -- this is the implementation designed to help avoid use of raw try/catch
+  try {
+    return getTryBlockOutput();
+  }
+  catch (whateverThatWasThrown) {
+    return getCatchBlockOutputFor(whateverThatWasThrown);
+  }
+};
+
+const sanctionedAsync = async <
+  TryBlockOutput,
+  CatchBlockOutput,
+>(
+  {
+    try: retrieveTryBlockOutput,
+    catch: getCatchBlockOutputFor,
+  }: {
+    try: () => Promise<TryBlockOutput>;
+    catch: ($0: unknown) => CatchBlockOutput;
+  },
+): Promise<TryBlockOutput | CatchBlockOutput> => {
+  // eslint-disable-next-line no-restricted-syntax -- this is the implementation designed to help avoid use of raw try/catch
+  try {
+    return await retrieveTryBlockOutput();
+  }
+  catch (whateverThatWasThrown) {
+    return getCatchBlockOutputFor(whateverThatWasThrown);
+  }
+};
+
+export {
+  sanctioned,
+  sanctionedAsync,
+};


### PR DESCRIPTION
- preps for improvements such as error casting