### PR TITLE
prefeature(library/Attempt): adds easier way to "rewrap" discriminated outcomes

### DIFF
--- a/src/library/Attempt/Outcome/Discriminable.ts
+++ b/src/library/Attempt/Outcome/Discriminable.ts
@@ -39,6 +39,14 @@ interface DiscriminableOutcome<
     SomePayload,
     never
   >;
+
+  rewrappedWith<
+    TransformedPayload extends (
+      SomeDiscriminant extends 'success'
+        ? unknown
+        : ActionableError<string>
+    ) = SomePayload,
+  >(): DiscriminableOutcome<SomeDiscriminant, TransformedPayload>;
 }
 
 export type {

--- a/src/library/Attempt/Outcome/Failure/Transformer.ts
+++ b/src/library/Attempt/Outcome/Failure/Transformer.ts
@@ -1,0 +1,34 @@
+import type {
+  ActionableError,
+} from '../../error';
+
+type CauseTransformer<
+  TransformableActionableError extends ActionableError<string>,
+  TransformedActionableError extends ActionableError<string>,
+> = (
+  transformableCause: TransformableActionableError,
+) => TransformedActionableError;
+
+const causeIdentity = <
+  TransformableActionableError extends ActionableError<string>,
+  TransformedActionableError extends ActionableError<string>,
+>(
+  transformableCause: NoInfer<TransformableActionableError>,
+): NoInfer<TransformedActionableError> => {
+  return transformableCause as unknown as TransformedActionableError;
+};
+
+interface Attempt_Failure_Transformer<
+  TransformableActionableError extends ActionableError<string>,
+  TransformedActionableError extends ActionableError<string>,
+> {
+  cause: CauseTransformer<
+    TransformableActionableError,
+    TransformedActionableError
+  >;
+}
+
+export {
+  type Attempt_Failure_Transformer,
+  causeIdentity,
+};

--- a/src/library/Attempt/Outcome/Failure/index.ts
+++ b/src/library/Attempt/Outcome/Failure/index.ts
@@ -8,6 +8,11 @@ import type {
   DiscriminableOutcome,
 } from '../Discriminable';
 
+import {
+  type Attempt_Failure_Transformer,
+  causeIdentity,
+} from './Transformer';
+
 interface SemanticallySugarfreeFailure<
   SomeActionableError extends ActionableError<string>,
 > extends DiscriminableOutcome<
@@ -58,5 +63,7 @@ const failureDueTo = <
 
 export {
   type Attempt_Failure,
+  type Attempt_Failure_Transformer,
   failureDueTo,
+  causeIdentity,
 };

--- a/src/library/Attempt/Outcome/Failure/index.ts
+++ b/src/library/Attempt/Outcome/Failure/index.ts
@@ -2,11 +2,11 @@
 
 import type {
   ActionableError,
-} from '../error';
+} from '../../error';
 
 import type {
   DiscriminableOutcome,
-} from './Discriminable';
+} from '../Discriminable';
 
 interface SemanticallySugarfreeFailure<
   SomeActionableError extends ActionableError<string>,

