### PR TITLE
linter: enforces style of import groupings

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -1,11 +1,14 @@
 import pluginVitest from '@vitest/eslint-plugin';
+
 import {
   defineConfigWithVueTs,
   vueTsConfigs,
 } from '@vue/eslint-config-typescript';
+
 // @ts-expect-error https://github.com/cypress-io/eslint-plugin-cypress/issues/232
 import pluginCypress from 'eslint-plugin-cypress';
 import pluginVue from 'eslint-plugin-vue';
+
 import tseslint, {
   type ConfigWithExtends,
 } from 'typescript-eslint';

--- a/eslint.import.ts
+++ b/eslint.import.ts
@@ -48,7 +48,12 @@ const extraConfig: ConfigWithExtends = {
             position: 'after',
           },
           {
-            pattern : '@/**', // Alias for "src/**"
+            pattern : '@/!{features}/**', // Alias for "src/**"
+            group   : 'internal',
+            position: 'after',
+          },
+          {
+            pattern : '@/features/**', // Highlights the business logic of the application
             group   : 'internal',
             position: 'after',
           },

--- a/eslint.import.ts
+++ b/eslint.import.ts
@@ -58,8 +58,9 @@ const extraConfig: ConfigWithExtends = {
             position: 'after',
           },
         ],
-        'newlines-between': 'always-and-inside-groups',
-        'alphabetize'     : {
+        'newlines-between'  : 'always-and-inside-groups',
+        'consolidateIslands': 'inside-groups',
+        'alphabetize'       : {
           order: 'asc',
         },
       },

