### PR TITLE
refactor(library/Base64CharacterEncodedByteSequence): highlights blockage of parsing propagation

### DIFF
--- a/src/library/Base64CharacterEncodedByteSequence.ts
+++ b/src/library/Base64CharacterEncodedByteSequence.ts
@@ -48,7 +48,8 @@ class Base64CharacterEncodedByteSequence
     }).forciblyUnwrap();
 
     const [byteEncodableCharacters, padding] = this.withPaddingDecoupled(paddedByteEncodableCharacters);
-    const base64ByteEncodableCharacters = Base64.CharacterSequence.ensureConformanceOf(byteEncodableCharacters).forciblyUnwrap();
+    const outcomeOfEnsuringConformantCharacters = Base64.CharacterSequence.ensureConformanceOf(byteEncodableCharacters);
+    const base64ByteEncodableCharacters = outcomeOfEnsuringConformantCharacters.forciblyUnwrap();
     const base64CharacterEncodedByteSequence = base64ByteEncodableCharacters + padding;
     return new this(base64CharacterEncodedByteSequence);
   };

--- a/src/library/Base64CharacterEncodedByteSequence.ts
+++ b/src/library/Base64CharacterEncodedByteSequence.ts
@@ -1,3 +1,4 @@
+import Attempt from '@/library/Attempt';
 import * as Base64 from '@/library/Base64';
 import * as Byte from '@/library/Byte';
 import StringSubset from '@/library/customTypes/StringSubset';
@@ -49,9 +50,12 @@ class Base64CharacterEncodedByteSequence
 
     const [byteEncodableCharacters, padding] = this.withPaddingDecoupled(paddedByteEncodableCharacters);
     const outcomeOfEnsuringConformantCharacters = Base64.CharacterSequence.ensureConformanceOf(byteEncodableCharacters);
-    const base64ByteEncodableCharacters = outcomeOfEnsuringConformantCharacters.forciblyUnwrap();
-    const base64CharacterEncodedByteSequence = base64ByteEncodableCharacters + padding;
-    return new this(base64CharacterEncodedByteSequence);
+
+    const outcomeOfParsingByteSequence = Attempt.Outcome.fromRewrapping(outcomeOfEnsuringConformantCharacters, {
+      product: $0 => new this($0 + padding),
+    });
+
+    return outcomeOfParsingByteSequence.forciblyUnwrap();
   };
 }
 


### PR DESCRIPTION
- the blockage is more obvious with `.forciblyUnwrap()` at the _end_ of the scope
- made possible by #420 
- facilitates #411 