### PR TITLE
fix(library/Attempt): avoids nesting built-in non-actionable errors

### DIFF
--- a/src/library/Attempt/adapter/asynchronous.ts
+++ b/src/library/Attempt/adapter/asynchronous.ts
@@ -5,8 +5,6 @@ import {
   type ActionableError,
 } from '../error';
 
-import HonoraryNonActionableError from '../error/HonoraryNonActionableError';
-
 import {
   assertPotentiallyActionable,
 } from '../error/modifier';
@@ -37,10 +35,6 @@ const attemptToEventually = async <
       catch(someError) {
         const potentiallyActionableError = assertPotentiallyActionable(someError);
 
-        if (
-          HonoraryNonActionableError.describes(potentiallyActionableError)
-        ) throw potentiallyActionableError; // eslint-disable-line no-restricted-syntax
-
         return NonActionableError.rethrow(potentiallyActionableError, {
           message: 'Expected error to be either interpreted or prevented altogether',
         });
@@ -62,10 +56,6 @@ const attemptToEventually = async <
       if (
         interpretedError !== null
       ) return interpretedError;
-
-      if (
-        HonoraryNonActionableError.describes(potentiallyActionableError)
-      ) throw potentiallyActionableError; // eslint-disable-line no-restricted-syntax
 
       return NonActionableError.rethrow(potentiallyActionableError, {
         message: 'Failed to end async attempt due to an unexpected error',

--- a/src/library/Attempt/adapter/asynchronous.ts
+++ b/src/library/Attempt/adapter/asynchronous.ts
@@ -56,6 +56,10 @@ const attemptToEventually = async <
         interpretedError !== null
       ) return interpretedError;
 
+      if (
+        HonoraryNonActionableError.describes(potentiallyActionableError)
+      ) throw potentiallyActionableError; // eslint-disable-line no-restricted-syntax
+
       return NonActionableError.rethrow(potentiallyActionableError, {
         message: 'Failed to end async attempt due to an unexpected error',
       });

--- a/src/library/Attempt/adapter/asynchronous.ts
+++ b/src/library/Attempt/adapter/asynchronous.ts
@@ -4,6 +4,9 @@ import {
   NonActionableError,
   type ActionableError,
 } from '../error';
+
+import HonoraryNonActionableError from '../error/HonoraryNonActionableError';
+
 import {
   assertPotentiallyActionable,
 } from '../error/modifier';
@@ -33,6 +36,10 @@ const attemptToEventually = async <
       },
       catch(someError) {
         const potentiallyActionableError = assertPotentiallyActionable(someError);
+
+        if (
+          HonoraryNonActionableError.describes(potentiallyActionableError)
+        ) throw potentiallyActionableError; // eslint-disable-line no-restricted-syntax
 
         return NonActionableError.rethrow(potentiallyActionableError, {
           message: 'Expected error to be either interpreted or prevented altogether',

--- a/src/library/Attempt/error/NonActionableError.ts
+++ b/src/library/Attempt/error/NonActionableError.ts
@@ -2,6 +2,8 @@ import type {
   Branded,
 } from '@/library/typeUtilities/Branded';
 
+import HonoraryNonActionableError from './HonoraryNonActionableError';
+
 interface NonActionableError_Options extends ErrorOptions {
   /** A function that's acting as an alternative to raw `throw` */
   thrower?: (...parameters: any[]) => unknown; // eslint-disable-line @typescript-eslint/no-explicit-any
@@ -56,6 +58,10 @@ class NonActionableError
     if (
       givenError instanceof this
     ) return givenError.throw();
+
+    if (
+      HonoraryNonActionableError.describes(givenError)
+    ) throw givenError; // eslint-disable-line no-restricted-syntax -- avoids wrapping built-in errors that are already non-actionable
 
     return this.throw(given.message, {
       cause  : givenError,

--- a/src/library/Attempt/error/assertions/assertActionable.ts
+++ b/src/library/Attempt/error/assertions/assertActionable.ts
@@ -3,8 +3,6 @@ import {
   type ActionableError,
 } from '..';
 
-import HonoraryNonActionableError from '../HonoraryNonActionableError';
-
 import {
   type AppropriatelyThrown,
   assertPotentiallyActionable,
@@ -16,10 +14,6 @@ const assertActionable = <
   givenError: AppropriatelyThrown<Error>,
 ): SomeActionableError => {
   const potentiallyActionableError = assertPotentiallyActionable(givenError);
-
-  if (
-    HonoraryNonActionableError.describes(potentiallyActionableError)
-  ) throw potentiallyActionableError; // eslint-disable-line no-restricted-syntax
 
   return NonActionableError.rethrow(potentiallyActionableError, {
     message: 'Expected error to be either interpreted or prevented altogether',

--- a/src/library/Attempt/error/assertions/assertActionable.ts
+++ b/src/library/Attempt/error/assertions/assertActionable.ts
@@ -3,6 +3,8 @@ import {
   type ActionableError,
 } from '..';
 
+import HonoraryNonActionableError from '../HonoraryNonActionableError';
+
 import {
   type AppropriatelyThrown,
   assertPotentiallyActionable,
@@ -14,6 +16,10 @@ const assertActionable = <
   givenError: AppropriatelyThrown<Error>,
 ): SomeActionableError => {
   const potentiallyActionableError = assertPotentiallyActionable(givenError);
+
+  if (
+    HonoraryNonActionableError.describes(potentiallyActionableError)
+  ) throw potentiallyActionableError; // eslint-disable-line no-restricted-syntax
 
   return NonActionableError.rethrow(potentiallyActionableError, {
     message: 'Expected error to be either interpreted or prevented altogether',

--- a/src/library/Attempt/error/modifier/PotentiallyActionable.ts
+++ b/src/library/Attempt/error/modifier/PotentiallyActionable.ts
@@ -1,9 +1,8 @@
-import HonoraryNonActionableError from '../HonoraryNonActionableError';
 import NonActionableError from '../NonActionableError';
 
 type PotentiallyActionable<
   SomeError extends Error,
-> = Exclude<SomeError, NonActionableError | HonoraryNonActionableError>;
+> = Exclude<SomeError, NonActionableError>;
 
 const assertPotentiallyActionable = <
   SomeError extends Error,
@@ -13,10 +12,6 @@ const assertPotentiallyActionable = <
   if (
     givenError instanceof NonActionableError
   ) return givenError.throw();
-
-  if (
-    HonoraryNonActionableError.describes(givenError)
-  ) throw givenError; // eslint-disable-line no-restricted-syntax
 
   return givenError as PotentiallyActionable<SomeError>;
 };


### PR DESCRIPTION
- subclasses like `ReferenceError`, `TypeError`, etc. are contextual, common, and expected during dev process in any JS project
- because of this, there's no need to wrap them with a `NonActionableError` instance
- ergo, they should be thrown as is