### PR TITLE
refactor: clarifies intent when returning new instances from some scope

### DIFF
--- a/src/library/WebAPI/Server.ts
+++ b/src/library/WebAPI/Server.ts
@@ -13,9 +13,11 @@ class Server {
   ) {}
 
   public static from(given: Server): Server {
-    return new Server(
+    const clonedServer = new Server(
       given.origin,
     );
+
+    return clonedServer;
   }
 }
 

--- a/src/library/customTypes/UniformResourceIdentifier/Data/Image/index.ts
+++ b/src/library/customTypes/UniformResourceIdentifier/Data/Image/index.ts
@@ -38,13 +38,15 @@ class ImageURI
   }
 
   public override get mediaType(): DataURI['mediaType'] {
-    return new MediaType(
+    const computedMediaType = new MediaType(
       ImageURI.fileType,
       null,
       this.format,
       null,
       null,
     );
+
+    return computedMediaType;
   }
 
   public static override forciblyParsedFrom = (

--- a/src/library/customTypes/UniformResourceIdentifier/Data/Image/index.ts
+++ b/src/library/customTypes/UniformResourceIdentifier/Data/Image/index.ts
@@ -62,11 +62,13 @@ class ImageURI
       format === undefined
     ) return new ImageURI_ParsingError(`Expected format to be one of ${allImageURIFormats.toString()}`).throwAnyway('To be converted to `Attempt` failure');
 
-    return new ImageURI(
+    const parsedImageURI = new ImageURI(
       format,
       proposedURI.encoding,
       proposedURI.data,
     );
+
+    return parsedImageURI;
   };
 }
 

--- a/src/library/customTypes/UniformResourceIdentifier/Data/MediaType/index.ts
+++ b/src/library/customTypes/UniformResourceIdentifier/Data/MediaType/index.ts
@@ -184,13 +184,15 @@ implements StringForciblyParsable<
 
     const parsedTree = reversedTreeBranchesBeginningWithFileSubtype.reverse();
 
-    return new MediaType(
+    const parsedMediaType = new MediaType(
       parsedFileType,
       parsedTree,
       parsedFileSubtype,
       parsedStructureType,
       parsedParametersByKey,
     );
+
+    return parsedMediaType;
   };
 }
 

--- a/src/library/customTypes/UniformResourceIdentifier/Data/index.ts
+++ b/src/library/customTypes/UniformResourceIdentifier/Data/index.ts
@@ -121,11 +121,13 @@ class DataURI
       coercedEncoding === undefined
     ) return new DataURI_ParsingError(`Expected encoding portion to be defined as one of: ${allDataURIBinaryEncodings.toString()}`).throwAnyway('To be converted to `Attempt` failure');
 
-    return new DataURI(
+    const parsedDataURI = new DataURI(
       MediaType.forciblyParsedFrom(rawMediaType),
       coercedEncoding,
       Base64CharacterEncodedByteSequence.forciblyParsedFrom(rawData),
     );
+
+    return parsedDataURI;
   };
 }
 

--- a/src/library/customTypes/UniformResourceIdentifier/index.ts
+++ b/src/library/customTypes/UniformResourceIdentifier/index.ts
@@ -242,13 +242,15 @@ implements StringForciblyParsable<
 
     const parsedPath = outcomeOfParsingPath.unwrapped;
 
-    return new UniformResourceIdentifier(
+    const parsedURI = new UniformResourceIdentifier(
       parsedScheme,
       parsedAuthority,
       parsedPath,
       parsedQuery,
       parsedFragment,
     );
+
+    return parsedURI;
   };
 }
 

--- a/src/utilities/Repository.ts
+++ b/src/utilities/Repository.ts
@@ -19,7 +19,8 @@ interface Repository_Issue {
 
 const Repository = {
   get emptyDraftOfNewIssue(): URL {
-    return new URL('https://github.com/nod-ai/shark-ui/issues/new');
+    const mutableURLForNewIssue = new URL('https://github.com/nod-ai/shark-ui/issues/new');
+    return mutableURLForNewIssue;
   },
   /** Creates a URL that drafts a new issue with pre-populated fields  */
   draftIssue(


### PR DESCRIPTION
- When using `return new ...`, it isn't always self-evident as to how the new instance should be thought of or why it was created
- common situations
    - the implementation leading up to the new instance is long: parsers
    - the instance is designed to be a fresh clone of something that's safe to mutate, i.e. getter that instantiates a new ref with the same value/structure on every call
    - the instance is simply derived or computed from members of some enveloping instance, i.e. a getter that just build something pertaining to class instance
- facilitates #446 