### PR TITLE
linter(style): prevents noise in diffs when modifying generic declarations

### DIFF
--- a/src/features/TextToImage/config/utilities/DynamicConfig/EndpointResponseError.ts
+++ b/src/features/TextToImage/config/utilities/DynamicConfig/EndpointResponseError.ts
@@ -5,7 +5,9 @@ import type {
 } from '@/library/customTypes/URLComponent';
 
 class DynamicConfig_EndpointResponseError
-  extends Attempt.ActionableError<'DynamicConfig_EndpointResponseError'> {
+  extends Attempt.ActionableError<
+  'DynamicConfig_EndpointResponseError'
+> {
   public constructor(given: {
     endpoint: URLPath;
     response: Response;

--- a/src/features/TextToImage/config/utilities/DynamicConfig/EndpointResponseError.ts
+++ b/src/features/TextToImage/config/utilities/DynamicConfig/EndpointResponseError.ts
@@ -4,7 +4,8 @@ import type {
   URLPath,
 } from '@/library/customTypes/URLComponent';
 
-class DynamicConfig_EndpointResponseError extends Attempt.ActionableError<'DynamicConfig_EndpointResponseError'> {
+class DynamicConfig_EndpointResponseError
+  extends Attempt.ActionableError<'DynamicConfig_EndpointResponseError'> {
   public constructor(given: {
     endpoint: URLPath;
     response: Response;

--- a/src/features/TextToImage/config/utilities/DynamicConfig/FetchingError.ts
+++ b/src/features/TextToImage/config/utilities/DynamicConfig/FetchingError.ts
@@ -5,7 +5,9 @@ import type {
 } from '@/library/customTypes/URLComponent';
 
 class DynamicConfig_FetchingError
-  extends Attempt.ActionableError<'DynamicConfigFetchError'> {
+  extends Attempt.ActionableError<
+  'DynamicConfigFetchError'
+> {
   public constructor(givenEndpoint: URLPath) {
     super(`Failed to fetch text-to-image config from endpoint: ${givenEndpoint.toString()}`);
     this.name = 'DynamicConfig_FetchingError';

--- a/src/features/TextToImage/config/utilities/DynamicConfig/FetchingError.ts
+++ b/src/features/TextToImage/config/utilities/DynamicConfig/FetchingError.ts
@@ -4,7 +4,8 @@ import type {
   URLPath,
 } from '@/library/customTypes/URLComponent';
 
-class DynamicConfig_FetchingError extends Attempt.ActionableError<'DynamicConfigFetchError'> {
+class DynamicConfig_FetchingError
+  extends Attempt.ActionableError<'DynamicConfigFetchError'> {
   public constructor(givenEndpoint: URLPath) {
     super(`Failed to fetch text-to-image config from endpoint: ${givenEndpoint.toString()}`);
     this.name = 'DynamicConfig_FetchingError';

--- a/src/features/TextToImage/config/utilities/StaticConfig/StaticConfigReadingError.ts
+++ b/src/features/TextToImage/config/utilities/StaticConfig/StaticConfigReadingError.ts
@@ -4,7 +4,8 @@ import type {
   URLPath,
 } from '@/library/customTypes/URLComponent';
 
-class StaticConfigReadingError extends Attempt.ActionableError<'StaticConfigReadingError'> {
+class StaticConfigReadingError
+  extends Attempt.ActionableError<'StaticConfigReadingError'> {
   public constructor(givenFile: URLPath, givenResponse: Response) {
     super(`Failed to read config at "${givenFile.toString()}". Cause: "${givenResponse.statusText}"`);
     this.name = 'StaticConfigReadError';

--- a/src/features/TextToImage/config/utilities/StaticConfig/StaticConfigReadingError.ts
+++ b/src/features/TextToImage/config/utilities/StaticConfig/StaticConfigReadingError.ts
@@ -5,7 +5,9 @@ import type {
 } from '@/library/customTypes/URLComponent';
 
 class StaticConfigReadingError
-  extends Attempt.ActionableError<'StaticConfigReadingError'> {
+  extends Attempt.ActionableError<
+  'StaticConfigReadingError'
+> {
   public constructor(givenFile: URLPath, givenResponse: Response) {
     super(`Failed to read config at "${givenFile.toString()}". Cause: "${givenResponse.statusText}"`);
     this.name = 'StaticConfigReadError';

--- a/src/features/TextToImage/webAPI/Server/ServerConnectionError.ts
+++ b/src/features/TextToImage/webAPI/Server/ServerConnectionError.ts
@@ -1,7 +1,9 @@
 import Attempt from '@/library/Attempt';
 
 class TextToImage_Server_ConnectionError
-  extends Attempt.ActionableError<'TextToImage_ServerConnectionError'> {
+  extends Attempt.ActionableError<
+  'TextToImage_ServerConnectionError'
+> {
   public constructor(
     public readonly endpoint: URL,
   ) {

--- a/src/features/TextToImage/webAPI/Server/ServerConnectionError.ts
+++ b/src/features/TextToImage/webAPI/Server/ServerConnectionError.ts
@@ -1,6 +1,7 @@
 import Attempt from '@/library/Attempt';
 
-class TextToImage_Server_ConnectionError extends Attempt.ActionableError<'TextToImage_ServerConnectionError'> {
+class TextToImage_Server_ConnectionError
+  extends Attempt.ActionableError<'TextToImage_ServerConnectionError'> {
   public constructor(
     public readonly endpoint: URL,
   ) {

--- a/src/features/TextToImage/webAPI/Server/ServerSpecificationError.ts
+++ b/src/features/TextToImage/webAPI/Server/ServerSpecificationError.ts
@@ -5,7 +5,9 @@ import type {
 } from '@/library/customTypes/URLComponent';
 
 class TextToImage_Server_SpecificationError
-  extends Attempt.ActionableError<'TextToImage_Server_SpecificationError'> {
+  extends Attempt.ActionableError<
+  'TextToImage_Server_SpecificationError'
+> {
   public constructor(
     public readonly environmentKey: string,
     public readonly file: URLPath,

--- a/src/features/TextToImage/webAPI/Server/ServerSpecificationError.ts
+++ b/src/features/TextToImage/webAPI/Server/ServerSpecificationError.ts
@@ -4,7 +4,8 @@ import type {
   URLPath,
 } from '@/library/customTypes/URLComponent';
 
-class TextToImage_Server_SpecificationError extends Attempt.ActionableError<'TextToImage_Server_SpecificationError'> {
+class TextToImage_Server_SpecificationError
+  extends Attempt.ActionableError<'TextToImage_Server_SpecificationError'> {
   public constructor(
     public readonly environmentKey: string,
     public readonly file: URLPath,

--- a/src/library/Attempt/Outcome/Failure.ts
+++ b/src/library/Attempt/Outcome/Failure.ts
@@ -10,14 +10,18 @@ import type {
 
 interface SemanticallySugarfreeFailure<
   SomeActionableError extends ActionableError<string>,
-> extends DiscriminableOutcome<unknown> {
+> extends DiscriminableOutcome<
+  unknown
+> {
   readonly case: 'failure';
   readonly cause: SomeActionableError;
 }
 
 interface Attempt_Failure<
   SomeActionableError extends ActionableError<string>,
-> extends SemanticallySugarfreeFailure<SomeActionableError> {
+> extends SemanticallySugarfreeFailure<
+  SomeActionableError
+> {
   /**
    * Semantic sugar for `cause`; useful for juxtaposition against early exits:
    * ```ts

--- a/src/library/Attempt/Outcome/Success.ts
+++ b/src/library/Attempt/Outcome/Success.ts
@@ -4,12 +4,16 @@ import type {
   DiscriminableOutcome,
 } from './Discriminable';
 
-interface SemanticallySugarfreeSuccess<SomeProduct> extends DiscriminableOutcome<SomeProduct> {
+interface SemanticallySugarfreeSuccess<
+  SomeProduct,
+> extends DiscriminableOutcome<SomeProduct> {
   readonly case: 'success';
   readonly product: SomeProduct;
 }
 
-interface Attempt_Success<SomeProduct> extends SemanticallySugarfreeSuccess<SomeProduct> {
+interface Attempt_Success<
+  SomeProduct,
+> extends SemanticallySugarfreeSuccess<SomeProduct> {
   /**
    * Access the product nested within a successful outcome.
    *

--- a/src/library/Attempt/Outcome/Success.ts
+++ b/src/library/Attempt/Outcome/Success.ts
@@ -6,14 +6,18 @@ import type {
 
 interface SemanticallySugarfreeSuccess<
   SomeProduct,
-> extends DiscriminableOutcome<SomeProduct> {
+> extends DiscriminableOutcome<
+  SomeProduct
+> {
   readonly case: 'success';
   readonly product: SomeProduct;
 }
 
 interface Attempt_Success<
   SomeProduct,
-> extends SemanticallySugarfreeSuccess<SomeProduct> {
+> extends SemanticallySugarfreeSuccess<
+  SomeProduct
+> {
   /**
    * Access the product nested within a successful outcome.
    *

--- a/src/library/Attempt/error/ActionableError.ts
+++ b/src/library/Attempt/error/ActionableError.ts
@@ -7,8 +7,9 @@ import {
 } from '.';
 
 /** Extend this class to describe errors from which callers ought to recover */
-abstract class ActionableError<SomeBrand extends string>
-  extends Error
+abstract class ActionableError<
+  SomeBrand extends string,
+> extends Error
   implements Branded<SomeBrand> {
   public readonly brand!: SomeBrand;
 

--- a/src/library/Attempt/error/ActionableError.ts
+++ b/src/library/Attempt/error/ActionableError.ts
@@ -10,7 +10,9 @@ import {
 abstract class ActionableError<
   SomeBrand extends string,
 > extends Error
-  implements Branded<SomeBrand> {
+  implements Branded<
+  SomeBrand
+> {
   public readonly brand!: SomeBrand;
 
   public throwAnyway = (

--- a/src/library/Attempt/error/NonActionableBuiltInError.ts
+++ b/src/library/Attempt/error/NonActionableBuiltInError.ts
@@ -4,27 +4,33 @@ import type {
 
 // These augmentations allow TypeScript to distinguish these error types from `Error` at the annotation level.
 declare global {
-  interface ReferenceError extends Branded<'ReferenceError'> {
+  interface ReferenceError
+    extends Branded<'ReferenceError'> {
     readonly brand: this['name'];
   }
 
-  interface TypeError extends Branded<'TypeError'> {
+  interface TypeError
+    extends Branded<'TypeError'> {
     readonly brand: this['name'];
   }
 
-  interface RangeError extends Branded<'RangeError'> {
+  interface RangeError
+    extends Branded<'RangeError'> {
     readonly brand: this['name'];
   }
 
-  interface URIError extends Branded<'URIError'> {
+  interface URIError
+    extends Branded<'URIError'> {
     readonly brand: this['name'];
   }
 
-  interface EvalError extends Branded<'EvalError'> {
+  interface EvalError
+    extends Branded<'EvalError'> {
     readonly brand: this['name'];
   }
 
-  interface SyntaxError extends Branded<'SyntaxError'> {
+  interface SyntaxError
+    extends Branded<'SyntaxError'> {
     readonly brand: this['name'];
   }
 }

--- a/src/library/Attempt/error/NonActionableBuiltInError.ts
+++ b/src/library/Attempt/error/NonActionableBuiltInError.ts
@@ -5,32 +5,44 @@ import type {
 // These augmentations allow TypeScript to distinguish these error types from `Error` at the annotation level.
 declare global {
   interface ReferenceError
-    extends Branded<'ReferenceError'> {
+    extends Branded<
+    'ReferenceError'
+  > {
     readonly brand: this['name'];
   }
 
   interface TypeError
-    extends Branded<'TypeError'> {
+    extends Branded<
+    'TypeError'
+  > {
     readonly brand: this['name'];
   }
 
   interface RangeError
-    extends Branded<'RangeError'> {
+    extends Branded<
+    'RangeError'
+  > {
     readonly brand: this['name'];
   }
 
   interface URIError
-    extends Branded<'URIError'> {
+    extends Branded<
+    'URIError'
+  > {
     readonly brand: this['name'];
   }
 
   interface EvalError
-    extends Branded<'EvalError'> {
+    extends Branded<
+    'EvalError'
+  > {
     readonly brand: this['name'];
   }
 
   interface SyntaxError
-    extends Branded<'SyntaxError'> {
+    extends Branded<
+    'SyntaxError'
+  > {
     readonly brand: this['name'];
   }
 }

--- a/src/library/Attempt/error/NonActionableError.ts
+++ b/src/library/Attempt/error/NonActionableError.ts
@@ -16,7 +16,9 @@ interface NonActionableError_Options
  */
 class NonActionableError
   extends Error
-  implements Branded<'NonActionableError'> {
+  implements Branded<
+  'NonActionableError'
+> {
   public readonly brand!: 'NonActionableError';
 
   protected constructor(

--- a/src/library/Attempt/error/NonActionableError.ts
+++ b/src/library/Attempt/error/NonActionableError.ts
@@ -2,7 +2,8 @@ import type {
   Branded,
 } from '@/library/typeUtilities/Branded';
 
-interface NonActionableError_Options extends ErrorOptions {
+interface NonActionableError_Options
+  extends ErrorOptions {
   /** A function that's acting as an alternative to raw `throw` */
   thrower?: (...parameters: any[]) => unknown; // eslint-disable-line @typescript-eslint/no-explicit-any
 }

--- a/src/library/Attempt/factory/AttemptCreationError.ts
+++ b/src/library/Attempt/factory/AttemptCreationError.ts
@@ -1,6 +1,7 @@
 import NonActionableError from '../error/NonActionableError';
 
-class AttemptCreationError extends NonActionableError {
+class AttemptCreationError
+  extends NonActionableError {
   public override readonly cause: Error;
 
   private constructor(

--- a/src/library/Base64/CharacterSequence/ConformanceError.ts
+++ b/src/library/Base64/CharacterSequence/ConformanceError.ts
@@ -3,7 +3,9 @@ import Attempt from '@/library/Attempt';
 import Base64_Alphabet from '../Alphabet';
 
 class Base64_CharacterSequence_ConformanceError
-  extends Attempt.ActionableError<'Base64_CharacterSequence_ConformanceError'> {
+  extends Attempt.ActionableError<
+  'Base64_CharacterSequence_ConformanceError'
+> {
   public constructor() {
     super(`Sequence contained 1+ character(s) outside of the Base64 Alphabet: ${Base64_Alphabet.pattern.toString()}`);
     this.name = 'Base64_CharacterSequence_ConformanceError';

--- a/src/library/Base64/CharacterSequence/ConformanceError.ts
+++ b/src/library/Base64/CharacterSequence/ConformanceError.ts
@@ -2,7 +2,8 @@ import Attempt from '@/library/Attempt';
 
 import Base64_Alphabet from '../Alphabet';
 
-class Base64_CharacterSequence_ConformanceError extends Attempt.ActionableError<'Base64_CharacterSequence_ConformanceError'> {
+class Base64_CharacterSequence_ConformanceError
+  extends Attempt.ActionableError<'Base64_CharacterSequence_ConformanceError'> {
   public constructor() {
     super(`Sequence contained 1+ character(s) outside of the Base64 Alphabet: ${Base64_Alphabet.pattern.toString()}`);
     this.name = 'Base64_CharacterSequence_ConformanceError';

--- a/src/library/Byte/Sequence/EncodingCompatibilityError.ts
+++ b/src/library/Byte/Sequence/EncodingCompatibilityError.ts
@@ -5,7 +5,9 @@ import {
 } from '..';
 
 class Byte_Sequence_EncodingCompatibilityError
-  extends Attempt.ActionableError<'Byte_Sequence_EncodingCompatibilityError'> {
+  extends Attempt.ActionableError<
+  'Byte_Sequence_EncodingCompatibilityError'
+> {
   public constructor(givenBitWidth: number) {
     const byteCofactor = Byte_cofactorTo(givenBitWidth);
     super(`Character count for ${givenBitWidth.toString()}-bit sequence must be a multiple of ${byteCofactor.toString()} to be byte encodable`);

--- a/src/library/Byte/Sequence/EncodingCompatibilityError.ts
+++ b/src/library/Byte/Sequence/EncodingCompatibilityError.ts
@@ -4,7 +4,8 @@ import {
   cofactorTo as Byte_cofactorTo,
 } from '..';
 
-class Byte_Sequence_EncodingCompatibilityError extends Attempt.ActionableError<'Byte_Sequence_EncodingCompatibilityError'> {
+class Byte_Sequence_EncodingCompatibilityError
+  extends Attempt.ActionableError<'Byte_Sequence_EncodingCompatibilityError'> {
   public constructor(givenBitWidth: number) {
     const byteCofactor = Byte_cofactorTo(givenBitWidth);
     super(`Character count for ${givenBitWidth.toString()}-bit sequence must be a multiple of ${byteCofactor.toString()} to be byte encodable`);

--- a/src/library/HTTP/Endpoint/RequestError.ts
+++ b/src/library/HTTP/Endpoint/RequestError.ts
@@ -1,6 +1,7 @@
 import Attempt from '@/library/Attempt';
 
-class HTTP_Endpoint_RequestError extends Attempt.ActionableError<'HTTP_Endpoint_RequestError'> {
+class HTTP_Endpoint_RequestError
+  extends Attempt.ActionableError<'HTTP_Endpoint_RequestError'> {
   public constructor(
     public readonly endpoint: URL,
   ) {

--- a/src/library/HTTP/Endpoint/RequestError.ts
+++ b/src/library/HTTP/Endpoint/RequestError.ts
@@ -1,7 +1,9 @@
 import Attempt from '@/library/Attempt';
 
 class HTTP_Endpoint_RequestError
-  extends Attempt.ActionableError<'HTTP_Endpoint_RequestError'> {
+  extends Attempt.ActionableError<
+  'HTTP_Endpoint_RequestError'
+> {
   public constructor(
     public readonly endpoint: URL,
   ) {

--- a/src/library/HTTP/Endpoint/ResponseError.ts
+++ b/src/library/HTTP/Endpoint/ResponseError.ts
@@ -4,7 +4,8 @@ import type {
   HTTP_Response,
 } from '../Response';
 
-class HTTP_Endpoint_ResponseError extends Attempt.ActionableError<'HTTP_Endpoint_ResponseError'> {
+class HTTP_Endpoint_ResponseError
+  extends Attempt.ActionableError<'HTTP_Endpoint_ResponseError'> {
   public readonly status: HTTP_Response.StatusCode.Error.Any;
 
   public constructor(givenMessage: string, givenStatus: HTTP_Response.StatusCode.Error.Any) {

--- a/src/library/HTTP/Endpoint/ResponseError.ts
+++ b/src/library/HTTP/Endpoint/ResponseError.ts
@@ -5,7 +5,9 @@ import type {
 } from '../Response';
 
 class HTTP_Endpoint_ResponseError
-  extends Attempt.ActionableError<'HTTP_Endpoint_ResponseError'> {
+  extends Attempt.ActionableError<
+  'HTTP_Endpoint_ResponseError'
+> {
   public readonly status: HTTP_Response.StatusCode.Error.Any;
 
   public constructor(givenMessage: string, givenStatus: HTTP_Response.StatusCode.Error.Any) {

--- a/src/library/Parser/ParsingError.ts
+++ b/src/library/Parser/ParsingError.ts
@@ -2,7 +2,9 @@ import Attempt from '@/library/Attempt';
 
 abstract class ParsingError<
   SomeSubject extends string,
-> extends Attempt.ActionableError<`${SomeSubject}_ParsingError`> {
+> extends Attempt.ActionableError<
+  `${SomeSubject}_ParsingError`
+> {
   public constructor(
     givenMessage: string,
     givenCause?: Error,

--- a/src/library/Range/DiscreteRange.ts
+++ b/src/library/Range/DiscreteRange.ts
@@ -2,7 +2,8 @@ import Attempt from '@/library/Attempt';
 
 import Range from './index.ts';
 
-class DiscreteRange extends Range {
+class DiscreteRange
+  extends Range {
   public constructor(
     lowerBound: Range['lowerBound'],
     upperBound: Range['upperBound'],

--- a/src/library/ShimmedStabilityAIClient/index.ts
+++ b/src/library/ShimmedStabilityAIClient/index.ts
@@ -102,7 +102,8 @@ const z_imageGenerationResponseBody = z.object({
 
 const generationEndpoint = URLPath.parsedFrom('/generate').forciblyUnwrap();
 
-class ImageClient extends HTTP.Client {
+class ImageClient
+  extends HTTP.Client {
   public async forciblyGenerateFromText(
     givenRequest: GenerateFromTextRequest,
   ): Promise<GenerateFromTextResponse> {
@@ -136,7 +137,8 @@ class ImageClient extends HTTP.Client {
   }
 }
 
-class Version1Client extends HTTP.Client {
+class Version1Client
+  extends HTTP.Client {
   private _image?: ImageClient;
 
   public get image(): ImageClient {
@@ -145,7 +147,8 @@ class Version1Client extends HTTP.Client {
   }
 }
 
-class ShimmedStabilityAIClient extends HTTP.Client {
+class ShimmedStabilityAIClient
+  extends HTTP.Client {
   public constructor(given: {
     serverURL: string;
   }) {

--- a/src/library/customTypes/Base64CharacterEncodedByteSequence.ts
+++ b/src/library/customTypes/Base64CharacterEncodedByteSequence.ts
@@ -16,7 +16,9 @@ import StringSubset from './StringSubset.ts';
 class Base64CharacterEncodedByteSequence
   extends StringSubset<
   'Base64CharacterEncodedByteSequence'
-> implements StringForciblyParsable<typeof Base64CharacterEncodedByteSequence> {
+> implements StringForciblyParsable<
+  typeof Base64CharacterEncodedByteSequence
+> {
   public static paddingCharacter = '=';
 
   private static readonly byteCofactor = Byte.cofactorTo(Base64.bitWidth);

--- a/src/library/customTypes/Base64CharacterEncodedByteSequence.ts
+++ b/src/library/customTypes/Base64CharacterEncodedByteSequence.ts
@@ -14,8 +14,9 @@ import StringSubset from './StringSubset.ts';
 
 /** See [RFC 4648 Section 4](https://www.rfc-editor.org/rfc/rfc4648.html#section-4) for more information */
 class Base64CharacterEncodedByteSequence
-  extends StringSubset<'Base64CharacterEncodedByteSequence'>
-  implements StringForciblyParsable<typeof Base64CharacterEncodedByteSequence> {
+  extends StringSubset<
+  'Base64CharacterEncodedByteSequence'
+> implements StringForciblyParsable<typeof Base64CharacterEncodedByteSequence> {
   public static paddingCharacter = '=';
 
   private static readonly byteCofactor = Byte.cofactorTo(Base64.bitWidth);

--- a/src/library/customTypes/NonTrivialString/ParsingError.ts
+++ b/src/library/customTypes/NonTrivialString/ParsingError.ts
@@ -3,7 +3,9 @@ import {
 } from '@/library/Parser';
 
 class NonTrivialString_ParsingError
-  extends ParsingError<'NonTrivialString'> {
+  extends ParsingError<
+  'NonTrivialString'
+> {
   public constructor(givenCulprit: string) {
     super(`Expected string to contain something beyond just whitespace, got "${givenCulprit}"`);
     this.name = 'NonTrivialString_ParsingError';

--- a/src/library/customTypes/NonTrivialString/ParsingError.ts
+++ b/src/library/customTypes/NonTrivialString/ParsingError.ts
@@ -2,7 +2,8 @@ import {
   ParsingError,
 } from '@/library/Parser';
 
-class NonTrivialString_ParsingError extends ParsingError<'NonTrivialString'> {
+class NonTrivialString_ParsingError
+  extends ParsingError<'NonTrivialString'> {
   public constructor(givenCulprit: string) {
     super(`Expected string to contain something beyond just whitespace, got "${givenCulprit}"`);
     this.name = 'NonTrivialString_ParsingError';

--- a/src/library/customTypes/NonTrivialString/index.ts
+++ b/src/library/customTypes/NonTrivialString/index.ts
@@ -13,8 +13,9 @@ import StringSubset from '../StringSubset.ts';
 import NonTrivialString_ParsingError from './ParsingError.ts';
 
 class NonTrivialString
-  extends StringSubset<'NonTrivialString'>
-  implements StringParsable<typeof NonTrivialString> {
+  extends StringSubset<
+  'NonTrivialString'
+> implements StringParsable<typeof NonTrivialString> {
   public static parsedFrom = (
     givenSubject: string,
   ): Attempt.Outcome<NonTrivialString, NonTrivialString_ParsingError> => Attempt.that((ends) => {

--- a/src/library/customTypes/NonTrivialString/index.ts
+++ b/src/library/customTypes/NonTrivialString/index.ts
@@ -15,7 +15,9 @@ import NonTrivialString_ParsingError from './ParsingError.ts';
 class NonTrivialString
   extends StringSubset<
   'NonTrivialString'
-> implements StringParsable<typeof NonTrivialString> {
+> implements StringParsable<
+  typeof NonTrivialString
+> {
   public static parsedFrom = (
     givenSubject: string,
   ): Attempt.Outcome<NonTrivialString, NonTrivialString_ParsingError> => Attempt.that((ends) => {

--- a/src/library/customTypes/StringSubset.ts
+++ b/src/library/customTypes/StringSubset.ts
@@ -5,8 +5,9 @@ import type {
 /**
  * When an open-ended `string` is too permissive, extend this class and provide a means to instantiate some subset
  */
-abstract class StringSubset<SomeBrand extends string>
-  extends String
+abstract class StringSubset<
+  SomeBrand extends string,
+> extends String
   implements Branded<SomeBrand> {
   public readonly brand!: SomeBrand;
 }

--- a/src/library/customTypes/StringSubset.ts
+++ b/src/library/customTypes/StringSubset.ts
@@ -8,7 +8,9 @@ import type {
 abstract class StringSubset<
   SomeBrand extends string,
 > extends String
-  implements Branded<SomeBrand> {
+  implements Branded<
+  SomeBrand
+> {
   public readonly brand!: SomeBrand;
 }
 

--- a/src/library/customTypes/URLComponent/URLOrigin.ts
+++ b/src/library/customTypes/URLComponent/URLOrigin.ts
@@ -26,7 +26,9 @@ class URLOrigin_ParsingError
 class URLOrigin
   extends StringSubset<
   'URLOrigin'
-> implements StringParsable<typeof URLOrigin> {
+> implements StringParsable<
+  typeof URLOrigin
+> {
   public static parsedFrom = (
     givenSubject: string,
   ): Attempt.Outcome<URLOrigin, URLOrigin_ParsingError> => Attempt.that((ends) => {

--- a/src/library/customTypes/URLComponent/URLOrigin.ts
+++ b/src/library/customTypes/URLComponent/URLOrigin.ts
@@ -11,7 +11,9 @@ import type {
 import StringSubset from '@/library/customTypes/StringSubset.ts';
 
 class URLOrigin_ParsingError
-  extends ParsingError<'URLOrigin'> {
+  extends ParsingError<
+  'URLOrigin'
+> {
   public constructor(given: {
     expectation: string;
     reality: string;
@@ -22,8 +24,9 @@ class URLOrigin_ParsingError
 }
 
 class URLOrigin
-  extends StringSubset<'URLOrigin'>
-  implements StringParsable<typeof URLOrigin> {
+  extends StringSubset<
+  'URLOrigin'
+> implements StringParsable<typeof URLOrigin> {
   public static parsedFrom = (
     givenSubject: string,
   ): Attempt.Outcome<URLOrigin, URLOrigin_ParsingError> => Attempt.that((ends) => {

--- a/src/library/customTypes/URLComponent/URLOrigin.ts
+++ b/src/library/customTypes/URLComponent/URLOrigin.ts
@@ -10,7 +10,8 @@ import type {
 
 import StringSubset from '@/library/customTypes/StringSubset.ts';
 
-class URLOrigin_ParsingError extends ParsingError<'URLOrigin'> {
+class URLOrigin_ParsingError
+  extends ParsingError<'URLOrigin'> {
   public constructor(given: {
     expectation: string;
     reality: string;

--- a/src/library/customTypes/URLComponent/URLPath.ts
+++ b/src/library/customTypes/URLComponent/URLPath.ts
@@ -26,7 +26,9 @@ class URLPath_ParsingError
 class URLPath
   extends StringSubset<
   'URLPath'
-> implements StringParsable<typeof URLPath> {
+> implements StringParsable<
+  typeof URLPath
+> {
   public static parsedFrom = (
     givenSubject: string,
   ): Attempt.Outcome<URLPath, URLPath_ParsingError> => Attempt.that((ends) => {

--- a/src/library/customTypes/URLComponent/URLPath.ts
+++ b/src/library/customTypes/URLComponent/URLPath.ts
@@ -11,7 +11,9 @@ import type {
 import StringSubset from '@/library/customTypes/StringSubset.ts';
 
 class URLPath_ParsingError
-  extends ParsingError<'URLPath'> {
+  extends ParsingError<
+  'URLPath'
+> {
   public constructor(given: {
     expectation: string;
     reality: string;
@@ -22,8 +24,9 @@ class URLPath_ParsingError
 }
 
 class URLPath
-  extends StringSubset<'URLPath'>
-  implements StringParsable<typeof URLPath> {
+  extends StringSubset<
+  'URLPath'
+> implements StringParsable<typeof URLPath> {
   public static parsedFrom = (
     givenSubject: string,
   ): Attempt.Outcome<URLPath, URLPath_ParsingError> => Attempt.that((ends) => {

--- a/src/library/customTypes/URLComponent/URLPath.ts
+++ b/src/library/customTypes/URLComponent/URLPath.ts
@@ -10,7 +10,8 @@ import type {
 
 import StringSubset from '@/library/customTypes/StringSubset.ts';
 
-class URLPath_ParsingError extends ParsingError<'URLPath'> {
+class URLPath_ParsingError
+  extends ParsingError<'URLPath'> {
   public constructor(given: {
     expectation: string;
     reality: string;

--- a/src/library/customTypes/UniformResourceIdentifier/Data/Image/ParsingError.ts
+++ b/src/library/customTypes/UniformResourceIdentifier/Data/Image/ParsingError.ts
@@ -2,7 +2,8 @@ import {
   ParsingError,
 } from '@/library/Parser';
 
-class ImageURI_ParsingError extends ParsingError<'ImageURI'> {
+class ImageURI_ParsingError
+  extends ParsingError<'ImageURI'> {
   public constructor(givenMessage: string) {
     super(givenMessage);
     this.name = 'ImageURI_ParsingError';

--- a/src/library/customTypes/UniformResourceIdentifier/Data/Image/ParsingError.ts
+++ b/src/library/customTypes/UniformResourceIdentifier/Data/Image/ParsingError.ts
@@ -3,7 +3,9 @@ import {
 } from '@/library/Parser';
 
 class ImageURI_ParsingError
-  extends ParsingError<'ImageURI'> {
+  extends ParsingError<
+  'ImageURI'
+> {
   public constructor(givenMessage: string) {
     super(givenMessage);
     this.name = 'ImageURI_ParsingError';

--- a/src/library/customTypes/UniformResourceIdentifier/Data/Image/index.ts
+++ b/src/library/customTypes/UniformResourceIdentifier/Data/Image/index.ts
@@ -14,7 +14,8 @@ import {
 
 import ImageURI_ParsingError from './ParsingError.ts';
 
-class ImageURI extends DataURI {
+class ImageURI
+  extends DataURI {
   public static readonly mediaType = 'image';
 
   private readonly _format: ImageURIFormat;

--- a/src/library/customTypes/UniformResourceIdentifier/Data/MediaType/ParsingError.ts
+++ b/src/library/customTypes/UniformResourceIdentifier/Data/MediaType/ParsingError.ts
@@ -3,7 +3,9 @@ import {
 } from '@/library/Parser';
 
 class MediaType_ParsingError
-  extends ParsingError<'MediaType'> {
+  extends ParsingError<
+  'MediaType'
+> {
   public constructor(givenMessage: string) {
     super(givenMessage);
     this.name = 'MediaType_ParsingError';

--- a/src/library/customTypes/UniformResourceIdentifier/Data/MediaType/ParsingError.ts
+++ b/src/library/customTypes/UniformResourceIdentifier/Data/MediaType/ParsingError.ts
@@ -2,7 +2,8 @@ import {
   ParsingError,
 } from '@/library/Parser';
 
-class MediaType_ParsingError extends ParsingError<'MediaType'> {
+class MediaType_ParsingError
+  extends ParsingError<'MediaType'> {
   public constructor(givenMessage: string) {
     super(givenMessage);
     this.name = 'MediaType_ParsingError';

--- a/src/library/customTypes/UniformResourceIdentifier/Data/MediaType/StructuredSyntaxNameSuffix/ParsingError.ts
+++ b/src/library/customTypes/UniformResourceIdentifier/Data/MediaType/StructuredSyntaxNameSuffix/ParsingError.ts
@@ -3,7 +3,9 @@ import {
 } from '@/library/Parser';
 
 class StructuredSyntaxNameSuffix_ParsingError
-  extends ParsingError<'StructuredSyntaxNameSuffix'> {
+  extends ParsingError<
+  'StructuredSyntaxNameSuffix'
+> {
   public constructor(givenCases: readonly string[]) {
     super(`Expected structured syntax name suffix as one of ${givenCases.toString()}`);
     this.name = 'StructuredSyntaxNameSuffix_ParsingError';

--- a/src/library/customTypes/UniformResourceIdentifier/Data/MediaType/StructuredSyntaxNameSuffix/ParsingError.ts
+++ b/src/library/customTypes/UniformResourceIdentifier/Data/MediaType/StructuredSyntaxNameSuffix/ParsingError.ts
@@ -2,7 +2,8 @@ import {
   ParsingError,
 } from '@/library/Parser';
 
-class StructuredSyntaxNameSuffix_ParsingError extends ParsingError<'StructuredSyntaxNameSuffix'> {
+class StructuredSyntaxNameSuffix_ParsingError
+  extends ParsingError<'StructuredSyntaxNameSuffix'> {
   public constructor(givenCases: readonly string[]) {
     super(`Expected structured syntax name suffix as one of ${givenCases.toString()}`);
     this.name = 'StructuredSyntaxNameSuffix_ParsingError';

--- a/src/library/customTypes/UniformResourceIdentifier/Data/MediaType/index.ts
+++ b/src/library/customTypes/UniformResourceIdentifier/Data/MediaType/index.ts
@@ -19,7 +19,8 @@ const allFileTypes = [
 type FileType = (typeof allFileTypes)[number];
 
 /** See [RFC 2045](https://datatracker.ietf.org/doc/html/rfc2045) for more information */
-class MediaType implements StringForciblyParsable<typeof MediaType> {
+class MediaType
+implements StringForciblyParsable<typeof MediaType> {
   public constructor(
     public fileType: FileType,
     public tree: string[] | null,

--- a/src/library/customTypes/UniformResourceIdentifier/Data/MediaType/index.ts
+++ b/src/library/customTypes/UniformResourceIdentifier/Data/MediaType/index.ts
@@ -20,7 +20,9 @@ type FileType = (typeof allFileTypes)[number];
 
 /** See [RFC 2045](https://datatracker.ietf.org/doc/html/rfc2045) for more information */
 class MediaType
-implements StringForciblyParsable<typeof MediaType> {
+implements StringForciblyParsable<
+  typeof MediaType
+> {
   public constructor(
     public fileType: FileType,
     public tree: string[] | null,

--- a/src/library/customTypes/UniformResourceIdentifier/Data/ParsingError.ts
+++ b/src/library/customTypes/UniformResourceIdentifier/Data/ParsingError.ts
@@ -2,7 +2,8 @@ import {
   ParsingError,
 } from '@/library/Parser';
 
-class DataURI_ParsingError extends ParsingError<'DataURI'> {
+class DataURI_ParsingError
+  extends ParsingError<'DataURI'> {
   public constructor(givenMessage: string) {
     super(givenMessage);
     this.name = 'DataURI_ParsingError';

--- a/src/library/customTypes/UniformResourceIdentifier/Data/ParsingError.ts
+++ b/src/library/customTypes/UniformResourceIdentifier/Data/ParsingError.ts
@@ -3,7 +3,9 @@ import {
 } from '@/library/Parser';
 
 class DataURI_ParsingError
-  extends ParsingError<'DataURI'> {
+  extends ParsingError<
+  'DataURI'
+> {
   public constructor(givenMessage: string) {
     super(givenMessage);
     this.name = 'DataURI_ParsingError';

--- a/src/library/customTypes/UniformResourceIdentifier/Data/index.ts
+++ b/src/library/customTypes/UniformResourceIdentifier/Data/index.ts
@@ -17,7 +17,8 @@ import MediaType from './MediaType';
 import DataURI_ParsingError from './ParsingError.ts';
 
 /** See [RFC 2397](https://datatracker.ietf.org/doc/rfc2397) for more info */
-class DataURI extends UniformResourceIdentifier {
+class DataURI
+  extends UniformResourceIdentifier {
   public static readonly scheme = NonTrivialString.parsedFrom('data').forciblyUnwrap();
   public static readonly encodingPrefix = ';';
   public static readonly dataPrefix = ',';

--- a/src/library/customTypes/UniformResourceIdentifier/ParsingError.ts
+++ b/src/library/customTypes/UniformResourceIdentifier/ParsingError.ts
@@ -3,7 +3,9 @@ import {
 } from '@/library/Parser';
 
 class URI_ParsingError
-  extends ParsingError<'URI'> {
+  extends ParsingError<
+  'URI'
+> {
   public constructor(givenMessage: string) {
     super(givenMessage);
     this.name = 'URI_ParsingError';

--- a/src/library/customTypes/UniformResourceIdentifier/ParsingError.ts
+++ b/src/library/customTypes/UniformResourceIdentifier/ParsingError.ts
@@ -2,7 +2,8 @@ import {
   ParsingError,
 } from '@/library/Parser';
 
-class URI_ParsingError extends ParsingError<'URI'> {
+class URI_ParsingError
+  extends ParsingError<'URI'> {
   public constructor(givenMessage: string) {
     super(givenMessage);
     this.name = 'URI_ParsingError';

--- a/src/library/customTypes/UniformResourceIdentifier/index.ts
+++ b/src/library/customTypes/UniformResourceIdentifier/index.ts
@@ -16,7 +16,9 @@ import URI_ParsingError from './ParsingError';
  * See [RFC 3986](https://www.rfc-editor.org/rfc/rfc3986) for more information
  */
 class UniformResourceIdentifier
-implements StringForciblyParsable<typeof UniformResourceIdentifier> {
+implements StringForciblyParsable<
+  typeof UniformResourceIdentifier
+> {
   private readonly _scheme: /*   */ NonTrivialString;
   private readonly _authority: /**/ NonTrivialString | null;
   private readonly _path: /*     */ NonTrivialString | null;

--- a/src/library/customTypes/UniformResourceIdentifier/index.ts
+++ b/src/library/customTypes/UniformResourceIdentifier/index.ts
@@ -15,7 +15,8 @@ import URI_ParsingError from './ParsingError';
  * Identifies an abstract or physical resource.
  * See [RFC 3986](https://www.rfc-editor.org/rfc/rfc3986) for more information
  */
-class UniformResourceIdentifier implements StringForciblyParsable<typeof UniformResourceIdentifier> {
+class UniformResourceIdentifier
+implements StringForciblyParsable<typeof UniformResourceIdentifier> {
   private readonly _scheme: /*   */ NonTrivialString;
   private readonly _authority: /**/ NonTrivialString | null;
   private readonly _path: /*     */ NonTrivialString | null;

--- a/src/library/modifiersByType/error/Contextualized.ts
+++ b/src/library/modifiersByType/error/Contextualized.ts
@@ -10,7 +10,9 @@ type Contextualized<
   }
 ;
 
-interface Instantiable<Any> {
+interface Instantiable<
+  Any,
+> {
   [Symbol.hasInstance]: (value: unknown) => value is Any;
 }
 

--- a/src/library/typeUtilities/Branded.ts
+++ b/src/library/typeUtilities/Branded.ts
@@ -4,7 +4,9 @@
  * When implemented by a class, makes subclasses structurally different from each other such that
  * the type-checker will complain if you try to assign a subclass to a variable of a different subclass.
  */
-interface Branded<SomeBrand extends string> {
+interface Branded<
+  SomeBrand extends string,
+> {
   /**
    * Allows the type-checker to discern between subclasses and complain about mismatched types.
    */

--- a/src/library/typeUtilities/ForcibleStringParser.ts
+++ b/src/library/typeUtilities/ForcibleStringParser.ts
@@ -1,4 +1,6 @@
-interface ForcibleStringParser<ParsedOutput> {
+interface ForcibleStringParser<
+  ParsedOutput,
+> {
   forciblyParsedFrom(givenSubject: string): ParsedOutput;
 }
 

--- a/src/library/typeUtilities/Static.ts
+++ b/src/library/typeUtilities/Static.ts
@@ -1,5 +1,7 @@
 /** The base shape of the _type_ of some class, rather than the class itself */
-interface Static<Any> {
+interface Static<
+  Any,
+> {
   prototype: Any;
 }
 


### PR DESCRIPTION
Facilitates #413

In the following example:
```typescript
class Foo<SomeRecord> extends Bar<CustomRecord> implements Baz<'Bop'> {
  ...
}
```
there are 6 total identifiers that are subject to change (even if it's just renaming):
1. class: "Foo"
2. class type parameter: "SomeRecord"
3. superclass: "Bar"
4. superclass type argument: "CustomRecord"
5. interface: "Baz"
6. interface type argument: "'Bop'"

The more of these that are done at once, the more likely the resulting noise will create merge/rebase conflicts

To help reduce severity of the conflicts, we introduced linebreaks:
```typescript
class Foo<
  SomeRecord,
> extends Bar<
  CustomRecord
> implements Baz<
  'Bop'
> {
  ...
}
```
This helps the diffing algorithm latch onto each identifier, which makes it easier for both git and reviewers to see what actually changed when resolving conflicts.