### PR TITLE
refactor(library/Attempt): makes `Attempt.Outcome` discriminant more obvious

### DIFF
--- a/src/library/Attempt/Outcome/Discriminable.ts
+++ b/src/library/Attempt/Outcome/Discriminable.ts
@@ -15,7 +15,7 @@ interface SyntacticallySugarfreeDiscriminableOutcome<
 
 interface DiscriminableOutcome<
   SomePayload,
-  SomeDiscriminant extends Attempt_Outcome_Discriminant = Attempt_Outcome_Discriminant,
+  SomeDiscriminant extends Attempt_Outcome_Discriminant,
 > extends SyntacticallySugarfreeDiscriminableOutcome<
   SomeDiscriminant
 > {

--- a/src/library/Attempt/Outcome/Discriminable.ts
+++ b/src/library/Attempt/Outcome/Discriminable.ts
@@ -4,9 +4,11 @@ import type {
   Not,
 } from '@/library/typeUtilities/Boolean';
 
+type Attempt_Outcome_Discriminant = 'success' | 'failure';
+
 // cspell:words sugarfree discriminable
 interface SyntacticallySugarfreeDiscriminableOutcome {
-  readonly discriminant: 'success' | 'failure';
+  readonly discriminant: Attempt_Outcome_Discriminant;
 }
 
 interface DiscriminableOutcome<

--- a/src/library/Attempt/Outcome/Discriminable.ts
+++ b/src/library/Attempt/Outcome/Discriminable.ts
@@ -15,8 +15,9 @@ interface SyntacticallySugarfreeDiscriminableOutcome<
 
 interface DiscriminableOutcome<
   SomePayload,
+  SomeDiscriminant extends Attempt_Outcome_Discriminant = Attempt_Outcome_Discriminant,
 > extends SyntacticallySugarfreeDiscriminableOutcome<
-  Attempt_Outcome_Discriminant
+  SomeDiscriminant
 > {
   readonly isSuccess: Is<this['discriminant'], 'success'>;
   readonly isFailure: Not<this['isSuccess']>;

--- a/src/library/Attempt/Outcome/Discriminable.ts
+++ b/src/library/Attempt/Outcome/Discriminable.ts
@@ -7,8 +7,10 @@ import type {
 type Attempt_Outcome_Discriminant = 'success' | 'failure';
 
 // cspell:words sugarfree discriminable
-interface SyntacticallySugarfreeDiscriminableOutcome {
-  readonly discriminant: Attempt_Outcome_Discriminant;
+interface SyntacticallySugarfreeDiscriminableOutcome<
+  SomeDiscriminant extends Attempt_Outcome_Discriminant = Attempt_Outcome_Discriminant,
+> {
+  readonly discriminant: SomeDiscriminant;
 }
 
 interface DiscriminableOutcome<

--- a/src/library/Attempt/Outcome/Discriminable.ts
+++ b/src/library/Attempt/Outcome/Discriminable.ts
@@ -8,14 +8,16 @@ type Attempt_Outcome_Discriminant = 'success' | 'failure';
 
 // cspell:words sugarfree discriminable
 interface SyntacticallySugarfreeDiscriminableOutcome<
-  SomeDiscriminant extends Attempt_Outcome_Discriminant = Attempt_Outcome_Discriminant,
+  SomeDiscriminant extends Attempt_Outcome_Discriminant,
 > {
   readonly discriminant: SomeDiscriminant;
 }
 
 interface DiscriminableOutcome<
   SomeProduct,
-> extends SyntacticallySugarfreeDiscriminableOutcome {
+> extends SyntacticallySugarfreeDiscriminableOutcome<
+  Attempt_Outcome_Discriminant
+> {
   readonly isSuccess: Is<this['discriminant'], 'success'>;
   readonly isFailure: Not<this['isSuccess']>;
 

--- a/src/library/Attempt/Outcome/Discriminable.ts
+++ b/src/library/Attempt/Outcome/Discriminable.ts
@@ -6,13 +6,13 @@ import type {
 
 // cspell:words sugarfree discriminable
 interface SyntacticallySugarfreeDiscriminableOutcome {
-  readonly case: 'success' | 'failure';
+  readonly discriminant: 'success' | 'failure';
 }
 
 interface DiscriminableOutcome<
   SomeProduct,
 > extends SyntacticallySugarfreeDiscriminableOutcome {
-  readonly isSuccess: Is<this['case'], 'success'>;
+  readonly isSuccess: Is<this['discriminant'], 'success'>;
   readonly isFailure: Not<this['isSuccess']>;
 
   optionallyUnwrap(): If<this['isSuccess'],

--- a/src/library/Attempt/Outcome/Discriminable.ts
+++ b/src/library/Attempt/Outcome/Discriminable.ts
@@ -14,8 +14,8 @@ interface SyntacticallySugarfreeDiscriminableOutcome<
 }
 
 interface DiscriminableOutcome<
-  SomePayload,
   SomeDiscriminant extends Attempt_Outcome_Discriminant,
+  SomePayload,
 > extends SyntacticallySugarfreeDiscriminableOutcome<
   SomeDiscriminant
 > {

--- a/src/library/Attempt/Outcome/Discriminable.ts
+++ b/src/library/Attempt/Outcome/Discriminable.ts
@@ -14,7 +14,7 @@ interface SyntacticallySugarfreeDiscriminableOutcome<
 }
 
 interface DiscriminableOutcome<
-  SomeProduct,
+  SomePayload,
 > extends SyntacticallySugarfreeDiscriminableOutcome<
   Attempt_Outcome_Discriminant
 > {
@@ -22,12 +22,12 @@ interface DiscriminableOutcome<
   readonly isFailure: Not<this['isSuccess']>;
 
   optionallyUnwrap(): If<this['isSuccess'],
-    SomeProduct,
+    SomePayload,
     null
   >;
 
   forciblyUnwrap(): If<this['isSuccess'],
-    SomeProduct,
+    SomePayload,
     never
   >;
 }

--- a/src/library/Attempt/Outcome/Failure.ts
+++ b/src/library/Attempt/Outcome/Failure.ts
@@ -11,9 +11,9 @@ import type {
 interface SemanticallySugarfreeFailure<
   SomeActionableError extends ActionableError<string>,
 > extends DiscriminableOutcome<
-  unknown
+  unknown,
+  'failure'
 > {
-  readonly discriminant: 'failure';
   readonly cause: SomeActionableError;
 }
 

--- a/src/library/Attempt/Outcome/Failure.ts
+++ b/src/library/Attempt/Outcome/Failure.ts
@@ -11,8 +11,8 @@ import type {
 interface SemanticallySugarfreeFailure<
   SomeActionableError extends ActionableError<string>,
 > extends DiscriminableOutcome<
-  unknown,
-  'failure'
+  'failure',
+  unknown
 > {
   readonly cause: SomeActionableError;
 }

--- a/src/library/Attempt/Outcome/Failure.ts
+++ b/src/library/Attempt/Outcome/Failure.ts
@@ -13,7 +13,7 @@ interface SemanticallySugarfreeFailure<
 > extends DiscriminableOutcome<
   unknown
 > {
-  readonly case: 'failure';
+  readonly discriminant: 'failure';
   readonly cause: SomeActionableError;
 }
 
@@ -47,7 +47,7 @@ const failureDueTo = <
 >(
   givenCause: SomeActionableError,
 ): Attempt_Failure<SomeActionableError> => ({
-  case            : 'failure',
+  discriminant    : 'failure',
   cause           : givenCause,
   isSuccess       : false,
   isFailure       : true,

--- a/src/library/Attempt/Outcome/Success.ts
+++ b/src/library/Attempt/Outcome/Success.ts
@@ -7,9 +7,9 @@ import type {
 interface SemanticallySugarfreeSuccess<
   SomeProduct,
 > extends DiscriminableOutcome<
-  SomeProduct
+  SomeProduct,
+  'success'
 > {
-  readonly discriminant: 'success';
   readonly product: SomeProduct;
 }
 

--- a/src/library/Attempt/Outcome/Success.ts
+++ b/src/library/Attempt/Outcome/Success.ts
@@ -7,8 +7,8 @@ import type {
 interface SemanticallySugarfreeSuccess<
   SomeProduct,
 > extends DiscriminableOutcome<
-  SomeProduct,
-  'success'
+  'success',
+  SomeProduct
 > {
   readonly product: SomeProduct;
 }

--- a/src/library/Attempt/Outcome/Success.ts
+++ b/src/library/Attempt/Outcome/Success.ts
@@ -9,7 +9,7 @@ interface SemanticallySugarfreeSuccess<
 > extends DiscriminableOutcome<
   SomeProduct
 > {
-  readonly case: 'success';
+  readonly discriminant: 'success';
   readonly product: SomeProduct;
 }
 
@@ -55,7 +55,7 @@ const successThatYielded = <
 >(
   givenProduct: SomeProduct,
 ): Attempt_Success<SomeProduct> => ({
-  case            : 'success',
+  discriminant    : 'success',
   product         : givenProduct,
   isSuccess       : true,
   isFailure       : false,


### PR DESCRIPTION
- codifies that the interpretation of a payload in an outcome depends on the discriminant
- facilitates #408