### PR TITLE
refactor(library/Attempt): dissolves "outcome.ts" into more manageable pieces

### DIFF
--- a/src/library/Attempt/Outcome/Discriminable.ts
+++ b/src/library/Attempt/Outcome/Discriminable.ts
@@ -1,0 +1,31 @@
+import type {
+  Is,
+  If,
+  Not,
+} from '@/library/typeUtilities/Boolean';
+
+// cspell:words sugarfree discriminable
+interface SyntacticallySugarfreeDiscriminableOutcome {
+  readonly case: 'success' | 'failure';
+}
+
+interface DiscriminableOutcome<
+  SomeProduct,
+> extends SyntacticallySugarfreeDiscriminableOutcome {
+  readonly isSuccess: Is<this['case'], 'success'>;
+  readonly isFailure: Not<this['isSuccess']>;
+
+  optionallyUnwrap(): If<this['isSuccess'],
+    SomeProduct,
+    null
+  >;
+
+  forciblyUnwrap(): If<this['isSuccess'],
+    SomeProduct,
+    never
+  >;
+}
+
+export type {
+  DiscriminableOutcome,
+};

--- a/src/library/Attempt/Outcome/Failure.ts
+++ b/src/library/Attempt/Outcome/Failure.ts
@@ -1,0 +1,58 @@
+// cspell:words sugarfree discriminable
+
+import type {
+  ActionableError,
+} from '../error';
+
+import type {
+  DiscriminableOutcome,
+} from './Discriminable';
+
+interface SemanticallySugarfreeFailure<
+  SomeActionableError extends ActionableError<string>,
+> extends DiscriminableOutcome<unknown> {
+  readonly case: 'failure';
+  readonly cause: SomeActionableError;
+}
+
+interface Attempt_Failure<
+  SomeActionableError extends ActionableError<string>,
+> extends SemanticallySugarfreeFailure<SomeActionableError> {
+  /**
+   * Semantic sugar for `cause`; useful for juxtaposition against early exits:
+   * ```ts
+   * function safelyGetProductWhileHandlingErrors(
+   *   givenOutcome: Attempt.Outcome<CustomProduct, CustomError>,
+   *   recoverFrom: (expectedError: CustomError) => void,
+   * ): CustomProduct {
+   *   if (
+   *     givenOutcome.isSuccess
+   *   ) return givenOutcome.unwrapped;
+   *
+   *   ...
+   *
+   *   recoverFrom(givenOutcome.causeOfFailure);
+   * }
+   * ```
+   */
+  readonly causeOfFailure: this['cause'];
+}
+
+const failureDueTo = <
+  SomeActionableError extends ActionableError<string>,
+>(
+  givenCause: SomeActionableError,
+): Attempt_Failure<SomeActionableError> => ({
+  case            : 'failure',
+  cause           : givenCause,
+  isSuccess       : false,
+  isFailure       : true,
+  optionallyUnwrap: () => null,
+  forciblyUnwrap  : () => givenCause.throwAnyway('Unexpected forceful unwrap of a failure'),
+  causeOfFailure  : givenCause,
+});
+
+export {
+  type Attempt_Failure,
+  failureDueTo,
+};

