### PR TITLE
fix(library/Attempt): considers all escorted errors to be potentially actionable

### DIFF
--- a/src/library/Attempt/adapter/asynchronous.ts
+++ b/src/library/Attempt/adapter/asynchronous.ts
@@ -32,16 +32,18 @@ const attemptToEventually = async <
   },
   catch(someError) {
     const someActionableError = (() => {
-      const assertPotentiallyActionable = (
-        givenError: typeof someError,
-      ): PotentiallyActionable<typeof someError> => {
+      const assertPotentiallyActionable = <
+        SomeError extends Error,
+      >(
+        givenError: SomeError,
+      ): PotentiallyActionable<SomeError> => {
         if (
           !(givenError instanceof NonActionableError)
-        ) return givenError;
+        ) return givenError as PotentiallyActionable<SomeError>;
 
         if (
           givenError.rethrownError !== null
-        ) return givenError.rethrownError;
+        ) return givenError.rethrownError as PotentiallyActionable<SomeError>;
 
         return givenError.throw();
       };

--- a/src/library/Attempt/adapter/asynchronous.ts
+++ b/src/library/Attempt/adapter/asynchronous.ts
@@ -39,7 +39,11 @@ const attemptToEventually = async <
           !(givenError instanceof NonActionableError)
         ) return givenError;
 
-        return givenError.rethrownError ?? givenError.throw();
+        if (
+          givenError.rethrownError !== null
+        ) return givenError.rethrownError;
+
+        return givenError.throw();
       };
 
       const potentiallyActionableError = assertPotentiallyActionable(someError);

--- a/src/library/Attempt/adapter/asynchronous.ts
+++ b/src/library/Attempt/adapter/asynchronous.ts
@@ -32,7 +32,7 @@ const attemptToEventually = async <
   },
   catch(someError) {
     const someActionableError = (() => {
-      const potentiallyActionableError = ((
+      const assertPotentiallyActionable = (
         givenError: typeof someError,
       ): PotentiallyActionable<typeof someError> => {
         if (
@@ -40,8 +40,9 @@ const attemptToEventually = async <
         ) return givenError;
 
         return givenError.rethrownError ?? givenError.throw();
-      })(someError);
+      };
 
+      const potentiallyActionableError = assertPotentiallyActionable(someError);
       const interpretedError = given.interpretationOf(potentiallyActionableError);
 
       if (

--- a/src/library/Attempt/adapter/asynchronous.ts
+++ b/src/library/Attempt/adapter/asynchronous.ts
@@ -33,7 +33,7 @@ const attemptToEventually = async <
   catch(someError) {
     const someActionableError = (() => {
       const potentiallyActionableError = ((
-        givenError,
+        givenError: typeof someError,
       ): PotentiallyActionable<typeof someError> => {
         if (
           !(givenError instanceof NonActionableError)

--- a/src/library/Attempt/adapter/asynchronous.ts
+++ b/src/library/Attempt/adapter/asynchronous.ts
@@ -5,8 +5,8 @@ import {
   type ActionableError,
 } from '../error';
 
-import type {
-  PotentiallyActionable,
+import {
+  assertPotentiallyActionable,
 } from '../error/modifier';
 
 import {
@@ -32,22 +32,6 @@ const attemptToEventually = async <
   },
   catch(someError) {
     const someActionableError = (() => {
-      const assertPotentiallyActionable = <
-        SomeError extends Error,
-      >(
-        givenError: SomeError,
-      ): PotentiallyActionable<SomeError> => {
-        if (
-          !(givenError instanceof NonActionableError)
-        ) return givenError as PotentiallyActionable<SomeError>;
-
-        if (
-          givenError.rethrownError !== null
-        ) return givenError.rethrownError as PotentiallyActionable<SomeError>;
-
-        return givenError.throw();
-      };
-
       const potentiallyActionableError = assertPotentiallyActionable(someError);
       const interpretedError = given.interpretationOf(potentiallyActionableError);
 

--- a/src/library/Attempt/adapter/asynchronous.ts
+++ b/src/library/Attempt/adapter/asynchronous.ts
@@ -32,7 +32,9 @@ const attemptToEventually = async <
   },
   catch(someError) {
     const someActionableError = (() => {
-      const potentiallyActionableError = ((givenError): PotentiallyActionable<typeof someError> => {
+      const potentiallyActionableError = ((
+        givenError,
+      ): PotentiallyActionable<typeof someError> => {
         if (
           !(givenError instanceof NonActionableError)
         ) return givenError;

--- a/src/library/Attempt/error/modifier/PotentiallyActionable.ts
+++ b/src/library/Attempt/error/modifier/PotentiallyActionable.ts
@@ -13,6 +13,10 @@ const assertPotentiallyActionable = <
     !(givenError instanceof NonActionableError)
   ) return givenError as PotentiallyActionable<SomeError>;
 
+  if (
+    givenError.rethrownError !== null
+  ) return givenError.rethrownError as PotentiallyActionable<SomeError>;
+
   return givenError.throw();
 };
 

--- a/src/library/Attempt/error/modifier/PotentiallyActionable.ts
+++ b/src/library/Attempt/error/modifier/PotentiallyActionable.ts
@@ -10,10 +10,10 @@ const assertPotentiallyActionable = <
   givenError: SomeError,
 ): PotentiallyActionable<SomeError> => {
   if (
-    givenError instanceof NonActionableError
-  ) return givenError.throw();
+    !(givenError instanceof NonActionableError)
+  ) return givenError as PotentiallyActionable<SomeError>;
 
-  return givenError as PotentiallyActionable<SomeError>;
+  return givenError.throw();
 };
 
 export {


### PR DESCRIPTION
- builds on #358, applying it to any place where errors are deemed "potentially actionable"