### PR TITLE
linter: enforces guard pattern

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -19,6 +19,9 @@ const extraConfigForESLint: ConfigWithExtends = {
     'eqeqeq': [
       'error', // Avoids `==` and `!=`, which perform type coercions that follow the rather obscure Abstract Equality Comparison Algorithm: https://www.ecma-international.org/ecma-262/5.1/#sec-11.9.3
     ],
+    'no-else-return': [
+      'error', // Helps highlight the primary path of a scope, avoids unnecessary nesting
+    ],
     'no-implicit-coercion': [
       'error', // Using constructors, factories, and parsers for coercion rather than operators leads to less confusing behavior
     ],

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -16,6 +16,10 @@ import pluginStylistic from './eslint.stylistic';
 const extraConfigForESLint: ConfigWithExtends = {
   name : 'shark-ui/eslint',
   rules: {
+    'curly': [
+      'error',
+      'multi', // Encourages consistent formatting for guard statements, which are often used to prevent unnecessary nesting
+    ],
     'eqeqeq': [
       'error', // Avoids `==` and `!=`, which perform type coercions that follow the rather obscure Abstract Equality Comparison Algorithm: https://www.ecma-international.org/ecma-262/5.1/#sec-11.9.3
     ],

--- a/src/library/Attempt/error/NonActionableError.ts
+++ b/src/library/Attempt/error/NonActionableError.ts
@@ -42,9 +42,7 @@ class NonActionableError
     if (
       ('captureStackTrace' in Error)
       && (Error.captureStackTrace instanceof Function)
-    ) {
-      Error.captureStackTrace.call(undefined, newError, givenOptions?.thrower ?? NonActionableError.throw);
-    }
+    ) Error.captureStackTrace.call(undefined, newError, givenOptions?.thrower ?? NonActionableError.throw);
 
     return newError.throw();
   };

--- a/src/library/customTypes/UniformResourceIdentifier/index.ts
+++ b/src/library/customTypes/UniformResourceIdentifier/index.ts
@@ -161,12 +161,10 @@ class UniformResourceIdentifier implements StaticStringParser<typeof UniformReso
         path: `${typeof pathSegmentDelimiter}${string}`;
       }
     ) => {
-      if (!componentsPrecedingQuery.startsWith(authorityPrefix)) {
-        return ({
-          authority: null,
-          path     : componentsPrecedingQuery,
-        });
-      }
+      if (!componentsPrecedingQuery.startsWith(authorityPrefix)) return ({
+        authority: null,
+        path     : componentsPrecedingQuery,
+      });
 
       const authorityAndPath = componentsPrecedingQuery.replace(authorityPrefix, '');
       const [


### PR DESCRIPTION
- allows the linter to help devs embrace the "return early"/"fail fast"/"show happy path" paradigms for readability