### PR TITLE
refactor(library/URI): avoids forcible unwrap in `DataURI` getter

### DIFF
--- a/src/library/customTypes/UniformResourceIdentifier/Data/index.ts
+++ b/src/library/customTypes/UniformResourceIdentifier/Data/index.ts
@@ -6,10 +6,6 @@ import {
   isEmpty,
 } from '@/library/utilitiesByType/array.ts';
 
-import {
-  concatenated,
-} from '@/library/utilitiesByType/string.ts';
-
 import UniformResourceIdentifier from '../index.ts';
 
 import {
@@ -78,7 +74,7 @@ class DataURI
       this.serializableData,
     ] as const;
 
-    const serializedPathComponents = concatenated(...orderedPathComponents);
+    const serializedPathComponents = NonTrivialString.fromConcatenating(...orderedPathComponents).toString();
     return NonTrivialString.parsedFrom(serializedPathComponents).forciblyUnwrap(/* TODO: prove to compiler that this forcible unwrap will never fail */);
   }
 

--- a/src/library/customTypes/UniformResourceIdentifier/Data/index.ts
+++ b/src/library/customTypes/UniformResourceIdentifier/Data/index.ts
@@ -76,7 +76,7 @@ class DataURI
       this.mediaType.serialized,
       this.serializableEncoding,
       this.serializableData,
-    ];
+    ] as const;
 
     const serializedPathComponents = concatenated(...orderedPathComponents);
     return NonTrivialString.parsedFrom(serializedPathComponents).forciblyUnwrap(/* TODO: prove to compiler that this forcible unwrap will never fail */);

--- a/src/library/customTypes/UniformResourceIdentifier/Data/index.ts
+++ b/src/library/customTypes/UniformResourceIdentifier/Data/index.ts
@@ -72,8 +72,8 @@ class DataURI
   }
 
   public override get path(): NonTrivialString {
-    const orderedPathComponents: string[] = [
-      this.mediaType.serialized.toString(),
+    const orderedPathComponents = [
+      this.mediaType.serialized,
       this.serializableEncoding,
       this.serializableData,
     ];

--- a/src/library/customTypes/UniformResourceIdentifier/Data/index.ts
+++ b/src/library/customTypes/UniformResourceIdentifier/Data/index.ts
@@ -74,8 +74,8 @@ class DataURI
       this.serializableData,
     ] as const;
 
-    const serializedPathComponents = NonTrivialString.fromConcatenating(...orderedPathComponents).toString();
-    return NonTrivialString.parsedFrom(serializedPathComponents).forciblyUnwrap(/* TODO: prove to compiler that this forcible unwrap will never fail */);
+    const serializedPathComponents = NonTrivialString.fromConcatenating(...orderedPathComponents);
+    return serializedPathComponents;
   }
 
   public static override forciblyParsedFrom = (


### PR DESCRIPTION
- follows up on TODO highlighted in #425 