### PR TITLE
refactor(library/Byte): avoids imports that could become circular

### DIFF
--- a/src/library/Byte/Sequence/EncodingCompatibilityError.ts
+++ b/src/library/Byte/Sequence/EncodingCompatibilityError.ts
@@ -1,8 +1,8 @@
 import Attempt from '@/library/Attempt';
 
 import {
-  cofactorTo as Byte_cofactorTo,
-} from '..';
+  Byte_cofactorTo,
+} from '../utilities/cofactorTo';
 
 class Byte_Sequence_EncodingCompatibilityError
   extends Attempt.ActionableError<

--- a/src/library/Byte/Sequence/index.ts
+++ b/src/library/Byte/Sequence/index.ts
@@ -1,8 +1,8 @@
 import Attempt from '@/library/Attempt';
 
 import {
-  cofactorTo as Byte_cofactorTo,
-} from '..';
+  Byte_cofactorTo,
+} from '../utilities/cofactorTo';
 
 import Byte_Sequence_EncodingCompatibilityError from './EncodingCompatibilityError';
 

--- a/src/library/Byte/index.ts
+++ b/src/library/Byte/index.ts
@@ -1,18 +1,5 @@
-import {
-  cofactor,
-} from '@/library/math/operators';
-
-const Byte_bitWidth = 8 as const;
-
-const Byte_cofactorTo = (givenBitWidth: number): number => {
-  return cofactor({
-    to        : givenBitWidth,
-    forLCMWith: Byte_bitWidth,
-  });
-};
-
 export * as Sequence from './Sequence';
 
 export {
   Byte_cofactorTo as cofactorTo,
-};
+} from './utilities/cofactorTo';

--- a/src/library/Byte/utilities/cofactorTo.ts
+++ b/src/library/Byte/utilities/cofactorTo.ts
@@ -1,0 +1,16 @@
+import {
+  cofactor,
+} from '@/library/math/operators';
+
+const Byte_bitWidth = 8 as const;
+
+const Byte_cofactorTo = (givenBitWidth: number): number => {
+  return cofactor({
+    to        : givenBitWidth,
+    forLCMWith: Byte_bitWidth,
+  });
+};
+
+export {
+  Byte_cofactorTo,
+};


### PR DESCRIPTION
- pre-requisite for #455