### PR TITLE
linter: documents custom typescript eslint config

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -13,6 +13,27 @@ import tseslint, {
 import pluginImport from './eslint.import';
 import pluginStylistic from './eslint.stylistic';
 
+const extraConfigForTypeScriptESLint: ConfigWithExtends = {
+  rules: {
+    '@typescript-eslint/consistent-type-exports': [
+      'error',
+    ],
+    '@typescript-eslint/consistent-type-imports': [
+      'error',
+      {
+        prefer  : 'type-imports', // makes it easier to see which imports might have side effects
+        fixStyle: 'inline-type-imports', // allows for more compact imports and tees up problematic imports to '@typescript-eslint/no-import-type-side-effects'
+      },
+    ],
+    '@typescript-eslint/explicit-member-accessibility': [
+      'error', // Easier to see dead code in situations where a member is marked `private`
+    ],
+    '@typescript-eslint/no-import-type-side-effects': [
+      'error', // Avoids unexpected behavior, trims down the size of the bundle
+    ],
+  },
+};
+
 const configWithVueTS = defineConfigWithVueTs(
   {
     name : 'app/files-to-lint',
@@ -54,26 +75,7 @@ const configWithVueTS = defineConfigWithVueTs(
       ],
     },
   },
-  {
-    rules: {
-      '@typescript-eslint/consistent-type-exports': [
-        'error',
-      ],
-      '@typescript-eslint/consistent-type-imports': [
-        'error',
-        {
-          prefer  : 'type-imports', // makes it easier to see which imports might have side effects
-          fixStyle: 'inline-type-imports', // allows for more compact imports and tees up problematic imports to '@typescript-eslint/no-import-type-side-effects'
-        },
-      ],
-      '@typescript-eslint/explicit-member-accessibility': [
-        'error', // Easier to see dead code in situations where a member is marked `private`
-      ],
-      '@typescript-eslint/no-import-type-side-effects': [
-        'error', // Avoids unexpected behavior, trims down the size of the bundle
-      ],
-    },
-  },
+  extraConfigForTypeScriptESLint,
   ...pluginStylistic,
   ...pluginImport,
 

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -14,6 +14,7 @@ import pluginImport from './eslint.import';
 import pluginStylistic from './eslint.stylistic';
 
 const extraConfigForTypeScriptESLint: ConfigWithExtends = {
+  name : 'shark-ui/@typescript-eslint',
   rules: {
     '@typescript-eslint/consistent-type-exports': [
       'error',

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -52,6 +52,10 @@ const configWithVueTS = defineConfigWithVueTs(
           message : 'Prefer `Attempt.that` callback for error propagation over `throw`.',
         },
       ],
+    },
+  },
+  {
+    rules: {
       '@typescript-eslint/consistent-type-exports': [
         'error',
       ],


### PR DESCRIPTION
- adds context to rule set
- ensures it's easy to identify when using `npx eslint --inspect-config`