### PR TITLE
fix(library/Attempt): ensures rethrown errors are offered for interpretation

### DIFF
--- a/src/library/Attempt/adapter/asynchronous.ts
+++ b/src/library/Attempt/adapter/asynchronous.ts
@@ -43,6 +43,10 @@ const attemptToEventually = async <
   catch(someError) {
     const someActionableError = (() => {
       const potentiallyActionableError = ((givenError) => {
+        if (
+          !(givenError instanceof NonActionableError)
+        ) return givenError;
+
         return givenError;
       })(someError);
 

--- a/src/library/Attempt/adapter/asynchronous.ts
+++ b/src/library/Attempt/adapter/asynchronous.ts
@@ -42,7 +42,10 @@ const attemptToEventually = async <
   },
   catch(someError) {
     const someActionableError = (() => {
-      const potentiallyActionableError = someError;
+      const potentiallyActionableError = ((givenError) => {
+        return givenError;
+      })(someError);
+
       const interpretedError = given.interpretationOf(potentiallyActionableError);
 
       if (

--- a/src/library/Attempt/adapter/asynchronous.ts
+++ b/src/library/Attempt/adapter/asynchronous.ts
@@ -47,7 +47,7 @@ const attemptToEventually = async <
           !(givenError instanceof NonActionableError)
         ) return givenError;
 
-        return givenError;
+        return givenError.rethrownError ?? givenError;
       })(someError);
 
       const interpretedError = given.interpretationOf(potentiallyActionableError);

--- a/src/library/Attempt/adapter/asynchronous.ts
+++ b/src/library/Attempt/adapter/asynchronous.ts
@@ -42,13 +42,14 @@ const attemptToEventually = async <
   },
   catch(someError) {
     const someActionableError = (() => {
-      const interpretedError = given.interpretationOf(someError);
+      const potentiallyActionableError = someError;
+      const interpretedError = given.interpretationOf(potentiallyActionableError);
 
       if (
         interpretedError !== null
       ) return interpretedError;
 
-      return NonActionableError.rethrow(someError, {
+      return NonActionableError.rethrow(potentiallyActionableError, {
         message: 'Failed to end async attempt due to an unexpected error',
       });
     })();

--- a/src/library/Attempt/error/NonActionableError.ts
+++ b/src/library/Attempt/error/NonActionableError.ts
@@ -62,6 +62,14 @@ class NonActionableError
       thrower: NonActionableError.rethrow,
     });
   };
+
+  public get rethrownError(): Error | null {
+    if (
+      this.cause instanceof Error
+    ) return this.cause;
+
+    return null;
+  }
 }
 
 export {


### PR DESCRIPTION
- prevalent in for something like an API that can't be reimplemented with the "Outcome"/"Result" pattern (lest the contract be broken) but uses that pattern internally
- error that are "rethrown" are essentially "escorted" by the `NonActionableError` in which they're nested
- consider the following scenario:
   - function `baz` returns a failure `Attempt.Outcome` with an associated instance of `ActionableError`
   - the caller of `baz`, a function named `bar`, does not handle that error and `throw`s it anyway
   - the caller of `bar`, a function named `foo`, acknowledges that `bar` doesn't use safe propagation by wrapping it with an adapter (like `Attempt.toEventually`)
- In the above scenario, `foo` will catch an `ActionableError` that was effectively wrapped in a `NonActionableError` for escort out of `bar` after being returned by `baz`