### PR TITLE
linter: enforces extensible function signatures

### DIFF
--- a/eslint.stylistic.ts
+++ b/eslint.stylistic.ts
@@ -10,6 +10,10 @@ const extraConfig: ConfigWithExtends = {
     '@stylistic': stylistic,
   },
   rules: {
+    '@stylistic/function-call-argument-newline': [
+      'error',
+      'consistent', // Helps minimize diffs and mitigate merge conflicts.
+    ],
     '@stylistic/key-spacing': [
       'error',
       {

--- a/eslint.stylistic.ts
+++ b/eslint.stylistic.ts
@@ -14,6 +14,10 @@ const extraConfig: ConfigWithExtends = {
       'error',
       'consistent', // Helps minimize diffs and mitigate merge conflicts.
     ],
+    '@stylistic/function-paren-newline': [
+      'error',
+      'multiline-arguments', // Helps minimize diffs and mitigate merge conflicts. Avoids asymmetry and grouping in function signatures.
+    ],
     '@stylistic/key-spacing': [
       'error',
       {


### PR DESCRIPTION
These linter rules make it easier to add new lines to function signatures

Tweaking function signatures is a common occurrence when refactoring any part of the codebase
  - it usually involves renaming the functions and modifying the arguments/parameters
  - doing this is easier to glean from diffs and less prone to merge conflicts when new lines are included