### PR TITLE
refactor(library): preps string parsers for migration to type-safe error propagation

### DIFF
--- a/src/library/customTypes/Base64CharacterEncodedByteSequence.ts
+++ b/src/library/customTypes/Base64CharacterEncodedByteSequence.ts
@@ -38,9 +38,9 @@ class Base64CharacterEncodedByteSequence
     return [remainingSequence, accumulatedPadding];
   }
 
-  public static forciblyParsedFrom(
+  public static forciblyParsedFrom = (
     givenCharacters: string,
-  ): Base64CharacterEncodedByteSequence {
+  ): Base64CharacterEncodedByteSequence => {
     const paddedByteEncodableCharacters = Byte.Sequence.assertEncodable(givenCharacters, {
       assuming: Base64.bitWidth,
     });
@@ -49,7 +49,7 @@ class Base64CharacterEncodedByteSequence
     const base64ByteEncodableCharacters = Base64.CharacterSequence.assertConformanceOf(byteEncodableCharacters);
     const base64CharacterEncodedByteSequence = base64ByteEncodableCharacters + padding;
     return new this(base64CharacterEncodedByteSequence);
-  }
+  };
 }
 
 export {

--- a/src/library/customTypes/NonTrivialString/index.ts
+++ b/src/library/customTypes/NonTrivialString/index.ts
@@ -13,7 +13,9 @@ import NonTrivialString_ParsingError from './ParsingError.ts';
 class NonTrivialString
   extends StringSubset<'NonTrivialString'>
   implements StringForciblyParsable<typeof NonTrivialString> {
-  public static forciblyParsedFrom(givenSubject: string): NonTrivialString {
+  public static forciblyParsedFrom(
+    givenSubject: string,
+  ): NonTrivialString {
     const trimmedSubject = givenSubject.trim();
 
     if (
@@ -23,7 +25,9 @@ class NonTrivialString
     return new NonTrivialString(givenSubject);
   }
 
-  public static nullableForciblyParsedFrom(givenSubject: string | null): NonTrivialString | null {
+  public static nullableForciblyParsedFrom(
+    givenSubject: string | null,
+  ): NonTrivialString | null {
     if (givenSubject === null) return givenSubject;
 
     return this.forciblyParsedFrom(givenSubject);

--- a/src/library/customTypes/NonTrivialString/index.ts
+++ b/src/library/customTypes/NonTrivialString/index.ts
@@ -13,9 +13,9 @@ import NonTrivialString_ParsingError from './ParsingError.ts';
 class NonTrivialString
   extends StringSubset<'NonTrivialString'>
   implements StringForciblyParsable<typeof NonTrivialString> {
-  public static forciblyParsedFrom(
+  public static forciblyParsedFrom = (
     givenSubject: string,
-  ): NonTrivialString {
+  ): NonTrivialString => {
     const trimmedSubject = givenSubject.trim();
 
     if (
@@ -23,15 +23,15 @@ class NonTrivialString
     ) return new NonTrivialString_ParsingError(givenSubject).throwAnyway('To be converted to `Attempt` failure');
 
     return new NonTrivialString(givenSubject);
-  }
+  };
 
-  public static nullableForciblyParsedFrom(
+  public static nullableForciblyParsedFrom = (
     givenSubject: string | null,
-  ): NonTrivialString | null {
+  ): NonTrivialString | null => {
     if (givenSubject === null) return givenSubject;
 
     return this.forciblyParsedFrom(givenSubject);
-  }
+  };
 
   public isEqualTo(that: NonTrivialString): boolean {
     return this.toString() === that.toString();

--- a/src/library/customTypes/URLComponent/URLOrigin.ts
+++ b/src/library/customTypes/URLComponent/URLOrigin.ts
@@ -21,7 +21,9 @@ class URLOrigin_ParsingError extends ParsingError<'URLOrigin'> {
 class URLOrigin
   extends StringSubset<'URLOrigin'>
   implements StringForciblyParsable<typeof URLOrigin> {
-  public static forciblyParsedFrom(givenSubject: string): URLOrigin {
+  public static forciblyParsedFrom(
+    givenSubject: string,
+  ): URLOrigin {
     const derived = new URL(givenSubject);
 
     if (

--- a/src/library/customTypes/URLComponent/URLOrigin.ts
+++ b/src/library/customTypes/URLComponent/URLOrigin.ts
@@ -21,9 +21,9 @@ class URLOrigin_ParsingError extends ParsingError<'URLOrigin'> {
 class URLOrigin
   extends StringSubset<'URLOrigin'>
   implements StringForciblyParsable<typeof URLOrigin> {
-  public static forciblyParsedFrom(
+  public static forciblyParsedFrom = (
     givenSubject: string,
-  ): URLOrigin {
+  ): URLOrigin => {
     const derived = new URL(givenSubject);
 
     if (
@@ -34,7 +34,7 @@ class URLOrigin
     }).throwAnyway('To be converted to `Attempt` failure');
 
     return new URLOrigin(derived.origin);
-  }
+  };
 }
 
 export {

--- a/src/library/customTypes/URLComponent/URLPath.ts
+++ b/src/library/customTypes/URLComponent/URLPath.ts
@@ -21,9 +21,9 @@ class URLPath_ParsingError extends ParsingError<'URLPath'> {
 class URLPath
   extends StringSubset<'URLPath'>
   implements StringForciblyParsable<typeof URLPath> {
-  public static forciblyParsedFrom(
+  public static forciblyParsedFrom = (
     givenSubject: string,
-  ): URLPath {
+  ): URLPath => {
     const exampleURL = new URL(`https://example.com${givenSubject}`);
 
     if (
@@ -34,7 +34,7 @@ class URLPath
     }).throwAnyway('To be converted to `Attempt` failure');
 
     return new URLPath(exampleURL.pathname);
-  }
+  };
 }
 
 export {

--- a/src/library/customTypes/URLComponent/URLPath.ts
+++ b/src/library/customTypes/URLComponent/URLPath.ts
@@ -21,7 +21,9 @@ class URLPath_ParsingError extends ParsingError<'URLPath'> {
 class URLPath
   extends StringSubset<'URLPath'>
   implements StringForciblyParsable<typeof URLPath> {
-  public static forciblyParsedFrom(givenSubject: string): URLPath {
+  public static forciblyParsedFrom(
+    givenSubject: string,
+  ): URLPath {
     const exampleURL = new URL(`https://example.com${givenSubject}`);
 
     if (

--- a/src/library/customTypes/UniformResourceIdentifier/Data/Image/index.ts
+++ b/src/library/customTypes/UniformResourceIdentifier/Data/Image/index.ts
@@ -47,7 +47,9 @@ class ImageURI extends DataURI {
     );
   }
 
-  public static override forciblyParsedFrom(givenSubject: string): ImageURI {
+  public static override forciblyParsedFrom(
+    givenSubject: string,
+  ): ImageURI {
     const proposedURI = super.forciblyParsedFrom(givenSubject);
 
     if (

--- a/src/library/customTypes/UniformResourceIdentifier/Data/Image/index.ts
+++ b/src/library/customTypes/UniformResourceIdentifier/Data/Image/index.ts
@@ -47,9 +47,9 @@ class ImageURI extends DataURI {
     );
   }
 
-  public static override forciblyParsedFrom(
+  public static override forciblyParsedFrom = (
     givenSubject: string,
-  ): ImageURI {
+  ): ImageURI => {
     const proposedURI = super.forciblyParsedFrom(givenSubject);
 
     if (
@@ -67,7 +67,7 @@ class ImageURI extends DataURI {
       proposedURI.encoding,
       proposedURI.data,
     );
-  }
+  };
 }
 
 export {

--- a/src/library/customTypes/UniformResourceIdentifier/Data/MediaType/index.ts
+++ b/src/library/customTypes/UniformResourceIdentifier/Data/MediaType/index.ts
@@ -94,7 +94,9 @@ class MediaType implements StringForciblyParsable<typeof MediaType> {
     return components.map($0 => $0 ?? '').join('');
   }
 
-  public static forciblyParsedFrom(givenSubject: string): MediaType {
+  public static forciblyParsedFrom(
+    givenSubject: string,
+  ): MediaType {
     const [
       rawFileType,
       remainderAfterFileType,

--- a/src/library/customTypes/UniformResourceIdentifier/Data/MediaType/index.ts
+++ b/src/library/customTypes/UniformResourceIdentifier/Data/MediaType/index.ts
@@ -94,9 +94,9 @@ class MediaType implements StringForciblyParsable<typeof MediaType> {
     return components.map($0 => $0 ?? '').join('');
   }
 
-  public static forciblyParsedFrom(
+  public static forciblyParsedFrom = (
     givenSubject: string,
-  ): MediaType {
+  ): MediaType => {
     const [
       rawFileType,
       remainderAfterFileType,
@@ -186,7 +186,7 @@ class MediaType implements StringForciblyParsable<typeof MediaType> {
       structureType,
       Object.fromEntries(parameterEntries),
     );
-  }
+  };
 }
 
 export {

--- a/src/library/customTypes/UniformResourceIdentifier/Data/index.ts
+++ b/src/library/customTypes/UniformResourceIdentifier/Data/index.ts
@@ -70,9 +70,9 @@ class DataURI extends UniformResourceIdentifier {
     return NonTrivialString.forciblyParsedFrom(components.join(''));
   }
 
-  public static override forciblyParsedFrom(
+  public static override forciblyParsedFrom = (
     givenSubject: string,
-  ): DataURI {
+  ): DataURI => {
     const proposedURI = super.forciblyParsedFrom(givenSubject);
 
     if (
@@ -118,7 +118,7 @@ class DataURI extends UniformResourceIdentifier {
       coercedEncoding,
       Base64CharacterEncodedByteSequence.forciblyParsedFrom(rawData),
     );
-  }
+  };
 }
 
 export {

--- a/src/library/customTypes/UniformResourceIdentifier/Data/index.ts
+++ b/src/library/customTypes/UniformResourceIdentifier/Data/index.ts
@@ -70,7 +70,9 @@ class DataURI extends UniformResourceIdentifier {
     return NonTrivialString.forciblyParsedFrom(components.join(''));
   }
 
-  public static override forciblyParsedFrom(givenSubject: string): DataURI {
+  public static override forciblyParsedFrom(
+    givenSubject: string,
+  ): DataURI {
     const proposedURI = super.forciblyParsedFrom(givenSubject);
 
     if (

--- a/src/library/customTypes/UniformResourceIdentifier/index.ts
+++ b/src/library/customTypes/UniformResourceIdentifier/index.ts
@@ -100,7 +100,9 @@ class UniformResourceIdentifier implements StringForciblyParsable<typeof Uniform
     return components.map($0 => $0 ?? '').join('');
   }
 
-  public static forciblyParsedFrom(givenSubject: string): UniformResourceIdentifier {
+  public static forciblyParsedFrom(
+    givenSubject: string,
+  ): UniformResourceIdentifier {
     const {
       schemeSuffix,
       authorityPrefix,

--- a/src/library/customTypes/UniformResourceIdentifier/index.ts
+++ b/src/library/customTypes/UniformResourceIdentifier/index.ts
@@ -100,9 +100,9 @@ class UniformResourceIdentifier implements StringForciblyParsable<typeof Uniform
     return components.map($0 => $0 ?? '').join('');
   }
 
-  public static forciblyParsedFrom(
+  public static forciblyParsedFrom = (
     givenSubject: string,
-  ): UniformResourceIdentifier {
+  ): UniformResourceIdentifier => {
     const {
       schemeSuffix,
       authorityPrefix,
@@ -191,7 +191,7 @@ class UniformResourceIdentifier implements StringForciblyParsable<typeof Uniform
       NonTrivialString.nullableForciblyParsedFrom(query),
       NonTrivialString.nullableForciblyParsedFrom(fragment),
     );
-  }
+  };
 }
 
 export {


### PR DESCRIPTION
- frontloads the changes that will be needed to adopt the `Attempt` utility and are common to all the string parsers, but add a bit of noise to the diffs to come