### PR TITLE
refactor: centralizes concatenation of `StringLike` instances

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,6 +2,7 @@
     "cSpell.words": [
         "cbor",
         "cofactor",
+        "concatenatable",
         "fastinfoset",
         "Flaggable",
         "SDXL",

--- a/src/library/customTypes/StringSubset.ts
+++ b/src/library/customTypes/StringSubset.ts
@@ -2,8 +2,9 @@ import type {
   Branded,
 } from '@/library/typeUtilities/Branded';
 
-import type {
-  StringLike,
+import {
+  type StringLike,
+  concatenated,
 } from '../utilitiesByType/string';
 
 /**
@@ -20,13 +21,13 @@ abstract class StringSubset<
   public appendedWith(
     givenSuffix: StringLike,
   ): string {
-    return this.concat(givenSuffix.toString());
+    return concatenated(this, givenSuffix);
   }
 
   public prependedWith(
     givenPrefix: StringLike,
   ): string {
-    return givenPrefix.concat(this.toString());
+    return concatenated(givenPrefix, this);
   }
 }
 

--- a/src/library/customTypes/UniformResourceIdentifier/index.ts
+++ b/src/library/customTypes/UniformResourceIdentifier/index.ts
@@ -104,10 +104,10 @@ implements StringForciblyParsable<
   }
 
   public get serialized(): string {
-    const orderedComponents: (string | null)[] = [
+    const orderedComponents = [
       this.serializableScheme,
       this.serializableAuthority,
-      this.path.toString(),
+      this.path,
       this.serializableQuery,
       this.serializableFragment,
     ];

--- a/src/library/utilitiesByType/string.ts
+++ b/src/library/utilitiesByType/string.ts
@@ -29,9 +29,10 @@ const droppingLastCharacter = (givenCharacters: string): string => {
 type StringLike = string | String; // eslint-disable-line @typescript-eslint/no-wrapper-object-types -- means "both the auto-boxed and primitive types"
 
 const concatenated = (
-  ...givenOperands: string[]
+  ...givenOperands: StringLike[]
 ): string => {
-  const concatenatedOperands = givenOperands.join('');
+  const concatenatableOperands = givenOperands.map($0 => $0.toString());
+  const concatenatedOperands = concatenatableOperands.join('');
   return concatenatedOperands;
 };
 


### PR DESCRIPTION
- facilitates #437 