### PR TITLE
fix(library/Attempt): prevents nested `NonActionableError` instances

### DIFF
--- a/src/library/Attempt/error/NonActionableError.ts
+++ b/src/library/Attempt/error/NonActionableError.ts
@@ -53,6 +53,10 @@ class NonActionableError
       message: NonActionableError['message'];
     },
   ): never => {
+    if (
+      givenError instanceof this
+    ) return givenError.throw();
+
     return this.throw(given.message, {
       cause  : givenError,
       thrower: NonActionableError.rethrow,


### PR DESCRIPTION
- `NonActionableError` instances can have a `cause` specified
- in the context of rethrows, the `cause` will be another error that wasn't explicitly handled
- But it doesn't make sense for `cause` to be yet another `NonActionableError` instance since they can't actually be caught, only avoided