### PR TITLE
linter(cypress): centralizes configuration

### DIFF
--- a/cypress/eslint.config.ts
+++ b/cypress/eslint.config.ts
@@ -1,0 +1,19 @@
+import pluginCypress from 'eslint-plugin-cypress';
+
+import type {
+  ConfigWithExtends,
+} from 'typescript-eslint';
+
+const overriddenCypressPlugin: ConfigWithExtends[] = [
+  {
+    ...pluginCypress.configs.recommended,
+    files: [
+      'cypress/e2e/**/*.{cy,spec}.{js,ts,jsx,tsx}',
+      'cypress/support/**/*.{js,ts,jsx,tsx}',
+    ],
+  },
+];
+
+export {
+  overriddenCypressPlugin as default,
+};

--- a/cypress/package.d.ts
+++ b/cypress/package.d.ts
@@ -1,0 +1,17 @@
+// 2025-Jul-02: This is a workaround for https://github.com/cypress-io/eslint-plugin-cypress/issues/232
+declare module 'eslint-plugin-cypress' {
+  import type {
+    Linter,
+  } from 'eslint';
+
+  const plugin: {
+    configs: {
+      recommended: Linter.Config;
+      [key: string]: Linter.Config | undefined;
+    };
+  };
+
+  export {
+    plugin as default,
+  };
+}

--- a/cypress/tsconfig.json
+++ b/cypress/tsconfig.json
@@ -1,9 +1,16 @@
 {
   "extends": "@vue/tsconfig/tsconfig.dom.json",
-  "include": ["./e2e/**/*", "./support/**/*"],
-  "exclude": ["./support/component.*"],
+  "include": [
+    "./e2e/**/*",
+    "./support/**/*"
+  ],
+  "exclude": [
+    "./support/component.*"
+  ],
   "compilerOptions": {
     "isolatedModules": false,
-    "types": ["cypress"]
+    "types": [
+      "cypress"
+    ]
   }
 }

--- a/cypress/tsconfig.json
+++ b/cypress/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "@vue/tsconfig/tsconfig.dom.json",
   "include": [
+    "./eslint.config.ts",
     "./package.d.ts",
     "./e2e/**/*",
     "./support/**/*"

--- a/cypress/tsconfig.json
+++ b/cypress/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "@vue/tsconfig/tsconfig.dom.json",
   "include": [
+    "./package.d.ts",
     "./e2e/**/*",
     "./support/**/*"
   ],

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -5,13 +5,13 @@ import {
   vueTsConfigs,
 } from '@vue/eslint-config-typescript';
 
-import pluginCypress from 'eslint-plugin-cypress';
 import pluginVue from 'eslint-plugin-vue';
 
 import tseslint, {
   type ConfigWithExtends,
 } from 'typescript-eslint';
 
+import pluginCypress from './cypress/eslint.config';
 import pluginImport from './eslint.import';
 import pluginStylistic from './eslint.stylistic';
 
@@ -104,13 +104,7 @@ const configWithVueTS = defineConfigWithVueTs(
     files: ['src/**/__tests__/*'],
   },
 
-  {
-    ...pluginCypress.configs.recommended,
-    files: [
-      'cypress/e2e/**/*.{cy,spec}.{js,ts,jsx,tsx}',
-      'cypress/support/**/*.{js,ts,jsx,tsx}',
-    ],
-  },
+  ...pluginCypress,
 );
 
 const completeConfig = tseslint.config([

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -5,7 +5,6 @@ import {
   vueTsConfigs,
 } from '@vue/eslint-config-typescript';
 
-// @ts-expect-error https://github.com/cypress-io/eslint-plugin-cypress/issues/232
 import pluginCypress from 'eslint-plugin-cypress';
 import pluginVue from 'eslint-plugin-vue';
 
@@ -106,7 +105,7 @@ const configWithVueTS = defineConfigWithVueTs(
   },
 
   {
-    ...pluginCypress.configs.recommended as ConfigWithExtends,
+    ...pluginCypress.configs.recommended,
     files: [
       'cypress/e2e/**/*.{cy,spec}.{js,ts,jsx,tsx}',
       'cypress/support/**/*.{js,ts,jsx,tsx}',

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -7,6 +7,7 @@
     "nightwatch.conf.*",
     "playwright.config.*",
     "eslint.*",
+    "cypress/package.d.ts",
     "lint-staged.config.*"
   ],
   "compilerOptions": {

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -7,6 +7,7 @@
     "nightwatch.conf.*",
     "playwright.config.*",
     "eslint.*",
+    "cypress/eslint.config.*",
     "cypress/package.d.ts",
     "lint-staged.config.*"
   ],


### PR DESCRIPTION
- pre-requisite to #467 so that the compiler doesn't complain about the lack of Cypress types