### PR TITLE
fix(library/Attempt): prevents escort of `NonActionableError` for all its subclasses

### DIFF
--- a/src/library/Attempt/error/NonActionableError.ts
+++ b/src/library/Attempt/error/NonActionableError.ts
@@ -52,7 +52,7 @@ class NonActionableError
     },
   ): never => {
     if (
-      givenError instanceof this
+      givenError instanceof NonActionableError
     ) return givenError.throw();
 
     return this.throw(given.message, {


### PR DESCRIPTION
- non-actionable errors are already expected to propagate via `throw`, so there's no need to wrap them in a `NonActionableError` as long as they extend `NonActionableError`