### PR TITLE
prefeature(library/Parser): defines string parsers with type-safe errors

### DIFF
--- a/src/library/Parser/string/StaticStringParser.ts
+++ b/src/library/Parser/string/StaticStringParser.ts
@@ -1,0 +1,22 @@
+import type Static from '@/library/typeUtilities/Static';
+
+import type ParsingError from '../ParsingError';
+
+import type {
+  StringParser,
+} from './StringParser';
+
+type StaticStringParser<
+  Any,
+> =
+  & Static<
+    Any
+  >
+  & StringParser<
+    Any,
+    ParsingError<string>
+  >;
+
+export type {
+  StaticStringParser,
+};

--- a/src/library/Parser/string/StringParsable.ts
+++ b/src/library/Parser/string/StringParsable.ts
@@ -1,0 +1,17 @@
+import type {
+  StaticStringParser,
+} from './StaticStringParser';
+
+/**
+ * Some classes need a factory that parses strings into an instance.
+ * Implement this type to ensure that the class follows the standard interface for this.
+ */
+type StringParsable<
+  SomeClassType extends StaticStringParser<
+    SomeClassType['prototype']
+  >,
+> = SomeClassType['prototype'];
+
+export type {
+  StringParsable,
+};

--- a/src/library/Parser/string/StringParser.ts
+++ b/src/library/Parser/string/StringParser.ts
@@ -1,0 +1,11 @@
+import type Parser from '..';
+import type ParsingError from '../ParsingError';
+
+type StringParser<
+  SomeParsedOutput,
+  SomeParsingError extends ParsingError<string>,
+> = Parser<string, SomeParsedOutput, SomeParsingError>;
+
+export type {
+  StringParser,
+};

--- a/src/library/Parser/string/index.ts
+++ b/src/library/Parser/string/index.ts
@@ -1,0 +1,3 @@
+export type {
+  StringParsable,
+} from './StringParsable';


### PR DESCRIPTION
- follows up on #388 