--- a/src/library/Attempt/Outcome/Success.ts
+++ b/src/library/Attempt/Outcome/Success.ts
@@ -1,0 +1,62 @@
+// cspell:words sugarfree discriminable
+
+import type {
+  DiscriminableOutcome,
+} from './Discriminable';
+
+interface SemanticallySugarfreeSuccess<SomeProduct> extends DiscriminableOutcome<SomeProduct> {
+  readonly case: 'success';
+  readonly product: SomeProduct;
+}
+
+interface Attempt_Success<SomeProduct> extends SemanticallySugarfreeSuccess<SomeProduct> {
+  /**
+   * Access the product nested within a successful outcome.
+   *
+   * Adds a guarded parallel to the `optionallyUnwrap` and `forciblyUnwrapped` methods:
+   * ```ts
+   * function doRiskyThingUnsafely(
+   *   givenOutcome: Attempt.Outcome<CustomProduct, CustomError>,
+   * ): void {
+   *   console.log(givenOutcome.forciblyUnwrap());
+   * }
+   *
+   * function doRiskyThingSafelyWhileIgnoringErrors(
+   *   givenOutcome: Attempt.Outcome<CustomProduct, CustomError>,
+   * ): void {
+   *   console.log(givenOutcome.optionallyUnwrap());
+   * }
+   *
+   * function doRiskyThingSafelyWhileHandlingErrors(
+   *   givenOutcome: Attempt.Outcome<CustomProduct, CustomError>,
+   *   recoverFrom: (expectedError: CustomError) => void,
+   * ): void {
+   *   if (
+   *     givenOutcome.isFailure
+   *   ) recoverFrom(givenOutcome.causeOfFailure);
+   *
+   *   console.log(givenOutcome.unwrapped);
+   * }
+   * ```
+   */
+  readonly unwrapped: this['product'];
+}
+
+const successThatYielded = <
+  SomeProduct,
+>(
+  givenProduct: SomeProduct,
+): Attempt_Success<SomeProduct> => ({
+  case            : 'success',
+  product         : givenProduct,
+  isSuccess       : true,
+  isFailure       : false,
+  optionallyUnwrap: () => givenProduct,
+  forciblyUnwrap  : () => givenProduct,
+  unwrapped       : givenProduct,
+});
+
+export {
+  type Attempt_Success,
+  successThatYielded,
+};

--- a/src/library/Attempt/Outcome/index.ts
+++ b/src/library/Attempt/Outcome/index.ts
@@ -1,61 +1,16 @@
-// cspell:words sugarfree discriminable
-
 import type {
   ActionableError,
 } from '../error';
 
-import type {
-  DiscriminableOutcome,
-} from './Discriminable';
+import {
+  type Attempt_Failure,
+  failureDueTo,
+} from './Failure';
 
 import {
   type Attempt_Success,
   successThatYielded,
 } from './Success';
-
-interface SemanticallySugarfreeFailure<
-  SomeActionableError extends ActionableError<string>,
-> extends DiscriminableOutcome<unknown> {
-  readonly case: 'failure';
-  readonly cause: SomeActionableError;
-}
-
-interface Attempt_Failure<
-  SomeActionableError extends ActionableError<string>,
-> extends SemanticallySugarfreeFailure<SomeActionableError> {
-  /**
-   * Semantic sugar for `cause`; useful for juxtaposition against early exits:
-   * ```ts
-   * function safelyGetProductWhileHandlingErrors(
-   *   givenOutcome: Attempt.Outcome<CustomProduct, CustomError>,
-   *   recoverFrom: (expectedError: CustomError) => void,
-   * ): CustomProduct {
-   *   if (
-   *     givenOutcome.isSuccess
-   *   ) return givenOutcome.unwrapped;
-   *
-   *   ...
-   *
-   *   recoverFrom(givenOutcome.causeOfFailure);
-   * }
-   * ```
-   */
-  readonly causeOfFailure: this['cause'];
-}
-
-const failureDueTo = <
-  SomeActionableError extends ActionableError<string>,
->(
-  givenCause: SomeActionableError,
-): Attempt_Failure<SomeActionableError> => ({
-  case            : 'failure',
-  cause           : givenCause,
-  isSuccess       : false,
-  isFailure       : true,
-  optionallyUnwrap: () => null,
-  forciblyUnwrap  : () => givenCause.throwAnyway('Unexpected forceful unwrap of a failure'),
-  causeOfFailure  : givenCause,
-});
 
 const Attempt_Outcome = {
   failureDueTo,

--- a/src/library/Attempt/Outcome/index.ts
+++ b/src/library/Attempt/Outcome/index.ts
@@ -8,49 +8,16 @@ import type {
   DiscriminableOutcome,
 } from './Discriminable';
 
-interface SemanticallySugarfreeSuccess<SomeProduct> extends DiscriminableOutcome<SomeProduct> {
-  readonly case: 'success';
-  readonly product: SomeProduct;
-}
+import {
+  type Attempt_Success,
+  successThatYielded,
+} from './Success';
 
 interface SemanticallySugarfreeFailure<
   SomeActionableError extends ActionableError<string>,
 > extends DiscriminableOutcome<unknown> {
   readonly case: 'failure';
   readonly cause: SomeActionableError;
-}
-
-interface Attempt_Success<SomeProduct> extends SemanticallySugarfreeSuccess<SomeProduct> {
-  /**
-   * Access the product nested within a successful outcome.
-   *
-   * Adds a guarded parallel to the `optionallyUnwrap` and `forciblyUnwrapped` methods:
-   * ```ts
-   * function doRiskyThingUnsafely(
-   *   givenOutcome: Attempt.Outcome<CustomProduct, CustomError>,
-   * ): void {
-   *   console.log(givenOutcome.forciblyUnwrap());
-   * }
-   *
-   * function doRiskyThingSafelyWhileIgnoringErrors(
-   *   givenOutcome: Attempt.Outcome<CustomProduct, CustomError>,
-   * ): void {
-   *   console.log(givenOutcome.optionallyUnwrap());
-   * }
-   *
-   * function doRiskyThingSafelyWhileHandlingErrors(
-   *   givenOutcome: Attempt.Outcome<CustomProduct, CustomError>,
-   *   recoverFrom: (expectedError: CustomError) => void,
-   * ): void {
-   *   if (
-   *     givenOutcome.isFailure
-   *   ) recoverFrom(givenOutcome.causeOfFailure);
-   *
-   *   console.log(givenOutcome.unwrapped);
-   * }
-   * ```
-   */
-  readonly unwrapped: this['product'];
 }
 
 interface Attempt_Failure<
@@ -75,20 +42,6 @@ interface Attempt_Failure<
    */
   readonly causeOfFailure: this['cause'];
 }
