### PR TITLE
refactor: standardizes guards

### DIFF
--- a/src/components/DiscreteSlider.vue
+++ b/src/components/DiscreteSlider.vue
@@ -54,10 +54,11 @@ const stylisticOffset = (
   const leftwardOffset = -endpointOffset;
   const rightwardOffset = endpointOffset;
 
-  if (givenPosition === givenRange.lowerBound) return leftwardOffset;
-  if (givenPosition === givenRange.upperBound) return rightwardOffset;
-
-  return defaultOffset;
+  switch (givenPosition) {
+    case givenRange.lowerBound: return leftwardOffset;
+    case givenRange.upperBound: return rightwardOffset;
+    default /*             */ : return defaultOffset;
+  }
 };
 
 type SliderTickLabel = string;

--- a/src/components/NavigationPanel.vue
+++ b/src/components/NavigationPanel.vue
@@ -26,11 +26,12 @@ const PanelWidth = {
       xl,
     } = given.thresholds;
 
-    /**/ if (given.width <= md) return 1.00;
-    else if (given.width <= lg) return 1.50;
-    else if (given.width <= xl) return 2.00;
-
-    return 2.50;
+    switch (true) {
+      case (given.width <= md): return 1.00;
+      case (given.width <= lg): return 1.50;
+      case (given.width <= xl): return 2.00;
+      default /*           */ : return 2.50;
+    }
   },
   for(
     givenDisplay: Display,

--- a/src/features/TextToImage/config/utilities/DynamicConfig/index.ts
+++ b/src/features/TextToImage/config/utilities/DynamicConfig/index.ts
@@ -15,7 +15,9 @@ import DynamicConfig_FetchingError from './FetchingError';
 const contentIsJSONIn = (givenResponse: Response): boolean => {
   const contentType = givenResponse.headers.get('Content-Type');
 
-  if (contentType === null) return false;
+  if (
+    contentType === null
+  ) return false;
 
   return contentType.includes('application/json');
 };

--- a/src/library/customTypes/NonTrivialString/index.ts
+++ b/src/library/customTypes/NonTrivialString/index.ts
@@ -28,7 +28,9 @@ class NonTrivialString
   public static nullableForciblyParsedFrom = (
     givenSubject: string | null,
   ): NonTrivialString | null => {
-    if (givenSubject === null) return givenSubject;
+    if (
+      givenSubject === null
+    ) return givenSubject;
 
     return this.forciblyParsedFrom(givenSubject);
   };

--- a/src/library/customTypes/UniformResourceIdentifier/Data/MediaType/index.ts
+++ b/src/library/customTypes/UniformResourceIdentifier/Data/MediaType/index.ts
@@ -55,7 +55,9 @@ class MediaType implements StringForciblyParsable<typeof MediaType> {
   public static readonly treeBranchSuffix = '.';
 
   private get suffixedTree(): string | null {
-    if (this.tree === null) return null;
+    if (
+      this.tree === null
+    ) return null;
 
     return this.tree
       .map($0 => $0 + MediaType.treeBranchSuffix)
@@ -65,7 +67,9 @@ class MediaType implements StringForciblyParsable<typeof MediaType> {
   public static readonly structureTypePrefix = '+';
 
   private get prefixedStructureType(): string | null {
-    if (this.structureType === null) return null;
+    if (
+      this.structureType === null
+    ) return null;
 
     return MediaType.structureTypePrefix + this.structureType;
   }
@@ -74,7 +78,9 @@ class MediaType implements StringForciblyParsable<typeof MediaType> {
   public static readonly parameterKeyValueDelimiter = '=';
 
   private get prefixedParameters(): string | null {
-    if (this.parameters === null) return null;
+    if (
+      this.parameters === null
+    ) return null;
 
     return Object.entries(this.parameters)
       .map($0 => MediaType.parameterPrefix + $0.join(MediaType.parameterKeyValueDelimiter))
@@ -154,7 +160,9 @@ class MediaType implements StringForciblyParsable<typeof MediaType> {
     ) return new MediaType_ParsingError(`Unexpected component sets after extraneous structure type prefix(es): ${extraComponentsWithStructureTypePrefix.toString()}`).throwAnyway('To be converted to `Attempt` failure');
 
     const structureType = (() => {
-      if (rawStructureType === undefined) return null;
+      if (
+        rawStructureType === undefined
+      ) return null;
 
       const potentialStructureType = allStructuredSyntaxNameSuffix.find($0 => $0 === rawStructureType);
 

--- a/src/library/customTypes/UniformResourceIdentifier/index.ts
+++ b/src/library/customTypes/UniformResourceIdentifier/index.ts
@@ -66,7 +66,9 @@ class UniformResourceIdentifier implements StringForciblyParsable<typeof Uniform
   public static readonly authorityPrefix = '//';
 
   private get prefixedAuthority(): string | null {
-    if (this.authority === null) return null;
+    if (
+      this.authority === null
+    ) return null;
 
     return UniformResourceIdentifier.authorityPrefix + this.authority.toString();
   }
@@ -74,7 +76,9 @@ class UniformResourceIdentifier implements StringForciblyParsable<typeof Uniform
   public static readonly queryPrefix = '?';
 
   private get prefixedQuery(): string | null {
-    if (this.query === null) return null;
+    if (
+      this.query === null
+    ) return null;
 
     return UniformResourceIdentifier.queryPrefix + this.query.toString();
   }
@@ -82,7 +86,9 @@ class UniformResourceIdentifier implements StringForciblyParsable<typeof Uniform
   public static readonly fragmentPrefix = '#';
 
   private get prefixedFragment(): string | null {
-    if (this.fragment === null) return null;
+    if (
+      this.fragment === null
+    ) return null;
 
     return UniformResourceIdentifier.fragmentPrefix + this.fragment.toString();
   }
@@ -163,7 +169,9 @@ class UniformResourceIdentifier implements StringForciblyParsable<typeof Uniform
         path: `${typeof pathSegmentDelimiter}${string}`;
       }
     ) => {
-      if (!componentsPrecedingQuery.startsWith(authorityPrefix)) return ({
+      if (
+        !componentsPrecedingQuery.startsWith(authorityPrefix)
+      ) return ({
         authority: null,
         path     : componentsPrecedingQuery,
       });


### PR DESCRIPTION
- prefers `switch` over chain of guard statements for readability
- modifies remaining guards to give each of their conditions its own line for diffability