### PR TITLE
refactor(library/URI): separates component parsing from instantiation in `MediaType`

### DIFF
--- a/src/library/customTypes/UniformResourceIdentifier/Data/MediaType/index.ts
+++ b/src/library/customTypes/UniformResourceIdentifier/Data/MediaType/index.ts
@@ -170,10 +170,10 @@ implements StringForciblyParsable<
 
     const treeBranchesEndingInFileSubtype = serializedTreeBranchesEndingInFileSubtype.split(MediaType.treeBranchSuffix);
     const reversedTreeBranchesBeginningWithFileSubtype = treeBranchesEndingInFileSubtype.reverse();
-    const fileSubtype = reversedTreeBranchesBeginningWithFileSubtype.shift();
+    const parsedFileSubtype = reversedTreeBranchesBeginningWithFileSubtype.shift();
 
     if (
-      fileSubtype === undefined
+      parsedFileSubtype === undefined
     ) return new MediaType_ParsingError('Expected file subtype').throwAnyway('To be converted to `Attempt` failure');
 
     const parsedTree = reversedTreeBranchesBeginningWithFileSubtype.reverse();
@@ -181,7 +181,7 @@ implements StringForciblyParsable<
     return new MediaType(
       parsedFileType,
       parsedTree,
-      fileSubtype,
+      parsedFileSubtype,
       parsedStructureType,
       parsedParametersByKey,
     );

--- a/src/library/customTypes/UniformResourceIdentifier/Data/MediaType/index.ts
+++ b/src/library/customTypes/UniformResourceIdentifier/Data/MediaType/index.ts
@@ -150,6 +150,8 @@ implements StringForciblyParsable<
       ] as const;
     });
 
+    const parsedParametersByKey = Object.fromEntries(parameterEntries);
+
     const [
       serializedTreeBranchesEndingInFileSubtype,
       rawStructureType = null,
@@ -181,7 +183,7 @@ implements StringForciblyParsable<
       tree,
       fileSubtype,
       parsedStructureType,
-      Object.fromEntries(parameterEntries),
+      parsedParametersByKey,
     );
   };
 }

--- a/src/library/customTypes/UniformResourceIdentifier/Data/MediaType/index.ts
+++ b/src/library/customTypes/UniformResourceIdentifier/Data/MediaType/index.ts
@@ -176,11 +176,11 @@ implements StringForciblyParsable<
       fileSubtype === undefined
     ) return new MediaType_ParsingError('Expected file subtype').throwAnyway('To be converted to `Attempt` failure');
 
-    const tree = reversedTreeBranchesBeginningWithFileSubtype.reverse();
+    const parsedTree = reversedTreeBranchesBeginningWithFileSubtype.reverse();
 
     return new MediaType(
       parsedFileType,
-      tree,
+      parsedTree,
       fileSubtype,
       parsedStructureType,
       parsedParametersByKey,

--- a/src/library/customTypes/UniformResourceIdentifier/Data/MediaType/index.ts
+++ b/src/library/customTypes/UniformResourceIdentifier/Data/MediaType/index.ts
@@ -114,10 +114,10 @@ implements StringForciblyParsable<
       !isEmpty(componentsFollowingUnexpectedFileTypeSuffix)
     ) return new MediaType_ParsingError(`Found component sets after extraneous file type suffix(es): ${componentsFollowingUnexpectedFileTypeSuffix.toString()}`).throwAnyway('To be converted to `Attempt` failure');
 
-    const fileType = allFileTypes.find($0 => $0 === rawFileType);
+    const parsedFileType = allFileTypes.find($0 => $0 === rawFileType);
 
     if (
-      fileType === undefined
+      parsedFileType === undefined
     ) return new MediaType_ParsingError(`Expected file type as one of ${allFileTypes.toString()}`).throwAnyway('To be converted to `Attempt` failure');
 
     const [
@@ -179,7 +179,7 @@ implements StringForciblyParsable<
     const tree = reversedTreeBranchesBeginningWithFileSubtype.reverse();
 
     return new MediaType(
-      fileType,
+      parsedFileType,
       tree,
       fileSubtype,
       parsedStructureType,

--- a/src/library/customTypes/UniformResourceIdentifier/Data/MediaType/index.ts
+++ b/src/library/customTypes/UniformResourceIdentifier/Data/MediaType/index.ts
@@ -160,7 +160,7 @@ implements StringForciblyParsable<
       !isEmpty(extraComponentsWithStructureTypePrefix)
     ) return new MediaType_ParsingError(`Unexpected component sets after extraneous structure type prefix(es): ${extraComponentsWithStructureTypePrefix.toString()}`).throwAnyway('To be converted to `Attempt` failure');
 
-    const structureType = StructuredSyntaxNameSuffix.Nullable.parsedFrom(rawStructureType).forciblyUnwrap(/* TODO: make adjacent to `return` statement */);
+    const parsedStructureType = StructuredSyntaxNameSuffix.Nullable.parsedFrom(rawStructureType).forciblyUnwrap(/* TODO: make adjacent to `return` statement */);
 
     if (
       serializedTreeBranchesEndingInFileSubtype === undefined
@@ -180,7 +180,7 @@ implements StringForciblyParsable<
       fileType,
       tree,
       fileSubtype,
-      structureType,
+      parsedStructureType,
       Object.fromEntries(parameterEntries),
     );
   };


### PR DESCRIPTION
- continues #448 
- facilitates #451