### PR TITLE
docs: adds missing context to forcible unwraps

### DIFF
--- a/src/library/Base64CharacterEncodedByteSequence.ts
+++ b/src/library/Base64CharacterEncodedByteSequence.ts
@@ -55,7 +55,7 @@ class Base64CharacterEncodedByteSequence
       product: $0 => new this($0 + padding),
     });
 
-    return outcomeOfParsingByteSequence.forciblyUnwrap();
+    return outcomeOfParsingByteSequence.forciblyUnwrap(/* TODO: enable safe error propagation */);
   };
 }
 

--- a/src/library/Base64CharacterEncodedByteSequence.ts
+++ b/src/library/Base64CharacterEncodedByteSequence.ts
@@ -46,7 +46,7 @@ class Base64CharacterEncodedByteSequence
   ): Base64CharacterEncodedByteSequence => {
     const paddedByteEncodableCharacters = Byte.Sequence.ensureEncodable(givenCharacters, {
       assuming: Base64.bitWidth,
-    }).forciblyUnwrap();
+    }).forciblyUnwrap(/* TODO: make adjacent to `return` statement */);
 
     const [byteEncodableCharacters, padding] = this.withPaddingDecoupled(paddedByteEncodableCharacters);
     const outcomeOfEnsuringConformantCharacters = Base64.CharacterSequence.ensureConformanceOf(byteEncodableCharacters);

--- a/src/library/ShimmedStabilityAIClient/index.ts
+++ b/src/library/ShimmedStabilityAIClient/index.ts
@@ -114,7 +114,7 @@ class ImageClient
       to: generationEndpoint,
     });
 
-    const newResource = outcomeOfSubmittingResource.forciblyUnwrap();
+    const newResource = outcomeOfSubmittingResource.forciblyUnwrap(/* matches error propagation of actual StabilityAI Client */);
 
     const {
       images,
@@ -153,7 +153,7 @@ class ShimmedStabilityAIClient
     serverURL: string;
   }) {
     super({
-      origin : URLOrigin.parsedFrom(given.serverURL).forciblyUnwrap(),
+      origin : URLOrigin.parsedFrom(given.serverURL).forciblyUnwrap(/* matches error propagation of actual StabilityAI client */),
       headers: {
         'Content-Type': 'application/json',
       },

--- a/src/library/customTypes/UniformResourceIdentifier/Data/MediaType/index.ts
+++ b/src/library/customTypes/UniformResourceIdentifier/Data/MediaType/index.ts
@@ -146,7 +146,7 @@ implements StringForciblyParsable<
       !isEmpty(extraComponentsWithStructureTypePrefix)
     ) return new MediaType_ParsingError(`Unexpected component sets after extraneous structure type prefix(es): ${extraComponentsWithStructureTypePrefix.toString()}`).throwAnyway('To be converted to `Attempt` failure');
 
-    const structureType = StructuredSyntaxNameSuffix.Nullable.parsedFrom(rawStructureType).forciblyUnwrap();
+    const structureType = StructuredSyntaxNameSuffix.Nullable.parsedFrom(rawStructureType).forciblyUnwrap(/* TODO: make adjacent to `return` statement */);
 
     if (
       serializedTreeBranchesEndingInFileSubtype === undefined

--- a/src/library/customTypes/UniformResourceIdentifier/Data/index.ts
+++ b/src/library/customTypes/UniformResourceIdentifier/Data/index.ts
@@ -66,7 +66,7 @@ class DataURI
       this.data.toString(),
     ];
 
-    return NonTrivialString.parsedFrom(components.join('')).forciblyUnwrap();
+    return NonTrivialString.parsedFrom(components.join('')).forciblyUnwrap(/* TODO: prove to compiler that this forcible unwrap will never fail */);
   }
 
   public static override forciblyParsedFrom = (

--- a/src/library/customTypes/UniformResourceIdentifier/index.ts
+++ b/src/library/customTypes/UniformResourceIdentifier/index.ts
@@ -195,11 +195,11 @@ implements StringForciblyParsable<
     })();
 
     return new UniformResourceIdentifier(
-      NonTrivialString.parsedFrom(scheme).forciblyUnwrap(),
-      NonTrivialString.nullableParsedFrom(authority).forciblyUnwrap(),
-      NonTrivialString.parsedFrom(path).forciblyUnwrap(),
-      NonTrivialString.nullableParsedFrom(query).forciblyUnwrap(),
-      NonTrivialString.nullableParsedFrom(fragment).forciblyUnwrap(),
+      NonTrivialString.parsedFrom(scheme).forciblyUnwrap(/* TODO: move closer to declaration */),
+      NonTrivialString.nullableParsedFrom(authority).forciblyUnwrap(/* TODO: move closer to declaration */),
+      NonTrivialString.parsedFrom(path).forciblyUnwrap(/* TODO: move closer to declaration */),
+      NonTrivialString.nullableParsedFrom(query).forciblyUnwrap(/* TODO: move closer to declaration */),
+      NonTrivialString.nullableParsedFrom(fragment).forciblyUnwrap(/* TODO: move closer to declaration */),
     );
   };
 }


### PR DESCRIPTION
- the intended use of `.forciblyUnwrap` is for static situations where the expression can be validated upon human inspection
    -  e.g. `URLPath.parsedFrom('/config/text-to-image.json').forciblyUnwrap()`
- in some cases, `.forciblyUnwrap` was used for outcomes that aren't self-evident and have no contextual rationale as to why they're safe to execute.
- maps out pre-requisites discovered while drafting #411