### PR TITLE
fix(library/Attempt): hides non-actionable errors from interpreter callback

### DIFF
--- a/src/library/Attempt/adapter/asynchronous.ts
+++ b/src/library/Attempt/adapter/asynchronous.ts
@@ -48,7 +48,7 @@ const attemptToEventually = async <
           !(givenError instanceof NonActionableError)
         ) return givenError;
 
-        return givenError.rethrownError ?? givenError;
+        return givenError.rethrownError ?? givenError.throw();
       })(someError);
 
       const interpretedError = given.interpretationOf(potentiallyActionableError);

--- a/src/library/Attempt/adapter/asynchronous.ts
+++ b/src/library/Attempt/adapter/asynchronous.ts
@@ -6,6 +6,7 @@ import {
 } from '../error';
 
 import {
+  type PotentiallyActionable,
   assertPotentiallyActionable,
 } from '../error/modifier';
 
@@ -43,7 +44,7 @@ const attemptToEventually = async <
   },
   catch(someError) {
     const someActionableError = (() => {
-      const potentiallyActionableError = ((givenError) => {
+      const potentiallyActionableError = ((givenError): PotentiallyActionable<typeof someError> => {
         if (
           !(givenError instanceof NonActionableError)
         ) return givenError;

--- a/src/library/Attempt/error/Interpreter.ts
+++ b/src/library/Attempt/error/Interpreter.ts
@@ -1,9 +1,13 @@
 import type ActionableError from './ActionableError';
 
+import type {
+  PotentiallyActionable,
+} from './modifier';
+
 type Attempt_ErrorInterpreter<
   SomeActionableError extends ActionableError<string>,
 > = (
-  caughtError: Error
+  caughtError: PotentiallyActionable<Error>
 ) => SomeActionableError | null;
 
 export {

--- a/src/library/Attempt/error/modifier/index.ts
+++ b/src/library/Attempt/error/modifier/index.ts
@@ -3,5 +3,6 @@ export {
 } from './AppropriatelyThrown';
 
 export {
+  type PotentiallyActionable,
   assertPotentiallyActionable,
 } from './PotentiallyActionable';


### PR DESCRIPTION
- since non-actionable errors are programmer errors by definition, there's nothing to delegate to callers.
  - their "interpretation" is written _proactively_ in the implementation designed to avoid such errors
- Only errors that _might_ have some _reactive_ "interpretation" are exposed to `Attempt.ErrorInterpreter` for the caller to define