### PR TITLE
linter: prefers config option in lieu of rule overrides for "no-unsafe-*" rules

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -1,6 +1,7 @@
 import pluginVitest from '@vitest/eslint-plugin';
 
 import {
+  configureVueProject,
   defineConfigWithVueTs,
   vueTsConfigs,
 } from '@vue/eslint-config-typescript';
@@ -74,6 +75,10 @@ const extraConfigForTypeScriptESLint: ConfigWithExtends = {
     ],
   },
 };
+
+configureVueProject({
+  allowComponentTypeUnsafety: false, // Takes advantage of strict type checking
+});
 
 const configWithVueTS = defineConfigWithVueTs(
   {

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -8,8 +8,8 @@ import {
 
 import pluginVue from 'eslint-plugin-vue';
 
-import tseslint, {
-  type ConfigWithExtends,
+import type {
+  ConfigWithExtends,
 } from 'typescript-eslint';
 
 import pluginCypress from './cypress/eslint.config';
@@ -112,23 +112,6 @@ const configWithVueTS = defineConfigWithVueTs(
   ...pluginCypress,
 );
 
-const completeConfig = tseslint.config([
-  ...configWithVueTS,
-  {
-    name : 'shark-ui/safety-override',
-    files: [
-      '*/**/*.ts',
-    ],
-    rules: {
-      '@typescript-eslint/no-unsafe-argument'     : 'error',
-      '@typescript-eslint/no-unsafe-assignment'   : 'error',
-      '@typescript-eslint/no-unsafe-call'         : 'error',
-      '@typescript-eslint/no-unsafe-member-access': 'error',
-      '@typescript-eslint/no-unsafe-return'       : 'error',
-    },
-  },
-]);
-
 export {
-  completeConfig as default,
+  configWithVueTS as default,
 };


### PR DESCRIPTION
- enabled by #463 