### PR TITLE
refactor(library/URI): proves that `MediaType` serializes into non-trivial string

### DIFF
--- a/src/library/customTypes/NonTrivialString/index.ts
+++ b/src/library/customTypes/NonTrivialString/index.ts
@@ -5,7 +5,9 @@ import type {
 } from '@/library/Parser/string';
 
 import {
+  concatenated,
   isEmpty,
+  type StringLike,
 } from '@/library/utilitiesByType/string.ts';
 
 import StringSubset from '../StringSubset.ts';
@@ -42,6 +44,28 @@ class NonTrivialString
 
   public isEqualTo(that: NonTrivialString): boolean {
     return this.toString() === that.toString();
+  }
+
+  public concatenatedWith(
+    ...givenOperands: (StringLike | null)[]
+  ): NonTrivialString {
+    const concatenatedOperands = concatenated(this, ...givenOperands);
+    const outcomeOfParsingConcatenatedOperands = NonTrivialString.parsedFrom(concatenatedOperands);
+    return outcomeOfParsingConcatenatedOperands.forciblyUnwrap(/* Safe to call since the leading string is always non-trivial and concatenation is purely additive */);
+  }
+
+  public static fromConcatenating(
+    ...givenOperands: [
+      NonTrivialString,
+      ...(StringLike | null)[],
+    ]
+  ): NonTrivialString {
+    const [
+      firstOperand,
+      ...remainingOperands
+    ] = givenOperands;
+
+    return firstOperand.concatenatedWith(...remainingOperands);
   }
 }
 

--- a/src/library/customTypes/UniformResourceIdentifier/Data/MediaType/index.ts
+++ b/src/library/customTypes/UniformResourceIdentifier/Data/MediaType/index.ts
@@ -88,10 +88,6 @@ implements StringForciblyParsable<
     return serializedKeyValuePairs;
   }
 
-  public toString(): string {
-    return this.serialized.toString();
-  }
-
   public get serialized(): NonTrivialString {
     const orderedComponents = [
       this.serializableFileType,

--- a/src/library/customTypes/UniformResourceIdentifier/Data/MediaType/index.ts
+++ b/src/library/customTypes/UniformResourceIdentifier/Data/MediaType/index.ts
@@ -95,7 +95,7 @@ implements StringForciblyParsable<
       this.fileSubtype,
       this.serializableStructureType,
       this.serializableParameters,
-    ];
+    ] as const;
 
     const serializedComponents = concatenated(...orderedComponents);
     return serializedComponents;

--- a/src/library/customTypes/UniformResourceIdentifier/Data/MediaType/index.ts
+++ b/src/library/customTypes/UniformResourceIdentifier/Data/MediaType/index.ts
@@ -1,3 +1,5 @@
+import NonTrivialString from '@/library/customTypes/NonTrivialString';
+
 import type {
   StringForciblyParsable,
 } from '@/library/typeUtilities/StringForciblyParsable';
@@ -43,8 +45,9 @@ implements StringForciblyParsable<
 
   public static readonly fileTypeSuffix = '/';
 
-  public get serializableFileType(): string {
-    return this.fileType.concat(MediaType.fileTypeSuffix);
+  public get serializableFileType(): NonTrivialString {
+    const suffixedFileType = this.fileType.concat(MediaType.fileTypeSuffix);
+    return NonTrivialString.parsedFrom(suffixedFileType).forciblyUnwrap(/* Proven safe by inspecting intellisense of `fileType` */);
   }
 
   public static readonly treeBranchSuffix = '.';

--- a/src/library/customTypes/UniformResourceIdentifier/Data/MediaType/index.ts
+++ b/src/library/customTypes/UniformResourceIdentifier/Data/MediaType/index.ts
@@ -97,7 +97,7 @@ implements StringForciblyParsable<
       this.serializableParameters,
     ] as const;
 
-    const serializedComponents = concatenated(...orderedComponents);
+    const serializedComponents = NonTrivialString.fromConcatenating(...orderedComponents).toString();
     return serializedComponents;
   }
 

--- a/src/library/customTypes/UniformResourceIdentifier/Data/MediaType/index.ts
+++ b/src/library/customTypes/UniformResourceIdentifier/Data/MediaType/index.ts
@@ -89,6 +89,10 @@ implements StringForciblyParsable<
   }
 
   public toString(): string {
+    return this.serialized.toString();
+  }
+
+  public get serialized(): NonTrivialString {
     const orderedComponents = [
       this.serializableFileType,
       this.serializableTree,
@@ -97,7 +101,7 @@ implements StringForciblyParsable<
       this.serializableParameters,
     ] as const;
 
-    const serializedComponents = NonTrivialString.fromConcatenating(...orderedComponents).toString();
+    const serializedComponents = NonTrivialString.fromConcatenating(...orderedComponents);
     return serializedComponents;
   }
 

--- a/src/library/customTypes/UniformResourceIdentifier/Data/index.ts
+++ b/src/library/customTypes/UniformResourceIdentifier/Data/index.ts
@@ -73,7 +73,7 @@ class DataURI
 
   public override get path(): NonTrivialString {
     const orderedPathComponents: string[] = [
-      this.mediaType.toString(),
+      this.mediaType.serialized.toString(),
       this.serializableEncoding,
       this.serializableData,
     ];


### PR DESCRIPTION
- pre-requisite for #437 