### PR TITLE
refactor(text-to-image): simplifies outcome propagation using "rewraps"

### DIFF
--- a/src/features/TextToImage/models/SDXL/client/index.ts
+++ b/src/features/TextToImage/models/SDXL/client/index.ts
@@ -18,24 +18,23 @@ import {
   Server,
 } from '@/features/TextToImage/webAPI';
 
-const initializeShimmedStabilityAIClient = (): Promise<
+const initializeShimmedStabilityAIClient = async (): Promise<
   Attempt.Outcome<ShimmedStabilityAIClient, Server.SpecificationError>
-> => Attempt.thatEventually(async (ends) => {
+> => {
   const outcomeOfRetrievingCurrentServer = await Server.retrieveCurrent();
 
   if (
     outcomeOfRetrievingCurrentServer.isFailure
   ) return outcomeOfRetrievingCurrentServer;
 
-  const textToImageServer = outcomeOfRetrievingCurrentServer.unwrapped;
-
-  const newClient = new ShimmedStabilityAIClient({
-    serverURL: textToImageServer.origin,
+  const outcomeOfInitializingClient = outcomeOfRetrievingCurrentServer.rewrappedWith({
+    product: textToImageServer => new ShimmedStabilityAIClient({
+      serverURL: textToImageServer.origin,
+    }),
   });
 
-  const outcomeOfInitializingClient = ends.inSuccessWith(newClient);
   return outcomeOfInitializingClient;
-});
+};
 
 type OutcomeOfGeneratingTextToImageOutput = Attempt.Outcome<Output,
   | Server.ConnectionError

--- a/src/features/TextToImage/models/SDXL/client/index.ts
+++ b/src/features/TextToImage/models/SDXL/client/index.ts
@@ -52,7 +52,7 @@ const generateOutputFrom = async (
     | 'seed'
     >;
   },
-): Promise<OutcomeOfGeneratingTextToImageOutput> => Attempt.thatEventually(async (ends) => {
+): Promise<OutcomeOfGeneratingTextToImageOutput> => {
   const outcomeOfInitializingClient = await initializeShimmedStabilityAIClient();
 
   if (
@@ -87,16 +87,15 @@ const generateOutputFrom = async (
     outcomeOfSettlingTextToImageResponse.isFailure
   ) return outcomeOfSettlingTextToImageResponse;
 
-  const textToImageResponse = outcomeOfSettlingTextToImageResponse.unwrapped;
-
-  const soleGeneratedOutput = firstTextToImageOutput({
-    in          : textToImageResponse,
-    inferredFrom: given.textToImageRequestBody.textPrompts,
+  const outcomeOfSettlingSoleTextToImageOutput = outcomeOfSettlingTextToImageResponse.rewrappedWith({
+    product: textToImageResponse => firstTextToImageOutput({
+      in          : textToImageResponse,
+      inferredFrom: given.textToImageRequestBody.textPrompts,
+    }),
   });
 
-  const outcomeOfSettlingSoleTextToImageOutput = ends.inSuccessWith(soleGeneratedOutput);
   return outcomeOfSettlingSoleTextToImageOutput;
-});
+};
 
 const SDXLTextToImageClient = {
   generateOutputFrom,

--- a/src/features/TextToImage/models/SDXL/client/index.ts
+++ b/src/features/TextToImage/models/SDXL/client/index.ts
@@ -33,7 +33,8 @@ const initializeShimmedStabilityAIClient = (): Promise<
     serverURL: textToImageServer.origin,
   });
 
-  return ends.inSuccessWith(newClient);
+  const outcomeOfInitializingClient = ends.inSuccessWith(newClient);
+  return outcomeOfInitializingClient;
 });
 
 type OutcomeOfGeneratingTextToImageOutput = Attempt.Outcome<Output,

--- a/src/features/TextToImage/models/SDXL/client/index.ts
+++ b/src/features/TextToImage/models/SDXL/client/index.ts
@@ -94,7 +94,8 @@ const generateOutputFrom = async (
     inferredFrom: given.textToImageRequestBody.textPrompts,
   });
 
-  return ends.inSuccessWith(soleGeneratedOutput);
+  const outcomeOfSettlingSoleTextToImageOutput = ends.inSuccessWith(soleGeneratedOutput);
+  return outcomeOfSettlingSoleTextToImageOutput;
 });
 
 const SDXLTextToImageClient = {

--- a/src/pages/TextToImagePage.vue
+++ b/src/pages/TextToImagePage.vue
@@ -70,7 +70,8 @@ const imageGeneration = useStatefulAttemptThatEventually(async (ends) => {
   ) return outcomeOfGeneratingOutput;
 
   const generatedOutput = outcomeOfGeneratingOutput.unwrapped;
-  return ends.inSuccessWith(generatedOutput.image);
+  const outcomeOfGeneratingImage = ends.inSuccessWith(generatedOutput.image);
+  return outcomeOfGeneratingImage;
 });
 </script>
 

--- a/src/pages/TextToImagePage.vue
+++ b/src/pages/TextToImagePage.vue
@@ -69,8 +69,10 @@ const imageGeneration = useStatefulAttemptThatEventually(async (ends) => {
     outcomeOfGeneratingOutput.isFailure
   ) return outcomeOfGeneratingOutput;
 
-  const generatedOutput = outcomeOfGeneratingOutput.unwrapped;
-  const outcomeOfGeneratingImage = ends.inSuccessWith(generatedOutput.image);
+  const outcomeOfGeneratingImage = outcomeOfGeneratingOutput.rewrappedWith({
+    product: $0 => $0.image,
+  });
+
   return outcomeOfGeneratingImage;
 });
 </script>


### PR DESCRIPTION
- Follow-up to #417 