### PR TITLE
fix(library/URI): adds missing call to `.unwrapped`

### DIFF
--- a/src/library/customTypes/UniformResourceIdentifier/index.ts
+++ b/src/library/customTypes/UniformResourceIdentifier/index.ts
@@ -164,7 +164,7 @@ implements StringForciblyParsable<
       outcomeOfParsingFragment.isFailure
     ) return outcomeOfParsingFragment.forciblyUnwrap(/* TODO: enable safe error propagation */);
 
-    const parsedFragment = outcomeOfParsingFragment;
+    const parsedFragment = outcomeOfParsingFragment.unwrapped;
 
     const [
       componentsPrecedingQuery,


### PR DESCRIPTION
- introduced in #450 