### PR TITLE
refactor(text-to-image): separates response conversion concerns from main logic in SDXL client

### DIFF
--- a/src/features/TextToImage/models/SDXL/client/conversions/GenerateFromTextResponse.ts
+++ b/src/features/TextToImage/models/SDXL/client/conversions/GenerateFromTextResponse.ts
@@ -1,0 +1,63 @@
+import type {
+  GenerateFromTextResponse,
+} from 'stabilityai-client-typescript/models/operations';
+
+import Attempt from '@/library/Attempt';
+import Base64CharacterEncodedByteSequence from '@/library/customTypes/Base64CharacterEncodedByteSequence';
+import ImageURI from '@/library/customTypes/UniformResourceIdentifier/Data/Image';
+
+import {
+  allSerialized,
+} from '@/features/TextToImage/models/SDXL/client/conversions/TextPrompt';
+
+import type {
+  Input,
+  Output,
+} from '@/features/TextToImage/types';
+
+const firstTextToImageOutput = (
+  {
+    in: givenResponse,
+    inferredFrom: givenInputText,
+  }: {
+    in: GenerateFromTextResponse;
+    inferredFrom: Input['text'];
+  },
+): Output => {
+  if (
+    !('artifacts' in givenResponse.result)
+  ) return Attempt.abandon('Expected response body rather than readable stream');
+
+  const generatedArtifacts = givenResponse.result.artifacts;
+
+  if (
+    generatedArtifacts === undefined
+  ) return Attempt.abandon('Expected artifacts in response result');
+
+  const [soleGeneratedArtifact] = generatedArtifacts;
+
+  if (
+    soleGeneratedArtifact === undefined
+  ) return Attempt.abandon('Expected at least one artifact in response');
+
+  if (
+    soleGeneratedArtifact.base64 === undefined
+  ) return Attempt.abandon('Expected image data from sole artifact');
+
+  const base64DataOfNewImage = Base64CharacterEncodedByteSequence.forciblyParsedFrom(soleGeneratedArtifact.base64);
+
+  const newImage = {
+    uri        : new ImageURI('png', 'base64', base64DataOfNewImage),
+    description: allSerialized(givenInputText),
+  };
+
+  const soleGeneratedOutput = {
+    image: newImage,
+  };
+
+  return soleGeneratedOutput;
+};
+
+export {
+  firstTextToImageOutput,
+};