-
-const successThatYielded = <
-  SomeProduct,
->(
-  givenProduct: SomeProduct,
-): Attempt_Success<SomeProduct> => ({
-  case            : 'success',
-  product         : givenProduct,
-  isSuccess       : true,
-  isFailure       : false,
-  optionallyUnwrap: () => givenProduct,
-  forciblyUnwrap  : () => givenProduct,
-  unwrapped       : givenProduct,
-});
 
 const failureDueTo = <
   SomeActionableError extends ActionableError<string>,

--- a/src/library/Attempt/Outcome/index.ts
+++ b/src/library/Attempt/Outcome/index.ts
@@ -6,7 +6,7 @@ import type {
 
 import type {
   ActionableError,
-} from './error';
+} from '../error';
 
 // cspell:words sugarfree discriminable
 interface SyntacticallySugarfreeDiscriminableOutcome {

--- a/src/library/Attempt/Outcome/index.ts
+++ b/src/library/Attempt/Outcome/index.ts
@@ -1,35 +1,12 @@
 // cspell:words sugarfree discriminable
 
 import type {
-  Is,
-  If,
-  Not,
-} from '@/library/typeUtilities/Boolean';
-
-import type {
   ActionableError,
 } from '../error';
 
-interface SyntacticallySugarfreeDiscriminableOutcome {
-  readonly case: 'success' | 'failure';
-}
-
-interface DiscriminableOutcome<
-  SomeProduct,
-> extends SyntacticallySugarfreeDiscriminableOutcome {
-  readonly isSuccess: Is<this['case'], 'success'>;
-  readonly isFailure: Not<this['isSuccess']>;
-
-  optionallyUnwrap(): If<this['isSuccess'],
-    SomeProduct,
-    null
-  >;
-
-  forciblyUnwrap(): If<this['isSuccess'],
-    SomeProduct,
-    never
-  >;
-}
+import type {
+  DiscriminableOutcome,
+} from './Discriminable';
 
 interface SemanticallySugarfreeSuccess<SomeProduct> extends DiscriminableOutcome<SomeProduct> {
   readonly case: 'success';

--- a/src/library/Attempt/Outcome/index.ts
+++ b/src/library/Attempt/Outcome/index.ts
@@ -1,3 +1,5 @@
+// cspell:words sugarfree discriminable
+
 import type {
   Is,
   If,
@@ -8,7 +10,6 @@ import type {
   ActionableError,
 } from '../error';
 
-// cspell:words sugarfree discriminable
 interface SyntacticallySugarfreeDiscriminableOutcome {
   readonly case: 'success' | 'failure';
 }


### PR DESCRIPTION
- this file was getting too cumbersome to modify
- supports #408 