### PR TITLE
refactor(library/Attempt): adds `Success` and `Failure` to namespace

### DIFF
--- a/src/library/Attempt/Outcome.ts
+++ b/src/library/Attempt/Outcome.ts
@@ -42,7 +42,7 @@ interface SemanticallySugarfreeFailure<
   readonly cause: SomeActionableError;
 }
 
-interface Success<SomeProduct> extends SemanticallySugarfreeSuccess<SomeProduct> {
+interface Attempt_Success<SomeProduct> extends SemanticallySugarfreeSuccess<SomeProduct> {
   /**
    * Access the product nested within a successful outcome.
    *
@@ -75,7 +75,7 @@ interface Success<SomeProduct> extends SemanticallySugarfreeSuccess<SomeProduct>
   readonly unwrapped: this['product'];
 }
 
-interface Failure<
+interface Attempt_Failure<
   SomeActionableError extends ActionableError<string>,
 > extends SemanticallySugarfreeFailure<SomeActionableError> {
   /**
@@ -102,7 +102,7 @@ const successThatYielded = <
   SomeProduct,
 >(
   givenProduct: SomeProduct,
-): Success<SomeProduct> => ({
+): Attempt_Success<SomeProduct> => ({
   case            : 'success',
   product         : givenProduct,
   isSuccess       : true,
@@ -116,7 +116,7 @@ const failureDueTo = <
   SomeActionableError extends ActionableError<string>,
 >(
   givenCause: SomeActionableError,
-): Failure<SomeActionableError> => ({
+): Attempt_Failure<SomeActionableError> => ({
   case            : 'failure',
   cause           : givenCause,
   isSuccess       : false,
@@ -135,18 +135,18 @@ type Attempt_Outcome<
   SomeProduct,
   SomeActionableError extends ActionableError<string>,
 > =
-  | Success<SomeProduct>
-  | Failure<SomeActionableError>;
+  | Attempt_Success<SomeProduct>
+  | Attempt_Failure<SomeActionableError>;
 
 type ProductOf<
   SomeOutcome extends Attempt_Outcome<unknown, ActionableError<string>>,
-> = SomeOutcome extends Success<infer NestedProduct>
+> = SomeOutcome extends Attempt_Success<infer NestedProduct>
   ? NestedProduct
   : never;
 
 type CauseOf<
   SomeOutcome extends Attempt_Outcome<unknown, ActionableError<string>>,
-> = SomeOutcome extends Failure<infer NestedError>
+> = SomeOutcome extends Attempt_Failure<infer NestedError>
   ? NestedError
   : never;
 

--- a/src/library/Attempt/Outcome.ts
+++ b/src/library/Attempt/Outcome.ts
@@ -152,6 +152,8 @@ type CauseOf<
 
 export {
   Attempt_Outcome,
+  type Attempt_Success,
+  type Attempt_Failure,
   type ProductOf,
   type CauseOf,
 };

--- a/src/library/Attempt/Outcome.ts
+++ b/src/library/Attempt/Outcome.ts
@@ -126,12 +126,12 @@ const failureDueTo = <
   causeOfFailure  : givenCause,
 });
 
-const Outcome = {
+const Attempt_Outcome = {
   failureDueTo,
   successThatYielded,
 };
 
-type Outcome<
+type Attempt_Outcome<
   SomeProduct,
   SomeActionableError extends ActionableError<string>,
 > =
@@ -139,19 +139,19 @@ type Outcome<
   | Failure<SomeActionableError>;
 
 type ProductOf<
-  SomeOutcome extends Outcome<unknown, ActionableError<string>>,
+  SomeOutcome extends Attempt_Outcome<unknown, ActionableError<string>>,
 > = SomeOutcome extends Success<infer NestedProduct>
   ? NestedProduct
   : never;
 
 type CauseOf<
-  SomeOutcome extends Outcome<unknown, ActionableError<string>>,
+  SomeOutcome extends Attempt_Outcome<unknown, ActionableError<string>>,
 > = SomeOutcome extends Failure<infer NestedError>
   ? NestedError
   : never;
 
 export {
-  Outcome as default,
+  Attempt_Outcome,
   type ProductOf,
   type CauseOf,
 };

--- a/src/library/Attempt/adapter/asynchronous.ts
+++ b/src/library/Attempt/adapter/asynchronous.ts
@@ -1,4 +1,6 @@
-import type Outcome from '../Outcome';
+import type {
+  Attempt_Outcome,
+} from '../Outcome';
 
 import type {
   ActionableError,
@@ -23,7 +25,7 @@ const attemptToEventually = async <
 >(
   forciblyRetrieveProduct: () => Promise<SomeProduct>,
   given: Attempt_AdapterConfig<SomeActionableError>,
-): Promise<Outcome<SomeProduct, SomeActionableError>> => Attempt_thatEventually(ends => sanctionedAsync({
+): Promise<Attempt_Outcome<SomeProduct, SomeActionableError>> => Attempt_thatEventually(ends => sanctionedAsync({
   async try() {
     const retrievedProduct: SomeProduct = await forciblyRetrieveProduct();
     return ends.inSuccessWith(retrievedProduct);
@@ -43,7 +45,7 @@ const attemptToSettle = async <
 >(
   promisedProduct: Promise<SomeProduct>,
   givenConfig: Attempt_AdapterConfig<SomeActionableError>,
-): Promise<Outcome<SomeProduct, SomeActionableError>> => {
+): Promise<Attempt_Outcome<SomeProduct, SomeActionableError>> => {
   const getPromisedProduct = () => promisedProduct;
   return attemptToEventually(getPromisedProduct, givenConfig);
 };

--- a/src/library/Attempt/adapter/synchronous.ts
+++ b/src/library/Attempt/adapter/synchronous.ts
@@ -1,4 +1,6 @@
-import type Outcome from '../Outcome';
+import type {
+  Attempt_Outcome,
+} from '../Outcome';
 
 import type {
   ActionableError,
@@ -23,7 +25,7 @@ const attemptTo = <
 >(
   forciblyGetProduct: () => SomeProduct,
   given: Attempt_AdapterConfig<SomeActionableError>,
-): Outcome<SomeProduct, SomeActionableError> => Attempt_that(ends => sanctioned({
+): Attempt_Outcome<SomeProduct, SomeActionableError> => Attempt_that(ends => sanctioned({
   try() {
     const gottenProduct = forciblyGetProduct();
     return ends.inSuccessWith(gottenProduct);

--- a/src/library/Attempt/ended.ts
+++ b/src/library/Attempt/ended.ts
@@ -1,4 +1,6 @@
-import Outcome from './Outcome';
+import {
+  Attempt_Outcome,
+} from './Outcome';
 
 import {
   NonActionableError,
@@ -12,9 +14,9 @@ import {
 */
 const Attempt_ended = {
   /** Call this when the attempt has completed and was considered successful */
-  inSuccessWith  : Outcome.successThatYielded,
+  inSuccessWith  : Attempt_Outcome.successThatYielded,
   /** Call this when the attempt has completed and was considered a failure */
-  inFailureDueTo : Outcome.failureDueTo,
+  inFailureDueTo : Attempt_Outcome.failureDueTo,
   /** Call this when it's not possible to complete the attempt */
   inFlamesBecause: NonActionableError.throw,
 };

--- a/src/library/Attempt/exports.ts
+++ b/src/library/Attempt/exports.ts
@@ -10,6 +10,8 @@ export {
 
 export {
   Attempt_Outcome as Outcome,
+  type Attempt_Success as Success,
+  type Attempt_Failure as Failure,
 } from './Outcome';
 
 export {

--- a/src/library/Attempt/exports.ts
+++ b/src/library/Attempt/exports.ts
@@ -9,7 +9,7 @@ export {
 };
 
 export {
-  default as Outcome,
+  Attempt_Outcome as Outcome,
 } from './Outcome';
 
 export {

--- a/src/library/Attempt/factory/asynchronous.ts
+++ b/src/library/Attempt/factory/asynchronous.ts
@@ -1,9 +1,8 @@
 import type {
+  Attempt_Outcome,
   CauseOf,
   ProductOf,
 } from '../Outcome';
-
-import type Outcome from '../Outcome';
 
 import {
   Attempt_ended as handles,
@@ -14,17 +13,17 @@ import type {
 } from '../error';
 
 type Attempt_EndRetriever<
-  InferredOutcome extends Outcome<unknown, ActionableError<string>>,
+  InferredOutcome extends Attempt_Outcome<unknown, ActionableError<string>>,
 > = (
   givenHandles: typeof handles
 ) => Promise<InferredOutcome>;
 
 const Attempt_thatEventually = async <
-  InferredOutcome extends Outcome<unknown, ActionableError<string>>,
+  InferredOutcome extends Attempt_Outcome<unknown, ActionableError<string>>,
 >(
   endsAccordingTo: Attempt_EndRetriever<InferredOutcome>,
 ) => {
-  type EquivalentOutcome = Outcome<ProductOf<InferredOutcome>, CauseOf<InferredOutcome>>;
+  type EquivalentOutcome = Attempt_Outcome<ProductOf<InferredOutcome>, CauseOf<InferredOutcome>>;
   return await endsAccordingTo(handles) as EquivalentOutcome;
 };
 

--- a/src/library/Attempt/factory/synchronous.ts
+++ b/src/library/Attempt/factory/synchronous.ts
@@ -1,9 +1,8 @@
 import type {
+  Attempt_Outcome,
   CauseOf,
   ProductOf,
 } from '../Outcome';
-
-import type Outcome from '../Outcome';
 
 import {
   Attempt_ended as handles,
@@ -13,17 +12,17 @@ import type {
 } from '../error';
 
 type Attempt_EndGetter<
-  InferredOutcome extends Outcome<unknown, ActionableError<string>>,
+  InferredOutcome extends Attempt_Outcome<unknown, ActionableError<string>>,
 > = (
   givenHandles: typeof handles
 ) => InferredOutcome;
 
 const Attempt_that = <
-  InferredOutcome extends Outcome<unknown, ActionableError<string>>,
+  InferredOutcome extends Attempt_Outcome<unknown, ActionableError<string>>,
 >(
   endsAccordingTo: Attempt_EndGetter<InferredOutcome>,
 ) => {
-  type EquivalentOutcome = Outcome<ProductOf<InferredOutcome>, CauseOf<InferredOutcome>>;
+  type EquivalentOutcome = Attempt_Outcome<ProductOf<InferredOutcome>, CauseOf<InferredOutcome>>;
   return endsAccordingTo(handles) as EquivalentOutcome;
 };
 


### PR DESCRIPTION
- `Success` and `Failure` are exposed to callers that use the namespace, so aliases are needed to make them appear as `Attempt.Success` and `Attempt.Failure`
- they along with `Attempt.Outcome` now follow "namespace prefix convention" so that, from within the namespace, it's more obvious that changes will be expose to API consumers