### PR TITLE
refactor(library/URLOrigin): propagates parsing errors safely

### DIFF
--- a/src/library/ShimmedStabilityAIClient/index.ts
+++ b/src/library/ShimmedStabilityAIClient/index.ts
@@ -150,7 +150,7 @@ class ShimmedStabilityAIClient extends HTTP.Client {
     serverURL: string;
   }) {
     super({
-      origin : URLOrigin.forciblyParsedFrom(given.serverURL),
+      origin : URLOrigin.parsedFrom(given.serverURL).forciblyUnwrap(),
       headers: {
         'Content-Type': 'application/json',
       },

--- a/src/library/customTypes/URLComponent/URLOrigin.ts
+++ b/src/library/customTypes/URLComponent/URLOrigin.ts
@@ -35,7 +35,8 @@ class URLOrigin
       derived.origin !== givenSubject
     ) return newParsingError.throwAnyway('To be converted to `Attempt` failure');
 
-    return new URLOrigin(derived.origin);
+    const parsedURLOrigin = new URLOrigin(derived.origin);
+    return parsedURLOrigin;
   };
 }
 

--- a/src/library/customTypes/URLComponent/URLOrigin.ts
+++ b/src/library/customTypes/URLComponent/URLOrigin.ts
@@ -1,12 +1,14 @@
+import Attempt from '@/library/Attempt';
+
 import {
   ParsingError,
 } from '@/library/Parser';
 
-import StringSubset from '@/library/customTypes/StringSubset.ts';
-
 import type {
-  StringForciblyParsable,
-} from '@/library/typeUtilities/StringForciblyParsable';
+  StringParsable,
+} from '@/library/Parser/string';
+
+import StringSubset from '@/library/customTypes/StringSubset.ts';
 
 class URLOrigin_ParsingError extends ParsingError<'URLOrigin'> {
   public constructor(given: {
@@ -20,10 +22,10 @@ class URLOrigin_ParsingError extends ParsingError<'URLOrigin'> {
 
 class URLOrigin
   extends StringSubset<'URLOrigin'>
-  implements StringForciblyParsable<typeof URLOrigin> {
-  public static forciblyParsedFrom = (
+  implements StringParsable<typeof URLOrigin> {
+  public static parsedFrom = (
     givenSubject: string,
-  ): URLOrigin => {
+  ): Attempt.Outcome<URLOrigin, URLOrigin_ParsingError> => Attempt.that((ends) => {
     const derived = new URL(givenSubject);
 
     const newParsingError = new URLOrigin_ParsingError({
@@ -33,11 +35,11 @@ class URLOrigin
 
     if (
       derived.origin !== givenSubject
-    ) return newParsingError.throwAnyway('To be converted to `Attempt` failure');
+    ) return ends.inFailureDueTo(newParsingError);
 
     const parsedURLOrigin = new URLOrigin(derived.origin);
-    return parsedURLOrigin;
-  };
+    return ends.inSuccessWith(parsedURLOrigin);
+  });
 }
 
 export {

--- a/src/library/customTypes/URLComponent/URLOrigin.ts
+++ b/src/library/customTypes/URLComponent/URLOrigin.ts
@@ -26,12 +26,14 @@ class URLOrigin
   ): URLOrigin => {
     const derived = new URL(givenSubject);
 
-    if (
-      derived.origin !== givenSubject
-    ) return new URLOrigin_ParsingError({
+    const newParsingError = new URLOrigin_ParsingError({
       expectation: derived.origin,
       reality    : givenSubject,
-    }).throwAnyway('To be converted to `Attempt` failure');
+    });
+
+    if (
+      derived.origin !== givenSubject
+    ) return newParsingError.throwAnyway('To be converted to `Attempt` failure');
 
     return new URLOrigin(derived.origin);
   };


### PR DESCRIPTION
- see PR commits for refactor operations