### PR TITLE
linter: minimizes noise in diffs when rearranging unions or intersections

### DIFF
--- a/src/features/TextToImage/components/TextToImageOutputAlert.vue
+++ b/src/features/TextToImage/components/TextToImageOutputAlert.vue
@@ -6,7 +6,8 @@ import * as TextToImage from '@/features/TextToImage';
 
 type OutputError =
   | TextToImage.Server.ConnectionError
-  | TextToImage.Server.SpecificationError;
+  | TextToImage.Server.SpecificationError
+;
 
 defineProps<{
   error: OutputError;

--- a/src/library/Attempt/Outcome.ts
+++ b/src/library/Attempt/Outcome.ts
@@ -136,7 +136,8 @@ type Attempt_Outcome<
   SomeActionableError extends ActionableError<string>,
 > =
   | Attempt_Success<SomeProduct>
-  | Attempt_Failure<SomeActionableError>;
+  | Attempt_Failure<SomeActionableError>
+;
 
 type ProductOf<
   SomeOutcome extends Attempt_Outcome<unknown, ActionableError<string>>,

--- a/src/library/Attempt/error/NonActionableBuiltInError.ts
+++ b/src/library/Attempt/error/NonActionableBuiltInError.ts
@@ -40,7 +40,8 @@ type NonActionableBuiltInError =
   | RangeError // Runtime was asked to create an impossible value.
   | URIError // An illegal escape sequence was passed to decodeURI/encodeURI.
   | EvalError // Something illegal was done with `eval` or `Function` constructor.
-  | SyntaxError; // The JS engine couldn't even parse the code.
+  | SyntaxError // The JS engine couldn't even parse the code.
+;
 
 const isNonActionableBuiltInError = (
   givenError: Error,

--- a/src/library/HTTP/Response/StatusCode/Any.ts
+++ b/src/library/HTTP/Response/StatusCode/Any.ts
@@ -8,7 +8,8 @@ import type {
 
 type HTTP_Response_StatusCode_Any =
   | HTTP_Response_StatusCode_Success
-  | HTTP_Response_StatusCode_Error.Any;
+  | HTTP_Response_StatusCode_Error.Any
+;
 
 export type {
   HTTP_Response_StatusCode_Any,

--- a/src/library/HTTP/Response/StatusCode/Error/Any.ts
+++ b/src/library/HTTP/Response/StatusCode/Error/Any.ts
@@ -8,7 +8,8 @@ import type {
 
 type HTTP_Response_StatusCode_Error_Any =
   | HTTP_Response_StatusCode_Error_Client
-  | HTTP_Response_StatusCode_Error_Server;
+  | HTTP_Response_StatusCode_Error_Server
+;
 
 export type {
   HTTP_Response_StatusCode_Error_Any,

--- a/src/library/Parser/string/StaticStringParser.ts
+++ b/src/library/Parser/string/StaticStringParser.ts
@@ -15,7 +15,8 @@ type StaticStringParser<
   & StringParser<
     Any,
     ParsingError<string>
-  >;
+  >
+;
 
 export type {
   StaticStringParser,

--- a/src/library/modifiersByType/error/Contextualized.ts
+++ b/src/library/modifiersByType/error/Contextualized.ts
@@ -7,7 +7,8 @@ type Contextualized<
   & SomeError
   & {
     cause: SomeCause;
-  };
+  }
+;
 
 interface Instantiable<Any> {
   [Symbol.hasInstance]: (value: unknown) => value is Any;

--- a/src/library/typeUtilities/Boolean.ts
+++ b/src/library/typeUtilities/Boolean.ts
@@ -6,7 +6,8 @@ type Is<
     ? RightHandOperand extends LeftHandOperand
       ? true
       : false
-    : false;
+    : false
+;
 
 type If<
   Condition extends boolean,
@@ -15,7 +16,8 @@ type If<
 > =
   Condition extends true
     ? WhenTrue
-    : WhenFalse;
+    : WhenFalse
+;
 
 type Not<
   SomeBoolean extends boolean,

--- a/src/library/typeUtilities/StaticForcibleStringParser.ts
+++ b/src/library/typeUtilities/StaticForcibleStringParser.ts
@@ -9,7 +9,8 @@ type StaticForcibleStringParser<
   >
   & ForcibleStringParser<
     Any
-  >;
+  >
+;
 
 export type {
   StaticForcibleStringParser,

--- a/src/utilities/Repository.ts
+++ b/src/utilities/Repository.ts
@@ -1,12 +1,14 @@
 type Repository_Issue_Label =
   | 'bug'
   | 'enhancement'
-  | 'documentation';
+  | 'documentation'
+;
 
 type Repository_Issue_Type =
   | 'Feature'
   | 'Bug'
-  | 'Task';
+  | 'Task'
+;
 
 interface Repository_Issue {
   title: string;


### PR DESCRIPTION
- separates `;` operator from list of members in union or intersection
- inspired by #400 