### PR TITLE
fix(library/URI): avoids serializing non-conformant encodings

### DIFF
--- a/src/library/customTypes/UniformResourceIdentifier/Data/index.ts
+++ b/src/library/customTypes/UniformResourceIdentifier/Data/index.ts
@@ -47,7 +47,11 @@ class DataURI
     return this._encoding;
   }
 
-  public get serializableEncoding(): string {
+  public get serializableEncoding(): string | null {
+    if (
+      this.encoding !== 'base64'
+    ) return null;
+
     return DataURI.encodingPrefix.concat(this.encoding);
   }
 


### PR DESCRIPTION
- ensures encoding flag is only serialized for "base64", conformant with [RFC 2397 Section 3](https://www.rfc-editor.org/rfc/rfc2397.html#section-3)
- found while drafting #477