### PR TITLE
refactor(library/typeUtilities): preps force parsers for replacement

### DIFF
--- a/src/library/customTypes/Base64CharacterEncodedByteSequence.ts
+++ b/src/library/customTypes/Base64CharacterEncodedByteSequence.ts
@@ -2,8 +2,8 @@ import * as Base64 from '@/library/Base64';
 import * as Byte from '@/library/Byte';
 
 import type {
-  StaticStringParser,
-} from '@/library/typeUtilities/StaticStringParser.ts';
+  StringForciblyParsable,
+} from '@/library/typeUtilities/StringForciblyParsable';
 
 import {
   droppingLastCharacter,
@@ -15,7 +15,7 @@ import StringSubset from './StringSubset.ts';
 /** See [RFC 4648 Section 4](https://www.rfc-editor.org/rfc/rfc4648.html#section-4) for more information */
 class Base64CharacterEncodedByteSequence
   extends StringSubset<'Base64CharacterEncodedByteSequence'>
-  implements StaticStringParser<typeof Base64CharacterEncodedByteSequence> {
+  implements StringForciblyParsable<typeof Base64CharacterEncodedByteSequence> {
   public static paddingCharacter = '=';
 
   private static readonly byteCofactor = Byte.cofactorTo(Base64.bitWidth);

--- a/src/library/customTypes/NonTrivialString/index.ts
+++ b/src/library/customTypes/NonTrivialString/index.ts
@@ -1,6 +1,6 @@
 import type {
-  StaticStringParser,
-} from '@/library/typeUtilities/StaticStringParser.ts';
+  StringForciblyParsable,
+} from '@/library/typeUtilities/StringForciblyParsable.ts';
 
 import {
   isEmpty,
@@ -12,7 +12,7 @@ import NonTrivialString_ParsingError from './ParsingError.ts';
 
 class NonTrivialString
   extends StringSubset<'NonTrivialString'>
-  implements StaticStringParser<typeof NonTrivialString> {
+  implements StringForciblyParsable<typeof NonTrivialString> {
   public static forciblyParsedFrom(givenSubject: string): NonTrivialString {
     const trimmedSubject = givenSubject.trim();
 

--- a/src/library/customTypes/URLComponent/URLOrigin.ts
+++ b/src/library/customTypes/URLComponent/URLOrigin.ts
@@ -5,8 +5,8 @@ import {
 import StringSubset from '@/library/customTypes/StringSubset.ts';
 
 import type {
-  StaticStringParser,
-} from '@/library/typeUtilities/StaticStringParser.ts';
+  StringForciblyParsable,
+} from '@/library/typeUtilities/StringForciblyParsable';
 
 class URLOrigin_ParsingError extends ParsingError<'URLOrigin'> {
   public constructor(given: {
@@ -20,7 +20,7 @@ class URLOrigin_ParsingError extends ParsingError<'URLOrigin'> {
 
 class URLOrigin
   extends StringSubset<'URLOrigin'>
-  implements StaticStringParser<typeof URLOrigin> {
+  implements StringForciblyParsable<typeof URLOrigin> {
   public static forciblyParsedFrom(givenSubject: string): URLOrigin {
     const derived = new URL(givenSubject);
 

--- a/src/library/customTypes/URLComponent/URLPath.ts
+++ b/src/library/customTypes/URLComponent/URLPath.ts
@@ -5,8 +5,8 @@ import {
 import StringSubset from '@/library/customTypes/StringSubset.ts';
 
 import type {
-  StaticStringParser,
-} from '@/library/typeUtilities/StaticStringParser.ts';
+  StringForciblyParsable,
+} from '@/library/typeUtilities/StringForciblyParsable';
 
 class URLPath_ParsingError extends ParsingError<'URLPath'> {
   public constructor(given: {
@@ -20,7 +20,7 @@ class URLPath_ParsingError extends ParsingError<'URLPath'> {
 
 class URLPath
   extends StringSubset<'URLPath'>
-  implements StaticStringParser<typeof URLPath> {
+  implements StringForciblyParsable<typeof URLPath> {
   public static forciblyParsedFrom(givenSubject: string): URLPath {
     const exampleURL = new URL(`https://example.com${givenSubject}`);
 

--- a/src/library/customTypes/UniformResourceIdentifier/Data/MediaType/index.ts
+++ b/src/library/customTypes/UniformResourceIdentifier/Data/MediaType/index.ts
@@ -1,6 +1,6 @@
 import type {
-  StaticStringParser,
-} from '@/library/typeUtilities/StaticStringParser';
+  StringForciblyParsable,
+} from '@/library/typeUtilities/StringForciblyParsable';
 
 import {
   isEmpty,
@@ -35,7 +35,7 @@ const allStructuredSyntaxNameSuffix = [
 type StructuredSyntaxNameSuffix = (typeof allStructuredSyntaxNameSuffix)[number];
 
 /** See [RFC 2045](https://datatracker.ietf.org/doc/html/rfc2045) for more information */
-class MediaType implements StaticStringParser<typeof MediaType> {
+class MediaType implements StringForciblyParsable<typeof MediaType> {
   public constructor(
     public fileType: FileType,
     public tree: string[] | null,

--- a/src/library/customTypes/UniformResourceIdentifier/index.ts
+++ b/src/library/customTypes/UniformResourceIdentifier/index.ts
@@ -3,8 +3,8 @@ import Attempt from '@/library/Attempt';
 import NonTrivialString from '@/library/customTypes/NonTrivialString';
 
 import type {
-  StaticStringParser,
-} from '@/library/typeUtilities/StaticStringParser';
+  StringForciblyParsable,
+} from '@/library/typeUtilities/StringForciblyParsable';
 
 import {
   isEmpty,
@@ -16,7 +16,7 @@ import URI_ParsingError from './ParsingError';
  * Identifies an abstract or physical resource.
  * See [RFC 3986](https://www.rfc-editor.org/rfc/rfc3986) for more information
  */
-class UniformResourceIdentifier implements StaticStringParser<typeof UniformResourceIdentifier> {
+class UniformResourceIdentifier implements StringForciblyParsable<typeof UniformResourceIdentifier> {
   private readonly _scheme: /*   */ NonTrivialString;
   private readonly _authority: /**/ NonTrivialString | null;
   private readonly _path: /*     */ NonTrivialString | null;

--- a/src/library/typeUtilities/ForcibleStringParser.ts
+++ b/src/library/typeUtilities/ForcibleStringParser.ts
@@ -1,0 +1,7 @@
+interface ForcibleStringParser<ParsedOutput> {
+  forciblyParsedFrom(givenSubject: string): ParsedOutput;
+}
+
+export type {
+  ForcibleStringParser as default,
+};

--- a/src/library/typeUtilities/StaticForcibleStringParser.ts
+++ b/src/library/typeUtilities/StaticForcibleStringParser.ts
@@ -1,0 +1,16 @@
+import type ForcibleStringParser from '@/library/typeUtilities/ForcibleStringParser';
+import type Static from '@/library/typeUtilities/Static.ts';
+
+type StaticForcibleStringParser<
+  Any,
+> =
+  & Static<
+    Any
+  >
+  & ForcibleStringParser<
+    Any
+  >;
+
+export type {
+  StaticForcibleStringParser,
+};

--- a/src/library/typeUtilities/StaticStringParser.ts
+++ b/src/library/typeUtilities/StaticStringParser.ts
@@ -1,12 +1,12 @@
+import type ForcibleStringParser from '@/library/typeUtilities/ForcibleStringParser';
 import type Static from '@/library/typeUtilities/Static.ts';
-import type StringParser from '@/library/typeUtilities/StringParser.ts';
 
 type StaticStringParser<
   SomeClassType extends
   & Static<
     SomeClassType['prototype']
   >
-  & StringParser<
+  & ForcibleStringParser<
     SomeClassType['prototype']
   >,
 > = SomeClassType['prototype'];

--- a/src/library/typeUtilities/StringForciblyParsable.ts
+++ b/src/library/typeUtilities/StringForciblyParsable.ts
@@ -1,12 +1,9 @@
-import type ForcibleStringParser from '@/library/typeUtilities/ForcibleStringParser';
-import type Static from '@/library/typeUtilities/Static.ts';
+import type {
+  StaticForcibleStringParser,
+} from './StaticForcibleStringParser';
 
 type StringForciblyParsable<
-  SomeClassType extends
-  & Static<
-    SomeClassType['prototype']
-  >
-  & ForcibleStringParser<
+  SomeClassType extends StaticForcibleStringParser<
     SomeClassType['prototype']
   >,
 > = SomeClassType['prototype'];

--- a/src/library/typeUtilities/StringForciblyParsable.ts
+++ b/src/library/typeUtilities/StringForciblyParsable.ts
@@ -1,7 +1,7 @@
 import type ForcibleStringParser from '@/library/typeUtilities/ForcibleStringParser';
 import type Static from '@/library/typeUtilities/Static.ts';
 
-type StaticStringParser<
+type StringForciblyParsable<
   SomeClassType extends
   & Static<
     SomeClassType['prototype']
@@ -12,5 +12,5 @@ type StaticStringParser<
 > = SomeClassType['prototype'];
 
 export type {
-  StaticStringParser,
+  StringForciblyParsable,
 };

--- a/src/library/typeUtilities/StringParser.ts
+++ b/src/library/typeUtilities/StringParser.ts
@@ -1,7 +1,0 @@
-interface StringParser<ParsedOutput> {
-  forciblyParsedFrom(givenSubject: string): ParsedOutput;
-}
-
-export type {
-  StringParser as default,
-};


### PR DESCRIPTION
- frees up the namespaces to be used for their error-safe counterparts