### PR TITLE
fix(library/HTTP): plugs leaky abstraction

### DIFF
--- a/src/features/TextToImage/components/TextToImageServerConnectionAlert.vue
+++ b/src/features/TextToImage/components/TextToImageServerConnectionAlert.vue
@@ -15,7 +15,7 @@ defineProps<{
     type="error"
     title="Failed to Connect"
   >
-    Server not found at specified origin "{{ error.origin.toString() }}".<br>
+    Server not found at specified origin "{{ error.endpoint.origin }}".<br>
     <br>
     Ensure that:<br>
     a. the environment/config has the correct origin<br>

--- a/src/features/TextToImage/models/SDXL/client/index.ts
+++ b/src/features/TextToImage/models/SDXL/client/index.ts
@@ -4,6 +4,7 @@ import type {
 
 import Attempt from '@/library/Attempt';
 
+import HTTP from '@/library/HTTP';
 import ShimmedStabilityAIClient from '@/library/ShimmedStabilityAIClient/index.ts';
 
 import Base64CharacterEncodedByteSequence from '@/library/customTypes/Base64CharacterEncodedByteSequence.ts';
@@ -74,13 +75,11 @@ const generateOutputFrom = async (
 
   const outcomeOfSettlingTextToImageResponse = await Attempt.toSettle(promisedTextToImageResponse, {
     interpretationOf: (caughtError) => {
-      const clientFailedToReachServer = caughtError.message.includes('Failed to fetch');
-
       if (
-        !clientFailedToReachServer
+        !(caughtError instanceof HTTP.Endpoint.RequestError)
       ) return null;
 
-      return new Server.ConnectionError(shimmedStabilityAIClient.origin);
+      return new Server.ConnectionError(caughtError.endpoint);
     },
   });
 

--- a/src/features/TextToImage/webAPI/Server/ServerConnectionError.ts
+++ b/src/features/TextToImage/webAPI/Server/ServerConnectionError.ts
@@ -1,14 +1,10 @@
 import Attempt from '@/library/Attempt';
 
-import type {
-  URLOrigin,
-} from '@/library/customTypes/URLComponent';
-
 class TextToImage_Server_ConnectionError extends Attempt.ActionableError<'TextToImage_ServerConnectionError'> {
   public constructor(
-    public readonly origin: URLOrigin,
+    public readonly endpoint: URL,
   ) {
-    super(`Failed to reach the text-to-image server at "${origin.toString()}".`);
+    super(`Failed to reach the text-to-image server at "${endpoint.origin}".`);
     this.name = 'TextToImage_ServerConnectionError';
   }
 }

--- a/src/library/HTTP/Client.ts
+++ b/src/library/HTTP/Client.ts
@@ -46,11 +46,13 @@ class HTTP_Client {
       using: HTTP_Request.Method;
     },
   ): Promise<HTTP_Endpoint.Outcome> => Attempt.thatEventually(async (ends) => {
-    const response = await fetch(this.originAt(givenPath), {
+    const promisedResponse = fetch(this.originAt(givenPath), {
       method : givenMethod,
       headers: this.headers,
       body   : JSON.stringify(givenRequestBody),
     });
+
+    const response = await promisedResponse;
 
     if (
       !response.ok

--- a/src/library/HTTP/Client.ts
+++ b/src/library/HTTP/Client.ts
@@ -55,12 +55,22 @@ class HTTP_Client {
     });
 
     const outcomeOfSettlingResponse = await Attempt.toSettle(promisedResponse, {
-      interpretationOf: () => {
-        return null;
+      interpretationOf: (caughtError) => {
+        const clientFailedToReachServer = caughtError.message.includes('Failed to fetch');
+
+        if (
+          !clientFailedToReachServer
+        ) return null;
+
+        return new HTTP_Endpoint.RequestError(endpointURL);
       },
     });
 
-    const response = outcomeOfSettlingResponse.forciblyUnwrap();
+    if (
+      outcomeOfSettlingResponse.isFailure
+    ) return outcomeOfSettlingResponse;
+
+    const response = outcomeOfSettlingResponse.unwrapped;
 
     if (
       !response.ok

--- a/src/library/HTTP/Client.ts
+++ b/src/library/HTTP/Client.ts
@@ -46,7 +46,9 @@ class HTTP_Client {
       using: HTTP_Request.Method;
     },
   ): Promise<HTTP_Endpoint.Outcome> => Attempt.thatEventually(async (ends) => {
-    const promisedResponse = fetch(this.originAt(givenPath), {
+    const endpointURL = this.originAt(givenPath);
+
+    const promisedResponse = fetch(endpointURL, {
       method : givenMethod,
       headers: this.headers,
       body   : JSON.stringify(givenRequestBody),

--- a/src/library/HTTP/Client.ts
+++ b/src/library/HTTP/Client.ts
@@ -54,7 +54,13 @@ class HTTP_Client {
       body   : JSON.stringify(givenRequestBody),
     });
 
-    const response = await promisedResponse;
+    const outcomeOfSettlingResponse = await Attempt.toSettle(promisedResponse, {
+      interpretationOf: () => {
+        return null;
+      },
+    });
+
+    const response = outcomeOfSettlingResponse.forciblyUnwrap();
 
     if (
       !response.ok

--- a/src/library/HTTP/Endpoint/Outcome.ts
+++ b/src/library/HTTP/Endpoint/Outcome.ts
@@ -1,12 +1,16 @@
 import type Attempt from '@/library/Attempt';
 
 import type {
+  HTTP_Endpoint_RequestError,
+} from './RequestError';
+
+import type {
   HTTP_Endpoint_ResponseError,
 } from './ResponseError';
 
 type HTTP_Endpoint_Outcome = Attempt.Outcome<
   unknown,
-  HTTP_Endpoint_ResponseError
+  HTTP_Endpoint_RequestError | HTTP_Endpoint_ResponseError
 >;
 
 export type {

--- a/src/library/HTTP/Endpoint/RequestError.ts
+++ b/src/library/HTTP/Endpoint/RequestError.ts
@@ -1,0 +1,14 @@
+import Attempt from '@/library/Attempt';
+
+class HTTP_Endpoint_RequestError extends Attempt.ActionableError<'HTTP_Endpoint_RequestError'> {
+  public constructor(
+    public readonly endpoint: URL,
+  ) {
+    super(`Failed to fetch from "${endpoint.toString()}".`);
+    this.name = 'HTTP_Endpoint_RequestError';
+  }
+}
+
+export {
+  HTTP_Endpoint_RequestError,
+};

--- a/src/library/HTTP/Endpoint/exports.ts
+++ b/src/library/HTTP/Endpoint/exports.ts
@@ -1,4 +1,8 @@
 export {
+  HTTP_Endpoint_RequestError as RequestError,
+} from './RequestError';
+
+export {
   HTTP_Endpoint_ResponseError as ResponseError,
 } from './ResponseError';
 


### PR DESCRIPTION
- addresses generic error from `HTTP.Client` that was traveling up the call stack and intercepted in an unintuitive spot