### PR TITLE
prefeature(library/Attempt): ensures that built-in errors are escorted on rethrow

### DIFF
--- a/src/library/Attempt/error/NonActionableBuiltInError.ts
+++ b/src/library/Attempt/error/NonActionableBuiltInError.ts
@@ -34,7 +34,7 @@ declare global {
  *
  * These errors are not expected to be caught or handled in any way.
  */
-type HonoraryNonActionableError =
+type NonActionableBuiltInError =
   | ReferenceError // Something was referenced that doesn't exist in scope.
   | TypeError // Something was called/iterated/assigned that can’t possibly support that operation.
   | RangeError // Runtime was asked to create an impossible value.
@@ -42,9 +42,9 @@ type HonoraryNonActionableError =
   | EvalError // Something illegal was done with `eval` or `Function` constructor.
   | SyntaxError; // The JS engine couldn't even parse the code.
 
-const isHonoraryNonActionableError = (
+const isNonActionableBuiltInError = (
   givenError: Error,
-): givenError is HonoraryNonActionableError => {
+): givenError is NonActionableBuiltInError => {
   return (
     (givenError instanceof ReferenceError)
     || (givenError instanceof TypeError)
@@ -55,10 +55,10 @@ const isHonoraryNonActionableError = (
   );
 };
 
-const HonoraryNonActionableError = {
-  describes: isHonoraryNonActionableError,
+const NonActionableBuiltInError = {
+  describes: isNonActionableBuiltInError,
 };
 
 export {
-  HonoraryNonActionableError as default,
+  NonActionableBuiltInError as default,
 };

--- a/src/library/Attempt/error/NonActionableError.ts
+++ b/src/library/Attempt/error/NonActionableError.ts
@@ -67,7 +67,8 @@ class NonActionableError
     });
   };
 
-  public get rethrownError(): Error | null {
+  /** The error being "escorted" across the call stack by this instance, if any */
+  public get charge(): Error | null {
     if (
       this.cause instanceof Error
     ) return this.cause;

--- a/src/library/Attempt/error/NonActionableError.ts
+++ b/src/library/Attempt/error/NonActionableError.ts
@@ -2,8 +2,6 @@ import type {
   Branded,
 } from '@/library/typeUtilities/Branded';
 
-import NonActionableBuiltInError from './NonActionableBuiltInError';
-
 interface NonActionableError_Options extends ErrorOptions {
   /** A function that's acting as an alternative to raw `throw` */
   thrower?: (...parameters: any[]) => unknown; // eslint-disable-line @typescript-eslint/no-explicit-any
@@ -56,10 +54,6 @@ class NonActionableError
     if (
       givenError instanceof this
     ) return givenError.throw();
-
-    if (
-      NonActionableBuiltInError.describes(givenError)
-    ) throw givenError; // eslint-disable-line no-restricted-syntax -- avoids wrapping built-in errors that are already non-actionable
 
     return this.throw(given.message, {
       cause  : givenError,

--- a/src/library/Attempt/error/NonActionableError.ts
+++ b/src/library/Attempt/error/NonActionableError.ts
@@ -2,7 +2,7 @@ import type {
   Branded,
 } from '@/library/typeUtilities/Branded';
 
-import HonoraryNonActionableError from './HonoraryNonActionableError';
+import NonActionableBuiltInError from './NonActionableBuiltInError';
 
 interface NonActionableError_Options extends ErrorOptions {
   /** A function that's acting as an alternative to raw `throw` */
@@ -58,7 +58,7 @@ class NonActionableError
     ) return givenError.throw();
 
     if (
-      HonoraryNonActionableError.describes(givenError)
+      NonActionableBuiltInError.describes(givenError)
     ) throw givenError; // eslint-disable-line no-restricted-syntax -- avoids wrapping built-in errors that are already non-actionable
 
     return this.throw(given.message, {

--- a/src/library/Attempt/error/assertions/assertActionable.ts
+++ b/src/library/Attempt/error/assertions/assertActionable.ts
@@ -32,12 +32,10 @@ const assertActionable = <
     definitelyActionableError !== null
   ) return definitelyActionableError;
 
-  if (
-    NonActionableBuiltInError.describes(givenError)
-  ) throw givenError; // eslint-disable-line no-restricted-syntax -- avoids wrapping built-in errors that are already non-actionable
-
   return NonActionableError.rethrow(potentiallyActionableError, {
-    message: 'Neglected to interpret or prevent potentially actionable error',
+    message: NonActionableBuiltInError.describes(givenError)
+      ? 'Neglected to prevent built-in error'
+      : 'Neglected to interpret or prevent potentially actionable error',
   });
 };
 

--- a/src/library/Attempt/error/assertions/assertActionable.ts
+++ b/src/library/Attempt/error/assertions/assertActionable.ts
@@ -37,7 +37,7 @@ const assertActionable = <
   ) throw givenError; // eslint-disable-line no-restricted-syntax -- avoids wrapping built-in errors that are already non-actionable
 
   return NonActionableError.rethrow(potentiallyActionableError, {
-    message: 'Expected error to be either interpreted or prevented altogether',
+    message: 'Neglected to interpret or prevent potentially actionable error',
   });
 };
 

--- a/src/library/Attempt/error/assertions/assertActionable.ts
+++ b/src/library/Attempt/error/assertions/assertActionable.ts
@@ -5,6 +5,8 @@ import {
 
 import type Attempt_ErrorInterpreter from '../Interpreter';
 
+import NonActionableBuiltInError from '../NonActionableBuiltInError';
+
 import {
   assertPotentiallyActionable,
 } from '../assertions';
@@ -29,6 +31,10 @@ const assertActionable = <
   if (
     definitelyActionableError !== null
   ) return definitelyActionableError;
+
+  if (
+    NonActionableBuiltInError.describes(givenError)
+  ) throw givenError; // eslint-disable-line no-restricted-syntax -- avoids wrapping built-in errors that are already non-actionable
 
   return NonActionableError.rethrow(potentiallyActionableError, {
     message: 'Expected error to be either interpreted or prevented altogether',

--- a/src/library/Attempt/error/assertions/assertPotentiallyActionable.ts
+++ b/src/library/Attempt/error/assertions/assertPotentiallyActionable.ts
@@ -16,8 +16,8 @@ const assertPotentiallyActionable = <
   ) return givenError as PotentiallyActionable<SomeError>;
 
   if (
-    givenError.rethrownError !== null
-  ) return givenError.rethrownError as PotentiallyActionable<SomeError>;
+    givenError.charge !== null
+  ) return givenError.charge as PotentiallyActionable<SomeError>;
 
   return givenError.throw();
 };


### PR DESCRIPTION
- before, built-in errors like `TypeError` and `RangeError` were treated as "unofficial" non-actionable errors
    - this was why we half-way committed to the paradigm, offering up these built-in errors for mapping to an "actionable" error, but then bypassing the "non-actionable" route by raw `throw`ing them
    - this ended up being problematic because, while is the intended use of these error classes, there are libraries that `throw` these errors with the expectation that consumers will indeed recover from them
- to avoid this problem, we now sanction only two classes of errors:
    - `ActionableError`s via `return` of `Attempt.Failure`
    - `NonActionableError`s via sanctioned `throw`
- all others that utilize an adapter must be categorized as:
    - "actionable" via the adapter's interpreter
    - "non-actionable" via `NonActionable.rethrow(...)`