### PR TITLE
refactor(library/Base64CharacterEncodedByteSequence): propagates parsing errors safely

### DIFF
--- a/src/features/TextToImage/models/SDXL/client/conversions/StabilityAI_Client_Image.ts
+++ b/src/features/TextToImage/models/SDXL/client/conversions/StabilityAI_Client_Image.ts
@@ -17,7 +17,7 @@ const toOutputImage = (
     givenImage.base64 === undefined
   ) return null;
 
-  const base64DataOfRawImage = Base64CharacterEncodedByteSequence.forciblyParsedFrom(givenImage.base64);
+  const base64DataOfRawImage = Base64CharacterEncodedByteSequence.parsedFrom(givenImage.base64).forciblyUnwrap(/* Broken web contracts require intervention */);
 
   const derivedImage = {
     uri        : new ImageURI('png', 'base64', base64DataOfRawImage),

--- a/src/library/Base64CharacterEncodedByteSequence/index.ts
+++ b/src/library/Base64CharacterEncodedByteSequence/index.ts
@@ -8,10 +8,6 @@ import type {
 
 import StringSubset from '@/library/customTypes/StringSubset';
 
-import type {
-  StringForciblyParsable,
-} from '@/library/typeUtilities/StringForciblyParsable';
-
 import {
   droppingLastCharacter,
   lastCharacterOf,
@@ -24,8 +20,6 @@ class Base64CharacterEncodedByteSequence
   extends StringSubset<
   'Base64CharacterEncodedByteSequence'
 > implements StringParsable<
-  typeof Base64CharacterEncodedByteSequence
->, StringForciblyParsable<
   typeof Base64CharacterEncodedByteSequence
 > {
   public static paddingCharacter = '=';
@@ -49,12 +43,6 @@ class Base64CharacterEncodedByteSequence
 
     return [remainingSequence, accumulatedPadding];
   }
-
-  public static forciblyParsedFrom = (
-    givenCharacters: string,
-  ): Base64CharacterEncodedByteSequence => {
-    return this.parsedFrom(givenCharacters).forciblyUnwrap(/* TODO: distribute to callers */);
-  };
 
   public static parsedFrom = (
     givenCharacters: string,

--- a/src/library/Base64CharacterEncodedByteSequence/index.ts
+++ b/src/library/Base64CharacterEncodedByteSequence/index.ts
@@ -1,6 +1,11 @@
 import Attempt from '@/library/Attempt';
 import Base64 from '@/library/Base64';
 import Byte from '@/library/Byte';
+
+import type {
+  StringParsable,
+} from '@/library/Parser/string';
+
 import StringSubset from '@/library/customTypes/StringSubset';
 
 import type {
@@ -18,7 +23,9 @@ import Base64CharacterEncodedByteSequence_ParsingError from './ParsingError.ts';
 class Base64CharacterEncodedByteSequence
   extends StringSubset<
   'Base64CharacterEncodedByteSequence'
-> implements StringForciblyParsable<
+> implements StringParsable<
+  typeof Base64CharacterEncodedByteSequence
+>, StringForciblyParsable<
   typeof Base64CharacterEncodedByteSequence
 > {
   public static paddingCharacter = '=';
@@ -46,6 +53,12 @@ class Base64CharacterEncodedByteSequence
   public static forciblyParsedFrom = (
     givenCharacters: string,
   ): Base64CharacterEncodedByteSequence => {
+    return this.parsedFrom(givenCharacters).forciblyUnwrap(/* TODO: distribute to callers */);
+  };
+
+  public static parsedFrom = (
+    givenCharacters: string,
+  ): Attempt.Outcome<Base64CharacterEncodedByteSequence, Base64CharacterEncodedByteSequence_ParsingError> => {
     const outcomeOfEnsuringEncodableCharacters = Byte.Sequence.ensureEncodable(givenCharacters, {
       assuming: Base64.bitWidth,
     });
@@ -55,7 +68,7 @@ class Base64CharacterEncodedByteSequence
         cause: $0 => Base64CharacterEncodedByteSequence_ParsingError.thatEscorts($0),
       });
 
-      return failureToEnsureEncodableCharacters.forciblyUnwrap(/* TODO: enable safe error propagation */);
+      return failureToEnsureEncodableCharacters;
     }
 
     const paddedByteEncodableCharacters = outcomeOfEnsuringEncodableCharacters.unwrapped;
@@ -67,7 +80,7 @@ class Base64CharacterEncodedByteSequence
       cause  : $0 => Base64CharacterEncodedByteSequence_ParsingError.thatEscorts($0),
     });
 
-    return outcomeOfParsingByteSequence.forciblyUnwrap(/* TODO: enable safe error propagation */);
+    return outcomeOfParsingByteSequence;
   };
 }
 

--- a/src/library/ShimmedStabilityAIClient/index.ts
+++ b/src/library/ShimmedStabilityAIClient/index.ts
@@ -93,7 +93,7 @@ const toBatchGenerationRequestBody = (givenRequests: GenerateFromTextRequest['te
 };
 
 const z_image = z.string().transform((someSubject) => {
-  return Base64CharacterEncodedByteSequence.forciblyParsedFrom(someSubject);
+  return Base64CharacterEncodedByteSequence.parsedFrom(someSubject).forciblyUnwrap(/* Zod can safely propagate errors */);
 });
 
 const z_imageGenerationResponseBody = z.object({

--- a/src/library/customTypes/UniformResourceIdentifier/Data/index.ts
+++ b/src/library/customTypes/UniformResourceIdentifier/Data/index.ts
@@ -101,7 +101,7 @@ class DataURI
       rawData === undefined
     ) return new DataURI_ParsingError('Expected data portion to be defined').throwAnyway('To be converted to `Attempt` failure');
 
-    const parsedData = Base64CharacterEncodedByteSequence.forciblyParsedFrom(rawData);
+    const parsedData = Base64CharacterEncodedByteSequence.parsedFrom(rawData).forciblyUnwrap(/* TODO: move to guard statement */);
 
     const [
       rawMediaType,


### PR DESCRIPTION
- addresses TODOs added in #423
- facilitates #446 