--- a/src/features/TextToImage/models/SDXL/client/conversions/GenerateFromTextResponse.ts
+++ b/src/features/TextToImage/models/SDXL/client/conversions/GenerateFromTextResponse.ts
@@ -42,7 +42,7 @@ const firstTextToImageOutput = (
     inferredFrom: Input['text'];
   },
 ): Output => {
-  const inferredOutputs = ((
+  const textToImageOutputs = (
     {
       in: givenResponse,
       inferredFrom: givenInputText,
@@ -68,7 +68,9 @@ const firstTextToImageOutput = (
       .map(toNullableOutput);
 
     return inferredOutputs;
-  })({
+  };
+
+  const inferredOutputs = textToImageOutputs({
     in          : givenResponse,
     inferredFrom: givenInputText,
   });

--- a/src/features/TextToImage/models/SDXL/client/conversions/GenerateFromTextResponse.ts
+++ b/src/features/TextToImage/models/SDXL/client/conversions/GenerateFromTextResponse.ts
@@ -52,12 +52,11 @@ const firstTextToImageOutput = (
     inferredRawImages === undefined
   ) return Attempt.abandon('Expected raw image in response result');
 
-  const inferredOutputImages = inferredRawImages
+  const inferredOutputs = inferredRawImages
     .map($0 => toOutputImage($0, {
       description: allSerialized(givenInputText),
-    }));
-
-  const inferredOutputs = inferredOutputImages.map(toNullableOutput);
+    }))
+    .map(toNullableOutput);
 
   if (
     !hasAtLeastOne(inferredOutputs)

--- a/src/features/TextToImage/models/SDXL/client/conversions/GenerateFromTextResponse.ts
+++ b/src/features/TextToImage/models/SDXL/client/conversions/GenerateFromTextResponse.ts
@@ -28,34 +28,34 @@ const firstTextToImageOutput = (
     !('artifacts' in givenResponse.result)
   ) return Attempt.abandon('Expected response body rather than readable stream');
 
-  const generatedRawImages = givenResponse.result.artifacts;
+  const inferredRawImages = givenResponse.result.artifacts;
 
   if (
-    generatedRawImages === undefined
+    inferredRawImages === undefined
   ) return Attempt.abandon('Expected raw image in response result');
 
-  const [soleGeneratedRawImage] = generatedRawImages;
+  const [soleInferredRawImage] = inferredRawImages;
 
   if (
-    soleGeneratedRawImage === undefined
+    soleInferredRawImage === undefined
   ) return Attempt.abandon('Expected at least one raw image in response');
 
   if (
-    soleGeneratedRawImage.base64 === undefined
+    soleInferredRawImage.base64 === undefined
   ) return Attempt.abandon('Expected image data from sole raw image');
 
-  const base64DataOfNewImage = Base64CharacterEncodedByteSequence.forciblyParsedFrom(soleGeneratedRawImage.base64);
+  const base64DataOfNewImage = Base64CharacterEncodedByteSequence.forciblyParsedFrom(soleInferredRawImage.base64);
 
-  const soleGeneratedOutputImage = {
+  const soleInferredOutputImage = {
     uri        : new ImageURI('png', 'base64', base64DataOfNewImage),
     description: allSerialized(givenInputText),
   };
 
-  const soleGeneratedOutput = {
-    image: soleGeneratedOutputImage,
+  const soleInferredOutput = {
+    image: soleInferredOutputImage,
   };
 
-  return soleGeneratedOutput;
+  return soleInferredOutput;
 };
 
 export {

--- a/src/features/TextToImage/models/SDXL/client/conversions/GenerateFromTextResponse.ts
+++ b/src/features/TextToImage/models/SDXL/client/conversions/GenerateFromTextResponse.ts
@@ -34,28 +34,28 @@ const firstTextToImageOutput = (
     inferredRawImages === undefined
   ) return Attempt.abandon('Expected raw image in response result');
 
-  const [soleInferredRawImage] = inferredRawImages;
+  const [firstInferredRawImage] = inferredRawImages;
 
   if (
-    soleInferredRawImage === undefined
+    firstInferredRawImage === undefined
   ) return Attempt.abandon('Expected at least one raw image in response');
 
   if (
-    soleInferredRawImage.base64 === undefined
-  ) return Attempt.abandon('Expected image data from sole raw image');
+    firstInferredRawImage.base64 === undefined
+  ) return Attempt.abandon('Expected image data from first raw image');
 
-  const base64DataOfNewImage = Base64CharacterEncodedByteSequence.forciblyParsedFrom(soleInferredRawImage.base64);
+  const base64DataOfNewImage = Base64CharacterEncodedByteSequence.forciblyParsedFrom(firstInferredRawImage.base64);
 
-  const soleInferredOutputImage = {
+  const firstInferredOutputImage = {
     uri        : new ImageURI('png', 'base64', base64DataOfNewImage),
     description: allSerialized(givenInputText),
   };
 
-  const soleInferredOutput = {
-    image: soleInferredOutputImage,
+  const firstInferredOutput = {
+    image: firstInferredOutputImage,
   };
 
-  return soleInferredOutput;
+  return firstInferredOutput;
 };
 
 export {

--- a/src/features/TextToImage/models/SDXL/client/conversions/GenerateFromTextResponse.ts
+++ b/src/features/TextToImage/models/SDXL/client/conversions/GenerateFromTextResponse.ts
@@ -52,10 +52,11 @@ const firstTextToImageOutput = (
     ?.map($0 => toOutputImage($0, {
       description: allSerialized(givenInputText),
     }))
-    .map(toNullableOutput);
+    .map(toNullableOutput)
+    ?? null;
 
   if (
-    inferredOutputs === undefined
+    inferredOutputs === null
   ) return Attempt.abandon('Expected text-to-image output in response result');
 
   if (

--- a/src/features/TextToImage/models/SDXL/client/conversions/GenerateFromTextResponse.ts
+++ b/src/features/TextToImage/models/SDXL/client/conversions/GenerateFromTextResponse.ts
@@ -42,18 +42,22 @@ const firstTextToImageOutput = (
     inferredFrom: Input['text'];
   },
 ): Output => {
-  if (
-    !('artifacts' in givenResponse.result)
-  ) return Attempt.abandon('Expected response body rather than readable stream');
+  const inferredOutputs = ((): (Output | null)[] | null => {
+    if (
+      !('artifacts' in givenResponse.result)
+    ) return Attempt.abandon('Expected response body rather than readable stream');
 
-  const inferredRawImages = givenResponse.result.artifacts;
+    const inferredRawImages = givenResponse.result.artifacts;
 
-  const inferredOutputs = inferredRawImages
-    ?.map($0 => toOutputImage($0, {
-      description: allSerialized(givenInputText),
-    }))
-    .map(toNullableOutput)
-    ?? null;
+    const inferredOutputs = inferredRawImages
+      ?.map($0 => toOutputImage($0, {
+        description: allSerialized(givenInputText),
+      }))
+      .map(toNullableOutput)
+      ?? null;
+
+    return inferredOutputs;
+  })();
 
   if (
     inferredOutputs === null

--- a/src/features/TextToImage/models/SDXL/client/conversions/GenerateFromTextResponse.ts
+++ b/src/features/TextToImage/models/SDXL/client/conversions/GenerateFromTextResponse.ts
@@ -52,16 +52,16 @@ const firstTextToImageOutput = (
     inferredRawImages === undefined
   ) return Attempt.abandon('Expected raw image in response result');
 
+  const inferredOutputImages = inferredRawImages
+    .map($0 => toOutputImage($0, {
+      description: allSerialized(givenInputText),
+    }));
+
   if (
-    !hasAtLeastOne(inferredRawImages)
-  ) return Attempt.abandon('Expected at least one raw image in response');
+    !hasAtLeastOne(inferredOutputImages)
+  ) return Attempt.abandon('Expected at least one output image in response');
 
-  const [firstInferredRawImage] = inferredRawImages;
-
-  const firstInferredOutputImage = toOutputImage(firstInferredRawImage, {
-    description: allSerialized(givenInputText),
-  });
-
+  const [firstInferredOutputImage] = inferredOutputImages;
   const firstInferredOutput = toNullableOutput(firstInferredOutputImage);
 
   if (

--- a/src/features/TextToImage/models/SDXL/client/conversions/GenerateFromTextResponse.ts
+++ b/src/features/TextToImage/models/SDXL/client/conversions/GenerateFromTextResponse.ts
@@ -57,12 +57,13 @@ const firstTextToImageOutput = (
       description: allSerialized(givenInputText),
     }));
 
-  if (
-    !hasAtLeastOne(inferredOutputImages)
-  ) return Attempt.abandon('Expected at least one output image in response');
+  const inferredOutputs = inferredOutputImages.map(toNullableOutput);
 
-  const [firstInferredOutputImage] = inferredOutputImages;
-  const firstInferredOutput = toNullableOutput(firstInferredOutputImage);
+  if (
+    !hasAtLeastOne(inferredOutputs)
+  ) return Attempt.abandon('Expected at least one text-to-image output in response');
+
+  const [firstInferredOutput] = inferredOutputs;
 
   if (
     firstInferredOutput === null

--- a/src/features/TextToImage/models/SDXL/client/conversions/GenerateFromTextResponse.ts
+++ b/src/features/TextToImage/models/SDXL/client/conversions/GenerateFromTextResponse.ts
@@ -17,6 +17,18 @@ import type {
   Output,
 } from '@/features/TextToImage/types';
 
+const toNullableOutput = (
+  givenImage: Output['image'] | null,
+): Output | null => {
+  if (
+    givenImage === null
+  ) return null;
+
+  return {
+    image: givenImage,
+  };
+};
+
 const firstTextToImageOutput = (
   {
     in: givenResponse,
@@ -46,13 +58,11 @@ const firstTextToImageOutput = (
     description: allSerialized(givenInputText),
   });
 
-  if (
-    firstInferredOutputImage === null
-  ) return Attempt.abandon('Expected at least one well-formed image in response');
+  const firstInferredOutput = toNullableOutput(firstInferredOutputImage);
 
-  const firstInferredOutput = {
-    image: firstInferredOutputImage,
-  };
+  if (
+    firstInferredOutput === null
+  ) return Attempt.abandon('Expected at least one well-formed text-to-image output in response');
 
   return firstInferredOutput;
 };

--- a/src/features/TextToImage/models/SDXL/client/conversions/GenerateFromTextResponse.ts
+++ b/src/features/TextToImage/models/SDXL/client/conversions/GenerateFromTextResponse.ts
@@ -48,15 +48,15 @@ const firstTextToImageOutput = (
 
   const inferredRawImages = givenResponse.result.artifacts;
 
-  if (
-    inferredRawImages === undefined
-  ) return Attempt.abandon('Expected raw image in response result');
-
   const inferredOutputs = inferredRawImages
-    .map($0 => toOutputImage($0, {
+    ?.map($0 => toOutputImage($0, {
       description: allSerialized(givenInputText),
     }))
     .map(toNullableOutput);
+
+  if (
+    inferredOutputs === undefined
+  ) return Attempt.abandon('Expected text-to-image output in response result');
 
   if (
     !hasAtLeastOne(inferredOutputs)

--- a/src/features/TextToImage/models/SDXL/client/conversions/GenerateFromTextResponse.ts
+++ b/src/features/TextToImage/models/SDXL/client/conversions/GenerateFromTextResponse.ts
@@ -28,23 +28,23 @@ const firstTextToImageOutput = (
     !('artifacts' in givenResponse.result)
   ) return Attempt.abandon('Expected response body rather than readable stream');
 
-  const generatedArtifacts = givenResponse.result.artifacts;
+  const generatedRawImages = givenResponse.result.artifacts;
 
   if (
-    generatedArtifacts === undefined
-  ) return Attempt.abandon('Expected artifacts in response result');
+    generatedRawImages === undefined
+  ) return Attempt.abandon('Expected raw image in response result');
 
-  const [soleGeneratedArtifact] = generatedArtifacts;
-
-  if (
-    soleGeneratedArtifact === undefined
-  ) return Attempt.abandon('Expected at least one artifact in response');
+  const [soleGeneratedRawImage] = generatedRawImages;
 
   if (
-    soleGeneratedArtifact.base64 === undefined
-  ) return Attempt.abandon('Expected image data from sole artifact');
+    soleGeneratedRawImage === undefined
+  ) return Attempt.abandon('Expected at least one raw image in response');
 
-  const base64DataOfNewImage = Base64CharacterEncodedByteSequence.forciblyParsedFrom(soleGeneratedArtifact.base64);
+  if (
+    soleGeneratedRawImage.base64 === undefined
+  ) return Attempt.abandon('Expected image data from sole raw image');
+
+  const base64DataOfNewImage = Base64CharacterEncodedByteSequence.forciblyParsedFrom(soleGeneratedRawImage.base64);
 
   const soleGeneratedOutputImage = {
     uri        : new ImageURI('png', 'base64', base64DataOfNewImage),

--- a/src/features/TextToImage/models/SDXL/client/conversions/GenerateFromTextResponse.ts
+++ b/src/features/TextToImage/models/SDXL/client/conversions/GenerateFromTextResponse.ts
@@ -57,12 +57,15 @@ const firstTextToImageOutput = (
 
     const inferredRawImages = givenResponse.result.artifacts;
 
+    if (
+      inferredRawImages === undefined
+    ) return null;
+
     const inferredOutputs = inferredRawImages
-      ?.map($0 => toOutputImage($0, {
+      .map($0 => toOutputImage($0, {
         description: allSerialized(givenInputText),
       }))
-      .map(toNullableOutput)
-      ?? null;
+      .map(toNullableOutput);
 
     return inferredOutputs;
   })({

--- a/src/features/TextToImage/models/SDXL/client/conversions/GenerateFromTextResponse.ts
+++ b/src/features/TextToImage/models/SDXL/client/conversions/GenerateFromTextResponse.ts
@@ -33,6 +33,34 @@ const toNullableOutput = (
   };
 };
 
+const textToImageOutputs = (
+  {
+    in: givenResponse,
+    inferredFrom: givenInputText,
+  }: {
+    in: GenerateFromTextResponse;
+    inferredFrom: Input['text'];
+  },
+): (Output | null)[] | null => {
+  if (
+    !('artifacts' in givenResponse.result)
+  ) return Attempt.abandon('Expected response body rather than readable stream');
+
+  const inferredRawImages = givenResponse.result.artifacts;
+
+  if (
+    inferredRawImages === undefined
+  ) return null;
+
+  const inferredOutputs = inferredRawImages
+    .map($0 => toOutputImage($0, {
+      description: allSerialized(givenInputText),
+    }))
+    .map(toNullableOutput);
+
+  return inferredOutputs;
+};
+
 const firstTextToImageOutput = (
   {
     in: givenResponse,
@@ -42,34 +70,6 @@ const firstTextToImageOutput = (
     inferredFrom: Input['text'];
   },
 ): Output => {
-  const textToImageOutputs = (
-    {
-      in: givenResponse,
-      inferredFrom: givenInputText,
-    }: {
-      in: GenerateFromTextResponse;
-      inferredFrom: Input['text'];
-    },
-  ): (Output | null)[] | null => {
-    if (
-      !('artifacts' in givenResponse.result)
-    ) return Attempt.abandon('Expected response body rather than readable stream');
-
-    const inferredRawImages = givenResponse.result.artifacts;
-
-    if (
-      inferredRawImages === undefined
-    ) return null;
-
-    const inferredOutputs = inferredRawImages
-      .map($0 => toOutputImage($0, {
-        description: allSerialized(givenInputText),
-      }))
-      .map(toNullableOutput);
-
-    return inferredOutputs;
-  };
-
   const inferredOutputs = textToImageOutputs({
     in          : givenResponse,
     inferredFrom: givenInputText,

--- a/src/features/TextToImage/models/SDXL/client/conversions/GenerateFromTextResponse.ts
+++ b/src/features/TextToImage/models/SDXL/client/conversions/GenerateFromTextResponse.ts
@@ -3,8 +3,10 @@ import type {
 } from 'stabilityai-client-typescript/models/operations';
 
 import Attempt from '@/library/Attempt';
-import Base64CharacterEncodedByteSequence from '@/library/customTypes/Base64CharacterEncodedByteSequence';
-import ImageURI from '@/library/customTypes/UniformResourceIdentifier/Data/Image';
+
+import {
+  toOutputImage,
+} from './StabilityAI_Client_Image';
 
 import {
   allSerialized,
@@ -40,16 +42,13 @@ const firstTextToImageOutput = (
     firstInferredRawImage === undefined
   ) return Attempt.abandon('Expected at least one raw image in response');
 
-  if (
-    firstInferredRawImage.base64 === undefined
-  ) return Attempt.abandon('Expected image data from first raw image');
-
-  const base64DataOfNewImage = Base64CharacterEncodedByteSequence.forciblyParsedFrom(firstInferredRawImage.base64);
-
-  const firstInferredOutputImage = {
-    uri        : new ImageURI('png', 'base64', base64DataOfNewImage),
+  const firstInferredOutputImage = toOutputImage(firstInferredRawImage, {
     description: allSerialized(givenInputText),
-  };
+  });
+
+  if (
+    firstInferredOutputImage === null
+  ) return Attempt.abandon('Expected at least one well-formed image in response');
 
   const firstInferredOutput = {
     image: firstInferredOutputImage,

--- a/src/features/TextToImage/models/SDXL/client/conversions/GenerateFromTextResponse.ts
+++ b/src/features/TextToImage/models/SDXL/client/conversions/GenerateFromTextResponse.ts
@@ -46,13 +46,13 @@ const firstTextToImageOutput = (
 
   const base64DataOfNewImage = Base64CharacterEncodedByteSequence.forciblyParsedFrom(soleGeneratedArtifact.base64);
 
-  const newImage = {
+  const soleGeneratedOutputImage = {
     uri        : new ImageURI('png', 'base64', base64DataOfNewImage),
     description: allSerialized(givenInputText),
   };
 
   const soleGeneratedOutput = {
-    image: newImage,
+    image: soleGeneratedOutputImage,
   };
 
   return soleGeneratedOutput;

--- a/src/features/TextToImage/models/SDXL/client/conversions/GenerateFromTextResponse.ts
+++ b/src/features/TextToImage/models/SDXL/client/conversions/GenerateFromTextResponse.ts
@@ -42,7 +42,15 @@ const firstTextToImageOutput = (
     inferredFrom: Input['text'];
   },
 ): Output => {
-  const inferredOutputs = ((): (Output | null)[] | null => {
+  const inferredOutputs = ((
+    {
+      in: givenResponse,
+      inferredFrom: givenInputText,
+    }: {
+      in: GenerateFromTextResponse;
+      inferredFrom: Input['text'];
+    },
+  ): (Output | null)[] | null => {
     if (
       !('artifacts' in givenResponse.result)
     ) return Attempt.abandon('Expected response body rather than readable stream');
@@ -57,7 +65,10 @@ const firstTextToImageOutput = (
       ?? null;
 
     return inferredOutputs;
-  })();
+  })({
+    in          : givenResponse,
+    inferredFrom: givenInputText,
+  });
 
   if (
     inferredOutputs === null

--- a/src/features/TextToImage/models/SDXL/client/conversions/GenerateFromTextResponse.ts
+++ b/src/features/TextToImage/models/SDXL/client/conversions/GenerateFromTextResponse.ts
@@ -5,6 +5,10 @@ import type {
 import Attempt from '@/library/Attempt';
 
 import {
+  hasAtLeastOne,
+} from '@/library/utilitiesByType/array';
+
+import {
   toOutputImage,
 } from './StabilityAI_Client_Image';
 
@@ -48,11 +52,11 @@ const firstTextToImageOutput = (
     inferredRawImages === undefined
   ) return Attempt.abandon('Expected raw image in response result');
 
-  const [firstInferredRawImage] = inferredRawImages;
-
   if (
-    firstInferredRawImage === undefined
+    !hasAtLeastOne(inferredRawImages)
   ) return Attempt.abandon('Expected at least one raw image in response');
+
+  const [firstInferredRawImage] = inferredRawImages;
 
   const firstInferredOutputImage = toOutputImage(firstInferredRawImage, {
     description: allSerialized(givenInputText),

--- a/src/features/TextToImage/models/SDXL/client/conversions/StabilityAI_Client_Image.ts
+++ b/src/features/TextToImage/models/SDXL/client/conversions/StabilityAI_Client_Image.ts
@@ -1,0 +1,32 @@
+import type * as StabilityAIClient from 'stabilityai-client-typescript/models/components';
+
+import Base64CharacterEncodedByteSequence from '@/library/customTypes/Base64CharacterEncodedByteSequence.ts';
+import ImageURI from '@/library/customTypes/UniformResourceIdentifier/Data/Image/index.ts';
+
+import type {
+  Output,
+} from '@/features/TextToImage/types';
+
+const toOutputImage = (
+  givenImage: StabilityAIClient.Image,
+  given: {
+    description: string;
+  },
+): Output['image'] | null => {
+  if (
+    givenImage.base64 === undefined
+  ) return null;
+
+  const base64DataOfRawImage = Base64CharacterEncodedByteSequence.forciblyParsedFrom(givenImage.base64);
+
+  const derivedImage = {
+    uri        : new ImageURI('png', 'base64', base64DataOfRawImage),
+    description: given.description,
+  };
+
+  return derivedImage;
+};
+
+export {
+  toOutputImage,
+};

--- a/src/features/TextToImage/models/SDXL/client/index.ts
+++ b/src/features/TextToImage/models/SDXL/client/index.ts
@@ -5,12 +5,10 @@ import type {
 import Attempt from '@/library/Attempt';
 import HTTP from '@/library/HTTP';
 import ShimmedStabilityAIClient from '@/library/ShimmedStabilityAIClient/index.ts';
-import Base64CharacterEncodedByteSequence from '@/library/customTypes/Base64CharacterEncodedByteSequence.ts';
-import ImageURI from '@/library/customTypes/UniformResourceIdentifier/Data/Image/index.ts';
 
 import {
-  allSerialized,
-} from '@/features/TextToImage/models/SDXL/client/conversions/TextPrompt';
+  firstTextToImageOutput,
+} from './conversions/GenerateFromTextResponse';
 
 import type {
   Output,
@@ -91,36 +89,10 @@ const generateOutputFrom = async (
 
   const textToImageResponse = outcomeOfSettlingTextToImageResponse.unwrapped;
 
-  if (
-    !('artifacts' in textToImageResponse.result)
-  ) return ends.inFlamesBecause('Expected response body rather than readable stream');
-
-  const generatedArtifacts = textToImageResponse.result.artifacts;
-
-  if (
-    generatedArtifacts === undefined
-  ) return ends.inFlamesBecause('Expected artifacts in response result');
-
-  const [soleGeneratedArtifact] = generatedArtifacts;
-
-  if (
-    soleGeneratedArtifact === undefined
-  ) return ends.inFlamesBecause('Expected at least one artifact in response');
-
-  if (
-    soleGeneratedArtifact.base64 === undefined
-  ) return ends.inFlamesBecause('Expected image data from sole artifact');
-
-  const base64DataOfNewImage = Base64CharacterEncodedByteSequence.forciblyParsedFrom(soleGeneratedArtifact.base64);
-
-  const newImage = {
-    uri        : new ImageURI('png', 'base64', base64DataOfNewImage),
-    description: allSerialized(given.textToImageRequestBody.textPrompts),
-  };
-
-  const soleGeneratedOutput = {
-    image: newImage,
-  };
+  const soleGeneratedOutput = firstTextToImageOutput({
+    in          : textToImageResponse,
+    inferredFrom: given.textToImageRequestBody.textPrompts,
+  });
 
   return ends.inSuccessWith(soleGeneratedOutput);
 });

--- a/src/features/TextToImage/models/SDXL/client/index.ts
+++ b/src/features/TextToImage/models/SDXL/client/index.ts
@@ -118,9 +118,11 @@ const generateOutputFrom = async (
     description: allSerialized(given.textToImageRequestBody.textPrompts),
   };
 
-  return ends.inSuccessWith({
+  const soleGeneratedOutput = {
     image: newImage,
-  });
+  };
+
+  return ends.inSuccessWith(soleGeneratedOutput);
 });
 
 const SDXLTextToImageClient = {

--- a/src/features/TextToImage/models/SDXL/client/index.ts
+++ b/src/features/TextToImage/models/SDXL/client/index.ts
@@ -93,7 +93,7 @@ const generateOutputFrom = async (
 
   if (
     !('artifacts' in textToImageResponse.result)
-  ) return ends.inFlamesBecause('Expected response rather than readable stream');
+  ) return ends.inFlamesBecause('Expected response body rather than readable stream');
 
   const generatedArtifacts = textToImageResponse.result.artifacts;
 

--- a/src/library/utilitiesByType/array.ts
+++ b/src/library/utilitiesByType/array.ts
@@ -1,4 +1,6 @@
-const isEmpty = (givenSubject: unknown[]): givenSubject is [] => {
+const isEmpty = (
+  givenSubject: unknown[],
+): givenSubject is [] => {
   return givenSubject.length === 0;
 };
 

--- a/src/library/utilitiesByType/array.ts
+++ b/src/library/utilitiesByType/array.ts
@@ -4,6 +4,13 @@ const isEmpty = (
   return givenSubject.length === 0;
 };
 
+const hasAtLeastOne = <Element>(
+  givenElements: Element[],
+): givenElements is [Element, ...Element[]] => {
+  return !isEmpty(givenElements);
+};
+
 export {
   isEmpty,
+  hasAtLeastOne as hasAtLeastOne,
 };


### PR DESCRIPTION
- facilitates #408