### PR TITLE
refactor: highlights anonymous string concatenation

### DIFF
--- a/src/library/customTypes/UniformResourceIdentifier/Data/MediaType/index.ts
+++ b/src/library/customTypes/UniformResourceIdentifier/Data/MediaType/index.ts
@@ -69,11 +69,11 @@ implements StringForciblyParsable<
       this.parameters === null
     ) return null;
 
-    const serializedKeyValuePairs = Object.entries(this.parameters)
+    const prefixedKeyValuePairs = Object.entries(this.parameters)
       .map($0 => $0.join(MediaType.parameterKeyValueDelimiter))
-      .map($0 => MediaType.parameterPrefix.concat($0))
-      .join('');
+      .map($0 => MediaType.parameterPrefix.concat($0));
 
+    const serializedKeyValuePairs = prefixedKeyValuePairs.join('');
     return serializedKeyValuePairs;
   }
 

--- a/src/library/customTypes/UniformResourceIdentifier/Data/MediaType/index.ts
+++ b/src/library/customTypes/UniformResourceIdentifier/Data/MediaType/index.ts
@@ -46,10 +46,8 @@ implements StringForciblyParsable<
       this.tree === null
     ) return null;
 
-    const serializedTreeBranches = this.tree
-      .map($0 => $0.concat(MediaType.treeBranchSuffix))
-      .join('');
-
+    const suffixedTreeBranches = this.tree.map($0 => $0.concat(MediaType.treeBranchSuffix));
+    const serializedTreeBranches = suffixedTreeBranches.join('');
     return serializedTreeBranches;
   }
 


### PR DESCRIPTION
- highlights 2 of the several `.join('')`s sprinkled throughout the codebase
- facilitates #411 