### PR TITLE
refactor(library/URI): clarifies logic involving serializable components

### DIFF
--- a/src/library/customTypes/UniformResourceIdentifier/Data/MediaType/index.ts
+++ b/src/library/customTypes/UniformResourceIdentifier/Data/MediaType/index.ts
@@ -41,7 +41,7 @@ implements StringForciblyParsable<
 
   public static readonly treeBranchSuffix = '.';
 
-  private get serializedTree(): string | null {
+  private get serializableTree(): string | null {
     if (
       this.tree === null
     ) return null;
@@ -81,7 +81,7 @@ implements StringForciblyParsable<
     const components = [
       this.fileType,
       MediaType.fileTypeSuffix,
-      this.serializedTree,
+      this.serializableTree,
       this.fileSubtype,
       this.serializedStructureType,
       this.serializedParameters,

--- a/src/library/customTypes/UniformResourceIdentifier/Data/MediaType/index.ts
+++ b/src/library/customTypes/UniformResourceIdentifier/Data/MediaType/index.ts
@@ -64,7 +64,7 @@ implements StringForciblyParsable<
   public static readonly parameterPrefix = ';';
   public static readonly parameterKeyValueDelimiter = '=';
 
-  private get serializedParameters(): string | null {
+  private get serializableParameters(): string | null {
     if (
       this.parameters === null
     ) return null;
@@ -84,7 +84,7 @@ implements StringForciblyParsable<
       this.serializableTree,
       this.fileSubtype,
       this.serializableStructureType,
-      this.serializedParameters,
+      this.serializableParameters,
     ];
 
     const serializedComponents = components.map($0 => $0 ?? '').join('');

--- a/src/library/customTypes/UniformResourceIdentifier/Data/MediaType/index.ts
+++ b/src/library/customTypes/UniformResourceIdentifier/Data/MediaType/index.ts
@@ -53,7 +53,7 @@ implements StringForciblyParsable<
 
   public static readonly structureTypePrefix = '+';
 
-  private get serializedStructureType(): string | null {
+  private get serializableStructureType(): string | null {
     if (
       this.structureType === null
     ) return null;
@@ -83,7 +83,7 @@ implements StringForciblyParsable<
       MediaType.fileTypeSuffix,
       this.serializableTree,
       this.fileSubtype,
-      this.serializedStructureType,
+      this.serializableStructureType,
       this.serializedParameters,
     ];
 

--- a/src/library/customTypes/UniformResourceIdentifier/index.ts
+++ b/src/library/customTypes/UniformResourceIdentifier/index.ts
@@ -51,7 +51,7 @@ implements StringForciblyParsable<
     return this._authority;
   }
 
-  private get prefixedAuthority(): string | null {
+  private get serializableAuthority(): string | null {
     if (
       this.authority === null
     ) return null;
@@ -99,7 +99,7 @@ implements StringForciblyParsable<
     const components: (string | null | undefined)[] = [
       this.scheme.toString(),
       UniformResourceIdentifier.schemeSuffix,
-      this.prefixedAuthority,
+      this.serializableAuthority,
       this.path.toString(),
       this.prefixedQuery,
       this.prefixedFragment,

--- a/src/library/customTypes/UniformResourceIdentifier/index.ts
+++ b/src/library/customTypes/UniformResourceIdentifier/index.ts
@@ -87,7 +87,7 @@ implements StringForciblyParsable<
     return this._fragment;
   }
 
-  private get prefixedFragment(): string | null {
+  private get serializableFragment(): string | null {
     if (
       this.fragment === null
     ) return null;
@@ -102,7 +102,7 @@ implements StringForciblyParsable<
       this.serializableAuthority,
       this.path.toString(),
       this.serializableQuery,
-      this.prefixedFragment,
+      this.serializableFragment,
     ];
 
     const serializedComponents = components.map($0 => $0 ?? '').join('');

--- a/src/library/customTypes/UniformResourceIdentifier/index.ts
+++ b/src/library/customTypes/UniformResourceIdentifier/index.ts
@@ -73,7 +73,7 @@ implements StringForciblyParsable<
     return this._query;
   }
 
-  private get prefixedQuery(): string | null {
+  private get serializableQuery(): string | null {
     if (
       this.query === null
     ) return null;
@@ -101,7 +101,7 @@ implements StringForciblyParsable<
       UniformResourceIdentifier.schemeSuffix,
       this.serializableAuthority,
       this.path.toString(),
-      this.prefixedQuery,
+      this.serializableQuery,
       this.prefixedFragment,
     ];
 


### PR DESCRIPTION
- "serializable" captures intent more accurately than "serialized", using it to mean "ready to be used as component in serialization"
- facilitates #435 