### PR TITLE
prefeature(library/Attempt): enables type-safe error identification

### DIFF
--- a/src/library/Attempt/adapter/asynchronous.ts
+++ b/src/library/Attempt/adapter/asynchronous.ts
@@ -1,12 +1,11 @@
 import type Outcome from '../Outcome';
 
-import {
-  NonActionableError,
-  type ActionableError,
+import type {
+  ActionableError,
 } from '../error';
 
 import {
-  assertPotentiallyActionable,
+  assertActionable,
 } from '../error/assertions';
 
 import {
@@ -31,18 +30,9 @@ const attemptToEventually = async <
     return ends.inSuccessWith(retrievedProduct);
   },
   catch(someError) {
-    const someActionableError = (() => {
-      const potentiallyActionableError = assertPotentiallyActionable(someError);
-      const interpretedError = given.interpretationOf(potentiallyActionableError);
-
-      if (
-        interpretedError !== null
-      ) return interpretedError;
-
-      return NonActionableError.rethrow(potentiallyActionableError, {
-        message: 'Failed to end async attempt due to an unexpected error',
-      });
-    })();
+    const someActionableError = assertActionable(someError, {
+      using: given.interpretationOf,
+    });
 
     return ends.inFailureDueTo(someActionableError);
   },

--- a/src/library/Attempt/adapter/asynchronous.ts
+++ b/src/library/Attempt/adapter/asynchronous.ts
@@ -3,7 +3,6 @@ import type Outcome from '../Outcome';
 import type {
   ActionableError,
 } from '../error';
-
 import {
   assertActionable,
 } from '../error/assertions';

--- a/src/library/Attempt/adapter/synchronous.ts
+++ b/src/library/Attempt/adapter/synchronous.ts
@@ -15,18 +15,24 @@ import {
   sanctioned,
 } from '../utilities/sanctionedTryCatch';
 
+import type Attempt_AdapterConfig from './Config';
+
 const attemptTo = <
   SomeProduct,
   SomeActionableError extends ActionableError<string>,
 >(
   forciblyGetProduct: () => SomeProduct,
+  given: Attempt_AdapterConfig<SomeActionableError>,
 ): Outcome<SomeProduct, SomeActionableError> => Attempt_that(ends => sanctioned({
   try() {
     const gottenProduct = forciblyGetProduct();
     return ends.inSuccessWith(gottenProduct);
   },
   catch(someError) {
-    const someActionableError = assertActionable<SomeActionableError>(someError);
+    const someActionableError = assertActionable(someError, {
+      using: given.interpretationOf,
+    });
+
     return ends.inFailureDueTo(someActionableError);
   },
 }));

--- a/src/library/Attempt/error/assertions/assertActionable.ts
+++ b/src/library/Attempt/error/assertions/assertActionable.ts
@@ -21,8 +21,6 @@ const assertActionable = <
     using: interpretationOf,
   }: {
     using: Attempt_ErrorInterpreter<SomeActionableError>;
-  } = {
-    using: () => null,
   },
 ): SomeActionableError => {
   const potentiallyActionableError = assertPotentiallyActionable(givenError);

--- a/src/library/Attempt/error/assertions/assertActionable.ts
+++ b/src/library/Attempt/error/assertions/assertActionable.ts
@@ -3,6 +3,8 @@ import {
   type ActionableError,
 } from '..';
 
+import type Attempt_ErrorInterpreter from '../Interpreter';
+
 import {
   assertPotentiallyActionable,
 } from '../assertions';
@@ -12,11 +14,23 @@ import type {
 } from '../modifier';
 
 const assertActionable = <
-  SomeActionableError extends ActionableError<string>, // eslint-disable-line @typescript-eslint/no-unnecessary-type-parameters
+  SomeActionableError extends ActionableError<string>,
 >(
   givenError: AppropriatelyThrown<Error>,
+  {
+    using: interpretationOf,
+  }: {
+    using: Attempt_ErrorInterpreter<SomeActionableError>;
+  } = {
+    using: () => null,
+  },
 ): SomeActionableError => {
   const potentiallyActionableError = assertPotentiallyActionable(givenError);
+  const definitelyActionableError = interpretationOf(potentiallyActionableError);
+
+  if (
+    definitelyActionableError !== null
+  ) return definitelyActionableError;
 
   return NonActionableError.rethrow(potentiallyActionableError, {
     message: 'Expected error to be either interpreted or prevented altogether',


### PR DESCRIPTION
- before, there was no way for TypeScript to tell which specific error instances could be propagated as a failure
    - just like the default error propagation in JavaScript, this library would default to rethrowing errors, just in a more obvious way
- now, functions that `throw` the default way can:
  1. be wrapped by `Attempt.to` or `Attempt.toEventually`
  1. specify which errors can be mapped to some instance of a subclass of `ActionableError`
  1. inform intellisense all of the subclasses it should present to the caller scope