### PR TITLE
types(library/Attempt): formalizes constraint of `Attempt.Failure` payload to `ActionableError`

### DIFF
--- a/src/library/Attempt/Outcome/Discriminable.ts
+++ b/src/library/Attempt/Outcome/Discriminable.ts
@@ -4,6 +4,10 @@ import type {
   Not,
 } from '@/library/typeUtilities/Boolean';
 
+import type {
+  ActionableError,
+} from '../error';
+
 type Attempt_Outcome_Discriminant = 'success' | 'failure';
 
 // cspell:words sugarfree discriminable
@@ -15,7 +19,11 @@ interface SyntacticallySugarfreeDiscriminableOutcome<
 
 interface DiscriminableOutcome<
   SomeDiscriminant extends Attempt_Outcome_Discriminant,
-  SomePayload,
+  SomePayload extends (
+    SomeDiscriminant extends 'success'
+      ? unknown
+      : ActionableError<string>
+  ),
 > extends SyntacticallySugarfreeDiscriminableOutcome<
   SomeDiscriminant
 > {

--- a/src/library/Attempt/Outcome/Failure.ts
+++ b/src/library/Attempt/Outcome/Failure.ts
@@ -12,7 +12,7 @@ interface SemanticallySugarfreeFailure<
   SomeActionableError extends ActionableError<string>,
 > extends DiscriminableOutcome<
   'failure',
-  unknown
+  SomeActionableError
 > {
   readonly cause: SomeActionableError;
 }


### PR DESCRIPTION
- this was the intent for the design from the beginning, but the base class did not properly reflect this constraint
- made possible by #413 