### PR TITLE
refactor(library/URI): prefers parsing components right after their declaration

### DIFF
--- a/src/library/customTypes/UniformResourceIdentifier/Data/index.ts
+++ b/src/library/customTypes/UniformResourceIdentifier/Data/index.ts
@@ -101,6 +101,8 @@ class DataURI
       rawData === undefined
     ) return new DataURI_ParsingError('Expected data portion to be defined').throwAnyway('To be converted to `Attempt` failure');
 
+    const parsedData = Base64CharacterEncodedByteSequence.forciblyParsedFrom(rawData);
+
     const [
       rawMediaType,
       rawEncoding,
@@ -122,7 +124,6 @@ class DataURI
     ) return new DataURI_ParsingError(`Expected encoding portion to be defined as one of: ${allDataURIBinaryEncodings.toString()}`).throwAnyway('To be converted to `Attempt` failure');
 
     const parsedMediaType = MediaType.forciblyParsedFrom(rawMediaType);
-    const parsedData = Base64CharacterEncodedByteSequence.forciblyParsedFrom(rawData);
 
     const parsedDataURI = new DataURI(
       parsedMediaType,

--- a/src/library/customTypes/UniformResourceIdentifier/Data/index.ts
+++ b/src/library/customTypes/UniformResourceIdentifier/Data/index.ts
@@ -117,13 +117,12 @@ class DataURI
       rawMediaType === undefined
     ) return new DataURI_ParsingError('Expected `mediaType` portion to be defined').throwAnyway('To be converted to `Attempt` failure');
 
+    const parsedMediaType = MediaType.forciblyParsedFrom(rawMediaType);
     const parsedEncoding = allDataURIBinaryEncodings.find($0 => $0 === rawEncoding);
 
     if (
       parsedEncoding === undefined
     ) return new DataURI_ParsingError(`Expected encoding portion to be defined as one of: ${allDataURIBinaryEncodings.toString()}`).throwAnyway('To be converted to `Attempt` failure');
-
-    const parsedMediaType = MediaType.forciblyParsedFrom(rawMediaType);
 
     const parsedDataURI = new DataURI(
       parsedMediaType,


### PR DESCRIPTION
- mirrors precedent establish in #447 
- preps for #411