--- a/src/library/Attempt/Outcome/Failure/index.ts
+++ b/src/library/Attempt/Outcome/Failure/index.ts
@@ -45,6 +45,15 @@ interface Attempt_Failure<
    * ```
    */
   readonly causeOfFailure: this['cause'];
+
+  rewrappedWith<
+    TransformedActionableError extends ActionableError<string> = SomeActionableError,
+  >(
+    given?: Attempt_Failure_Transformer<
+      SomeActionableError,
+      TransformedActionableError
+    >
+  ): Attempt_Failure<TransformedActionableError>;
 }
 
 const failureDueTo = <
@@ -59,6 +68,19 @@ const failureDueTo = <
   optionallyUnwrap: () => null,
   forciblyUnwrap  : () => givenCause.throwAnyway('Unexpected forceful unwrap of a failure'),
   causeOfFailure  : givenCause,
+  rewrappedWith   : <
+    TransformedActionableError extends ActionableError<string>,
+  >(
+    {
+      cause: transformed,
+    } = {
+      cause: causeIdentity<SomeActionableError, TransformedActionableError>,
+    },
+  ) => {
+    const transformedCause = transformed(givenCause);
+    const transformedFailure = failureDueTo(transformedCause);
+    return transformedFailure;
+  },
 });
 
 export {

--- a/src/library/Attempt/Outcome/Success/Transformer.ts
+++ b/src/library/Attempt/Outcome/Success/Transformer.ts
@@ -1,0 +1,30 @@
+type ProductTransformer<
+  TransformableProduct,
+  TransformedProduct,
+> = (
+  transformableProduct: TransformableProduct,
+) => TransformedProduct;
+
+const productIdentity = <
+  TransformableProduct,
+  TransformedProduct,
+>(
+  transformableProduct: NoInfer<TransformableProduct>,
+): NoInfer<TransformedProduct> => {
+  return transformableProduct as unknown as TransformedProduct;
+};
+
+interface Attempt_Success_Transformer<
+  TransformableProduct,
+  TransformedProduct,
+> {
+  product: ProductTransformer<
+    TransformableProduct,
+    TransformedProduct
+  >;
+}
+
+export {
+  type Attempt_Success_Transformer,
+  productIdentity,
+};

--- a/src/library/Attempt/Outcome/Success/index.ts
+++ b/src/library/Attempt/Outcome/Success/index.ts
@@ -4,6 +4,11 @@ import type {
   DiscriminableOutcome,
 } from '../Discriminable';
 
+import {
+  type Attempt_Success_Transformer,
+  productIdentity,
+} from './Transformer';
+
 interface SemanticallySugarfreeSuccess<
   SomeProduct,
 > extends DiscriminableOutcome<
@@ -66,5 +71,7 @@ const successThatYielded = <
 
 export {
   type Attempt_Success,
+  type Attempt_Success_Transformer,
   successThatYielded,
+  productIdentity,
 };

--- a/src/library/Attempt/Outcome/Success/index.ts
+++ b/src/library/Attempt/Outcome/Success/index.ts
@@ -53,6 +53,15 @@ interface Attempt_Success<
    * ```
    */
   readonly unwrapped: this['product'];
+
+  rewrappedWith<
+    TransformedProduct = SomeProduct,
+  >(
+    given?: Attempt_Success_Transformer<
+      SomeProduct,
+      TransformedProduct
+    >
+  ): Attempt_Success<TransformedProduct>;
 }
 
 const successThatYielded = <
@@ -67,6 +76,19 @@ const successThatYielded = <
   optionallyUnwrap: () => givenProduct,
   forciblyUnwrap  : () => givenProduct,
   unwrapped       : givenProduct,
+  rewrappedWith   : <
+    TransformedProduct,
+  >(
+    {
+      product: transformed,
+    } = {
+      product: productIdentity<SomeProduct, TransformedProduct>,
+    },
+  ) => {
+    const transformedProduct = transformed(givenProduct);
+    const transformedSuccess = successThatYielded(transformedProduct);
+    return transformedSuccess;
+  },
 });
 
 export {

--- a/src/library/Attempt/Outcome/Success/index.ts
+++ b/src/library/Attempt/Outcome/Success/index.ts
@@ -2,7 +2,7 @@
 
 import type {
   DiscriminableOutcome,
-} from './Discriminable';
+} from '../Discriminable';
 
 interface SemanticallySugarfreeSuccess<
   SomeProduct,


### PR DESCRIPTION
- a common pattern for success/failure propagation is
    1. discern success vs failure
    1. unwrap product/cause
    1. transform product/cause
    1. wrap transformed payload/cause in success/failure
    1. `return` transformed success failure
- these steps essentially compose into a "rewrap" operation, now formalized with these changes
- facilitates #408 