### PR TITLE
refactor(text-to-image): extracts conversions from SDXL client

### DIFF
--- a/src/features/TextToImage/models/SDXL/client/conversions/TextPrompt.ts
+++ b/src/features/TextToImage/models/SDXL/client/conversions/TextPrompt.ts
@@ -1,0 +1,31 @@
+import type {
+  TextPrompt,
+} from 'stabilityai-client-typescript/models/components';
+
+const isDefault = (
+  givenWeight: TextPrompt['weight'],
+) => {
+  return (givenWeight === undefined) || (givenWeight === 1);
+};
+
+const serialized = (
+  givenPrompt: TextPrompt,
+): string => {
+  if (
+    isDefault(givenPrompt.weight)
+  ) return givenPrompt.text;
+
+  return `(${givenPrompt.text}: ${givenPrompt.weight.toString()})`;
+};
+
+const allSerialized = (
+  givenPrompts: TextPrompt[],
+): string => {
+  return givenPrompts
+    .map(serialized)
+    .join(', ');
+};
+
+export {
+  allSerialized,
+};

--- a/src/features/TextToImage/models/SDXL/client/index.ts
+++ b/src/features/TextToImage/models/SDXL/client/index.ts
@@ -11,6 +11,10 @@ import Base64CharacterEncodedByteSequence from '@/library/customTypes/Base64Char
 
 import ImageURI from '@/library/customTypes/UniformResourceIdentifier/Data/Image/index.ts';
 
+import {
+  allSerialized,
+} from '@/features/TextToImage/models/SDXL/client/conversions/TextPrompt';
+
 import type {
   Output,
 } from '@/features/TextToImage/types';
@@ -113,12 +117,7 @@ const generateOutputFrom = async (
 
   const newImage = {
     uri        : new ImageURI('png', 'base64', base64DataOfNewImage),
-    description: given.textToImageRequestBody.textPrompts
-      .map($0 => (($0.weight === undefined) || ($0.weight === 1))
-        ? $0.text
-        : `(${$0.text}: ${$0.weight.toString()})`,
-      )
-      .join(', '),
+    description: allSerialized(given.textToImageRequestBody.textPrompts),
   };
 
   return ends.inSuccessWith({


### PR DESCRIPTION
- pointed out by #389, but the overlapping levels of abstractions was the actual source of the diff noise rather than style 