### PR TITLE
refactor(library/URI): highlights concatenation of strings in array

### DIFF
--- a/src/library/customTypes/UniformResourceIdentifier/Data/MediaType/index.ts
+++ b/src/library/customTypes/UniformResourceIdentifier/Data/MediaType/index.ts
@@ -6,6 +6,10 @@ import {
   isEmpty,
 } from '@/library/utilitiesByType/array.ts';
 
+import {
+  concatenated,
+} from '@/library/utilitiesByType/string';
+
 import MediaType_ParsingError from './ParsingError';
 import StructuredSyntaxNameSuffix from './StructuredSyntaxNameSuffix';
 
@@ -51,7 +55,7 @@ implements StringForciblyParsable<
     ) return null;
 
     const suffixedTreeBranches = this.tree.map($0 => $0.concat(MediaType.treeBranchSuffix));
-    const serializedTreeBranches = suffixedTreeBranches.join('');
+    const serializedTreeBranches = concatenated(...suffixedTreeBranches);
     return serializedTreeBranches;
   }
 
@@ -77,7 +81,7 @@ implements StringForciblyParsable<
       .map($0 => $0.join(MediaType.parameterKeyValueDelimiter))
       .map($0 => MediaType.parameterPrefix.concat($0));
 
-    const serializedKeyValuePairs = prefixedKeyValuePairs.join('');
+    const serializedKeyValuePairs = concatenated(...prefixedKeyValuePairs);
     return serializedKeyValuePairs;
   }
 
@@ -90,7 +94,7 @@ implements StringForciblyParsable<
       this.serializableParameters,
     ];
 
-    const serializedComponents = orderedComponents.map($0 => $0 ?? '').join('');
+    const serializedComponents = concatenated(...orderedComponents.map($0 => $0 ?? ''));
     return serializedComponents;
   }
 

--- a/src/library/customTypes/UniformResourceIdentifier/Data/index.ts
+++ b/src/library/customTypes/UniformResourceIdentifier/Data/index.ts
@@ -6,6 +6,10 @@ import {
   isEmpty,
 } from '@/library/utilitiesByType/array.ts';
 
+import {
+  concatenated,
+} from '@/library/utilitiesByType/string.ts';
+
 import UniformResourceIdentifier from '../index.ts';
 
 import {
@@ -74,7 +78,7 @@ class DataURI
       this.serializableData,
     ];
 
-    const serializedPathComponents = orderedPathComponents.join('');
+    const serializedPathComponents = concatenated(...orderedPathComponents);
     return NonTrivialString.parsedFrom(serializedPathComponents).forciblyUnwrap(/* TODO: prove to compiler that this forcible unwrap will never fail */);
   }
 

--- a/src/library/customTypes/UniformResourceIdentifier/index.ts
+++ b/src/library/customTypes/UniformResourceIdentifier/index.ts
@@ -9,6 +9,10 @@ import {
   isEmpty,
 } from '@/library/utilitiesByType/array.ts';
 
+import {
+  concatenated,
+} from '@/library/utilitiesByType/string';
+
 import URI_ParsingError from './ParsingError';
 
 /**
@@ -108,7 +112,7 @@ implements StringForciblyParsable<
       this.serializableFragment,
     ];
 
-    const serializedComponents = orderedComponents.map($0 => $0 ?? '').join('');
+    const serializedComponents = concatenated(...orderedComponents.map($0 => $0 ?? ''));
     return serializedComponents;
   }
 

--- a/src/library/utilitiesByType/string.ts
+++ b/src/library/utilitiesByType/string.ts
@@ -26,6 +26,13 @@ const droppingLastCharacter = (givenCharacters: string): string => {
   return givenCharacters.substring(0, givenCharacters.length - 1);
 };
 
+const concatenated = (
+  ...givenOperands: string[]
+): string => {
+  const concatenatedOperands = givenOperands.join('');
+  return concatenatedOperands;
+};
+
 export {
   isString,
   asString,
@@ -34,4 +41,5 @@ export {
   isEmpty,
   lastCharacterOf,
   droppingLastCharacter,
+  concatenated,
 };


### PR DESCRIPTION
- using `.join('')` is fragile since omitting or changing the delimiter from `''` would break these implementations
- facilitates #437 