--- a/src/components/DiscreteSlider.vue
+++ b/src/components/DiscreteSlider.vue
@@ -7,9 +7,11 @@ import {
 import {
   VBtn,
 } from 'vuetify/components/VBtn';
+
 import {
   VCard,
 } from 'vuetify/components/VCard';
+
 import {
   VSlider,
 } from 'vuetify/components/VSlider';

--- a/src/components/NavigationPanel.vue
+++ b/src/components/NavigationPanel.vue
@@ -7,6 +7,7 @@ import {
 import {
   VNavigationDrawer,
 } from 'vuetify/components/VNavigationDrawer';
+
 import {
   useDisplay,
 } from 'vuetify/framework';

--- a/src/features/TextToImage/components/TextToImageInputSection.vue
+++ b/src/features/TextToImage/components/TextToImageInputSection.vue
@@ -9,9 +9,11 @@ import {
 import {
   watch,
 } from 'vue';
+
 import {
   VCard,
 } from 'vuetify/components/VCard';
+
 import {
   VTextarea,
 } from 'vuetify/components/VTextarea';

--- a/src/features/TextToImage/models/SDXL/client/index.ts
+++ b/src/features/TextToImage/models/SDXL/client/index.ts
@@ -3,12 +3,9 @@ import type {
 } from 'stabilityai-client-typescript/models/operations';
 
 import Attempt from '@/library/Attempt';
-
 import HTTP from '@/library/HTTP';
 import ShimmedStabilityAIClient from '@/library/ShimmedStabilityAIClient/index.ts';
-
 import Base64CharacterEncodedByteSequence from '@/library/customTypes/Base64CharacterEncodedByteSequence.ts';
-
 import ImageURI from '@/library/customTypes/UniformResourceIdentifier/Data/Image/index.ts';
 
 import {
@@ -18,6 +15,7 @@ import {
 import type {
   Output,
 } from '@/features/TextToImage/types';
+
 import {
   Server,
 } from '@/features/TextToImage/webAPI';

--- a/src/library/Attempt/adapter/asynchronous.ts
+++ b/src/library/Attempt/adapter/asynchronous.ts
@@ -5,6 +5,7 @@ import type {
 import type {
   ActionableError,
 } from '../error';
+
 import {
   assertActionable,
 } from '../error/assertions';

--- a/src/library/Attempt/adapter/synchronous.ts
+++ b/src/library/Attempt/adapter/synchronous.ts
@@ -5,6 +5,7 @@ import type {
 import type {
   ActionableError,
 } from '../error';
+
 import {
   assertActionable,
 } from '../error/assertions';

--- a/src/library/Attempt/error/assertions/assertActionable.ts
+++ b/src/library/Attempt/error/assertions/assertActionable.ts
@@ -4,7 +4,6 @@ import {
 } from '..';
 
 import type Attempt_ErrorInterpreter from '../Interpreter';
-
 import NonActionableBuiltInError from '../NonActionableBuiltInError';
 
 import {

--- a/src/library/Attempt/utilities/sanctionedTryCatch.ts
+++ b/src/library/Attempt/utilities/sanctionedTryCatch.ts
@@ -5,6 +5,7 @@ import {
 import {
   assertAppropriatelyThrown,
 } from '../error/assertions';
+
 import type {
   AppropriatelyThrown,
 } from '../error/modifier';

--- a/src/library/HTTP/Response/StatusCode/Error/Any.ts
+++ b/src/library/HTTP/Response/StatusCode/Error/Any.ts
@@ -1,6 +1,7 @@
 import type {
   HTTP_Response_StatusCode_Error_Client,
 } from './Client';
+
 import type {
   HTTP_Response_StatusCode_Error_Server,
 } from './Server';

--- a/src/library/ShimmedStabilityAIClient/index.ts
+++ b/src/library/ShimmedStabilityAIClient/index.ts
@@ -1,6 +1,7 @@
 import type {
   TextToImageRequestBody,
 } from 'stabilityai-client-typescript/models/components';
+
 import type {
   GenerateFromTextRequest,
   GenerateFromTextResponse,
@@ -11,7 +12,6 @@ import {
 } from 'zod/v4';
 
 import HTTP from '@/library/HTTP';
-
 import Base64CharacterEncodedByteSequence from '@/library/customTypes/Base64CharacterEncodedByteSequence.ts';
 
 import {

--- a/src/library/customTypes/UniformResourceIdentifier/Data/Image/index.ts
+++ b/src/library/customTypes/UniformResourceIdentifier/Data/Image/index.ts
@@ -5,7 +5,6 @@ import type {
 } from '../DataURIBinaryEncoding.ts';
 
 import MediaType from '../MediaType';
-
 import DataURI from '../index.ts';
 
 import {

--- a/src/library/customTypes/UniformResourceIdentifier/Data/index.ts
+++ b/src/library/customTypes/UniformResourceIdentifier/Data/index.ts
@@ -1,7 +1,5 @@
 import Attempt from '@/library/Attempt';
-
 import Base64CharacterEncodedByteSequence from '@/library/customTypes/Base64CharacterEncodedByteSequence.ts';
-
 import NonTrivialString from '@/library/customTypes/NonTrivialString';
 
 import {

--- a/src/library/customTypes/UniformResourceIdentifier/index.ts
+++ b/src/library/customTypes/UniformResourceIdentifier/index.ts
@@ -1,5 +1,4 @@
 import Attempt from '@/library/Attempt';
-
 import NonTrivialString from '@/library/customTypes/NonTrivialString';
 
 import type {

--- a/src/pages/TextToImagePage.vue
+++ b/src/pages/TextToImagePage.vue
@@ -4,6 +4,7 @@ import {
   ref,
   type Ref,
 } from '@/library/vue/reactivity.ts';
+
 import {
   useStatefulAttemptThatEventually,
 } from '@/library/vue/statefulAttempt';
@@ -11,15 +12,19 @@ import {
 import {
   VBtn,
 } from 'vuetify/components/VBtn';
+
 import {
   VForm,
 } from 'vuetify/components/VForm';
+
 import {
   VContainer,
 } from 'vuetify/components/VGrid';
+
 import {
   VMain,
 } from 'vuetify/components/VMain';
+
 import {
   VSkeletonLoader,
 } from 'vuetify/components/VSkeletonLoader';


### PR DESCRIPTION
- ensures that style of imports converges automatically so they show up less in diffs/reviews
- enabled by #401