### PR TITLE
chore(dev): bump typescript-eslint from 8.34.0 to 8.34.1

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -134,8 +134,6 @@ const configWithVueTS = defineConfigWithVueTs(
     },
   },
 
-  // TODO: Remove the @ts-expect-error comment once @typescript-eslint adds support of ES17/ES2026 (after v8.34.0)
-  // @ts-expect-error -- ESLint v9.29.0 broke `FlatConfig.LanguageOptions` compatibility with @typescript-eslint v8.34.0
   stylistic.configs.customize({
     commaDangle: 'always-multiline',
     quotes     : 'single',

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "lodash.clonedeep": "^4.5.0",
         "stabilityai-client-typescript": "github:nod-ai/StabilityAI-client-typescript#npm/v0.1.0",
-        "typescript-eslint": "^8.34.0",
+        "typescript-eslint": "^8.34.1",
         "vue": "^3.5.16",
         "vue-router": "^4.5.1",
         "vuetify": "^3.8.9",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "lodash.clonedeep": "^4.5.0",
     "stabilityai-client-typescript": "github:nod-ai/StabilityAI-client-typescript#npm/v0.1.0",
-    "typescript-eslint": "^8.34.0",
+    "typescript-eslint": "^8.34.1",
     "vue": "^3.5.16",
     "vue-router": "^4.5.1",
     "vuetify": "^3.8.9",


### PR DESCRIPTION
See [release](https://github.com/typescript-eslint/typescript-eslint/releases/tag/v8.34.1) for full details