### PR TITLE
refactor(text-to-image): simplifies outcome propagation using static "rewraps"

### DIFF
--- a/src/features/TextToImage/models/SDXL/client/index.ts
+++ b/src/features/TextToImage/models/SDXL/client/index.ts
@@ -23,11 +23,7 @@ const initializeShimmedStabilityAIClient = async (): Promise<
 > => {
   const outcomeOfRetrievingCurrentServer = await Server.retrieveCurrent();
 
-  if (
-    outcomeOfRetrievingCurrentServer.isFailure
-  ) return outcomeOfRetrievingCurrentServer;
-
-  const outcomeOfInitializingClient = outcomeOfRetrievingCurrentServer.rewrappedWith({
+  const outcomeOfInitializingClient = Attempt.Outcome.fromRewrapping(outcomeOfRetrievingCurrentServer, {
     product: textToImageServer => new ShimmedStabilityAIClient({
       serverURL: textToImageServer.origin,
     }),

--- a/src/features/TextToImage/models/SDXL/client/index.ts
+++ b/src/features/TextToImage/models/SDXL/client/index.ts
@@ -79,11 +79,7 @@ const generateOutputFrom = async (
     },
   });
 
-  if (
-    outcomeOfSettlingTextToImageResponse.isFailure
-  ) return outcomeOfSettlingTextToImageResponse;
-
-  const outcomeOfSettlingSoleTextToImageOutput = outcomeOfSettlingTextToImageResponse.rewrappedWith({
+  const outcomeOfSettlingSoleTextToImageOutput = Attempt.Outcome.fromRewrapping(outcomeOfSettlingTextToImageResponse, {
     product: textToImageResponse => firstTextToImageOutput({
       in          : textToImageResponse,
       inferredFrom: given.textToImageRequestBody.textPrompts,

--- a/src/pages/TextToImagePage.vue
+++ b/src/pages/TextToImagePage.vue
@@ -29,6 +29,7 @@ import {
   VSkeletonLoader,
 } from 'vuetify/components/VSkeletonLoader';
 
+import Attempt from '@/library/Attempt';
 import SDXLDiffusionStepCount from '@/library/ShimmedStabilityAIClient/models/SDXLDiffusionStepCount.ts';
 
 import DiscreteSlider from '@/components/DiscreteSlider.vue';
@@ -65,11 +66,7 @@ const imageGeneration = useStatefulAttemptThatEventually(async (ends) => {
     },
   });
 
-  if (
-    outcomeOfGeneratingOutput.isFailure
-  ) return outcomeOfGeneratingOutput;
-
-  const outcomeOfGeneratingImage = outcomeOfGeneratingOutput.rewrappedWith({
+  const outcomeOfGeneratingImage = Attempt.Outcome.fromRewrapping(outcomeOfGeneratingOutput, {
     product: $0 => $0.image,
   });
 


### PR DESCRIPTION
- follow-up enabled by #419