### PR TITLE
refactor(library/Attempt): simplifies happy path in `Attempt.toEventually`

### DIFF
--- a/src/library/Attempt/adapter/asynchronous.ts
+++ b/src/library/Attempt/adapter/asynchronous.ts
@@ -27,15 +27,8 @@ const attemptToEventually = async <
   given: Attempt_AdapterConfig<SomeActionableError>,
 ): Promise<Outcome<SomeProduct, SomeActionableError>> => Attempt_thatEventually(ends => sanctionedAsync({
   async try() {
-    return await sanctionedAsync({
-      async try() {
-        const retrievedProduct: SomeProduct = await forciblyRetrieveProduct();
-        return ends.inSuccessWith(retrievedProduct);
-      },
-      catch(someError) {
-        throw someError; // eslint-disable-line no-restricted-syntax
-      },
-    });
+    const retrievedProduct: SomeProduct = await forciblyRetrieveProduct();
+    return ends.inSuccessWith(retrievedProduct);
   },
   catch(someError) {
     const someActionableError = (() => {

--- a/src/library/Attempt/adapter/asynchronous.ts
+++ b/src/library/Attempt/adapter/asynchronous.ts
@@ -37,9 +37,7 @@ const attemptToEventually = async <
           someError instanceof NonActionableError
         ) return someError.throw();
 
-        const potentiallyActionableError = (() => {
-          return someError;
-        })();
+        const potentiallyActionableError = someError;
 
         return NonActionableError.rethrow(potentiallyActionableError, {
           message: 'Expected error to be either interpreted or prevented altogether',

--- a/src/library/Attempt/adapter/asynchronous.ts
+++ b/src/library/Attempt/adapter/asynchronous.ts
@@ -33,7 +33,7 @@ const attemptToEventually = async <
         return ends.inSuccessWith(retrievedProduct);
       },
       catch(someError) {
-        const assertPotentiallyActionable = (
+        const potentiallyActionableError = ((
           givenError: typeof someError,
         ): PotentiallyActionable<typeof someError> => {
           if (
@@ -41,9 +41,7 @@ const attemptToEventually = async <
           ) return givenError.throw();
 
           return givenError;
-        };
-
-        const potentiallyActionableError = assertPotentiallyActionable(someError);
+        })(someError);
 
         return NonActionableError.rethrow(potentiallyActionableError, {
           message: 'Expected error to be either interpreted or prevented altogether',

--- a/src/library/Attempt/adapter/asynchronous.ts
+++ b/src/library/Attempt/adapter/asynchronous.ts
@@ -33,10 +33,6 @@ const attemptToEventually = async <
         return ends.inSuccessWith(retrievedProduct);
       },
       catch(someError) {
-        if (
-          someError instanceof NonActionableError
-        ) throw someError; // eslint-disable-line no-restricted-syntax
-
         throw someError; // eslint-disable-line no-restricted-syntax
       },
     });

--- a/src/library/Attempt/adapter/asynchronous.ts
+++ b/src/library/Attempt/adapter/asynchronous.ts
@@ -33,16 +33,14 @@ const attemptToEventually = async <
         return ends.inSuccessWith(retrievedProduct);
       },
       catch(someError) {
-        const assertPotentiallyActionable = <
-          SomeError extends Error,
-        >(
-          givenError: SomeError,
-        ): PotentiallyActionable<SomeError> => {
+        const assertPotentiallyActionable = (
+          givenError: typeof someError,
+        ): PotentiallyActionable<typeof someError> => {
           if (
             givenError instanceof NonActionableError
           ) return givenError.throw();
 
-          return givenError as PotentiallyActionable<SomeError>;
+          return givenError;
         };
 
         const potentiallyActionableError = assertPotentiallyActionable(someError);

--- a/src/library/Attempt/adapter/asynchronous.ts
+++ b/src/library/Attempt/adapter/asynchronous.ts
@@ -5,9 +5,8 @@ import {
   type ActionableError,
 } from '../error';
 
-import {
-  type PotentiallyActionable,
-  assertPotentiallyActionable,
+import type {
+  PotentiallyActionable,
 } from '../error/modifier';
 
 import {
@@ -34,6 +33,18 @@ const attemptToEventually = async <
         return ends.inSuccessWith(retrievedProduct);
       },
       catch(someError) {
+        const assertPotentiallyActionable = <
+          SomeError extends Error,
+        >(
+          givenError: SomeError,
+        ): PotentiallyActionable<SomeError> => {
+          if (
+            givenError instanceof NonActionableError
+          ) return givenError.throw();
+
+          return givenError as PotentiallyActionable<SomeError>;
+        };
+
         const potentiallyActionableError = assertPotentiallyActionable(someError);
 
         return NonActionableError.rethrow(potentiallyActionableError, {

--- a/src/library/Attempt/adapter/asynchronous.ts
+++ b/src/library/Attempt/adapter/asynchronous.ts
@@ -37,7 +37,7 @@ const attemptToEventually = async <
           someError instanceof NonActionableError
         ) return someError.throw();
 
-        const potentiallyActionableError = ((): PotentiallyActionable<typeof someError> => {
+        const potentiallyActionableError = (() => {
           return someError;
         })();
 

--- a/src/library/Attempt/adapter/asynchronous.ts
+++ b/src/library/Attempt/adapter/asynchronous.ts
@@ -37,9 +37,7 @@ const attemptToEventually = async <
           someError instanceof NonActionableError
         ) return someError.throw();
 
-        return NonActionableError.rethrow(someError, {
-          message: 'Expected error to be either interpreted or prevented altogether',
-        });
+        throw someError; // eslint-disable-line no-restricted-syntax
       },
     });
   },

--- a/src/library/Attempt/adapter/asynchronous.ts
+++ b/src/library/Attempt/adapter/asynchronous.ts
@@ -37,9 +37,7 @@ const attemptToEventually = async <
           someError instanceof NonActionableError
         ) return someError.throw();
 
-        const potentiallyActionableError = someError;
-
-        return NonActionableError.rethrow(potentiallyActionableError, {
+        return NonActionableError.rethrow(someError, {
           message: 'Expected error to be either interpreted or prevented altogether',
         });
       },

--- a/src/library/Attempt/adapter/asynchronous.ts
+++ b/src/library/Attempt/adapter/asynchronous.ts
@@ -33,11 +33,11 @@ const attemptToEventually = async <
         return ends.inSuccessWith(retrievedProduct);
       },
       catch(someError) {
-        const potentiallyActionableError = ((): PotentiallyActionable<typeof someError> => {
-          if (
-            someError instanceof NonActionableError
-          ) return someError.throw();
+        if (
+          someError instanceof NonActionableError
+        ) return someError.throw();
 
+        const potentiallyActionableError = ((): PotentiallyActionable<typeof someError> => {
           return someError;
         })();
 

--- a/src/library/Attempt/adapter/asynchronous.ts
+++ b/src/library/Attempt/adapter/asynchronous.ts
@@ -33,15 +33,13 @@ const attemptToEventually = async <
         return ends.inSuccessWith(retrievedProduct);
       },
       catch(someError) {
-        const potentiallyActionableError = ((
-          givenError: typeof someError,
-        ): PotentiallyActionable<typeof someError> => {
+        const potentiallyActionableError = ((): PotentiallyActionable<typeof someError> => {
           if (
-            givenError instanceof NonActionableError
-          ) return givenError.throw();
+            someError instanceof NonActionableError
+          ) return someError.throw();
 
-          return givenError;
-        })(someError);
+          return someError;
+        })();
 
         return NonActionableError.rethrow(potentiallyActionableError, {
           message: 'Expected error to be either interpreted or prevented altogether',

--- a/src/library/Attempt/adapter/asynchronous.ts
+++ b/src/library/Attempt/adapter/asynchronous.ts
@@ -35,7 +35,7 @@ const attemptToEventually = async <
       catch(someError) {
         if (
           someError instanceof NonActionableError
-        ) return someError.throw();
+        ) throw someError; // eslint-disable-line no-restricted-syntax
 
         throw someError; // eslint-disable-line no-restricted-syntax
       },


### PR DESCRIPTION
- nested error propagation in `Attempt.toEventually` ended up dissolving away
- see PR commits for proof/refactor operations