### PR TITLE
refactor: differentiates string concatenation from numeric addition

### DIFF
--- a/src/library/Base64CharacterEncodedByteSequence.ts
+++ b/src/library/Base64CharacterEncodedByteSequence.ts
@@ -52,7 +52,7 @@ class Base64CharacterEncodedByteSequence
     const outcomeOfEnsuringConformantCharacters = Base64.CharacterSequence.ensureConformanceOf(byteEncodableCharacters);
 
     const outcomeOfParsingByteSequence = Attempt.Outcome.fromRewrapping(outcomeOfEnsuringConformantCharacters, {
-      product: $0 => new this($0 + padding),
+      product: $0 => new this($0.concat(padding)),
     });
 
     return outcomeOfParsingByteSequence.forciblyUnwrap(/* TODO: enable safe error propagation */);

--- a/src/library/HTTP/Client.ts
+++ b/src/library/HTTP/Client.ts
@@ -26,13 +26,7 @@ class HTTP_Client {
   }
 
   public originAt(givenPath: URLPath): URL {
-    const serializedURLComponents = [
-      this.origin,
-      givenPath,
-    ]
-      .map($0 => $0.toString())
-      .join('');
-
+    const serializedURLComponents = this.origin.concat(givenPath.toString());
     return new URL(serializedURLComponents);
   }
 

--- a/src/library/customTypes/UniformResourceIdentifier/Data/MediaType/index.ts
+++ b/src/library/customTypes/UniformResourceIdentifier/Data/MediaType/index.ts
@@ -72,7 +72,8 @@ implements StringForciblyParsable<
     ) return null;
 
     const serializedKeyValuePairs = Object.entries(this.parameters)
-      .map($0 => MediaType.parameterPrefix + $0.join(MediaType.parameterKeyValueDelimiter))
+      .map($0 => $0.join(MediaType.parameterKeyValueDelimiter))
+      .map($0 => MediaType.parameterPrefix + $0)
       .join('');
 
     return serializedKeyValuePairs;

--- a/src/library/customTypes/UniformResourceIdentifier/Data/MediaType/index.ts
+++ b/src/library/customTypes/UniformResourceIdentifier/Data/MediaType/index.ts
@@ -47,7 +47,7 @@ implements StringForciblyParsable<
     ) return null;
 
     const serializedTreeBranches = this.tree
-      .map($0 => $0 + MediaType.treeBranchSuffix)
+      .map($0 => $0.concat(MediaType.treeBranchSuffix))
       .join('');
 
     return serializedTreeBranches;
@@ -60,7 +60,7 @@ implements StringForciblyParsable<
       this.structureType === null
     ) return null;
 
-    return MediaType.structureTypePrefix + this.structureType;
+    return MediaType.structureTypePrefix.concat(this.structureType);
   }
 
   public static readonly parameterPrefix = ';';
@@ -73,7 +73,7 @@ implements StringForciblyParsable<
 
     const serializedKeyValuePairs = Object.entries(this.parameters)
       .map($0 => $0.join(MediaType.parameterKeyValueDelimiter))
-      .map($0 => MediaType.parameterPrefix + $0)
+      .map($0 => MediaType.parameterPrefix.concat($0))
       .join('');
 
     return serializedKeyValuePairs;

--- a/src/library/customTypes/UniformResourceIdentifier/index.ts
+++ b/src/library/customTypes/UniformResourceIdentifier/index.ts
@@ -72,7 +72,7 @@ implements StringForciblyParsable<
       this.authority === null
     ) return null;
 
-    return UniformResourceIdentifier.authorityPrefix + this.authority.toString();
+    return UniformResourceIdentifier.authorityPrefix.concat(this.authority.toString());
   }
 
   public static readonly queryPrefix = '?';
@@ -82,7 +82,7 @@ implements StringForciblyParsable<
       this.query === null
     ) return null;
 
-    return UniformResourceIdentifier.queryPrefix + this.query.toString();
+    return UniformResourceIdentifier.queryPrefix.concat(this.query.toString());
   }
 
   public static readonly fragmentPrefix = '#';
@@ -92,7 +92,7 @@ implements StringForciblyParsable<
       this.fragment === null
     ) return null;
 
-    return UniformResourceIdentifier.fragmentPrefix + this.fragment.toString();
+    return UniformResourceIdentifier.fragmentPrefix.concat(this.fragment.toString());
   }
 
   public get serialized(): string {


### PR DESCRIPTION
- In JS, the `+` operator is a loose cannon, but in a type-safe codebase:
    - when between two numbers, it'll add them
    - when between two strings, it'll concatenate them
- to make the codebase easier to search, we reserve `+` for numeric addition only
- for string concatenation, we defer to the `.concat(...)` instance method
- facilitates #411 