### PR TITLE
refactor: preserves intent of named re-exports

### DIFF
--- a/src/library/HTTP/Request/index.ts
+++ b/src/library/HTTP/Request/index.ts
@@ -1,1 +1,5 @@
-export * as HTTP_Request from './exports';
+import * as HTTP_Request from './exports';
+
+export {
+  HTTP_Request,
+};

--- a/src/library/HTTP/Response/index.ts
+++ b/src/library/HTTP/Response/index.ts
@@ -1,1 +1,5 @@
-export * as HTTP_Response from './exports';
+import * as HTTP_Response from './exports';
+
+export {
+  HTTP_Response,
+};


### PR DESCRIPTION
- makes it more obvious that author not only wanted to re-export, but also wanted to control the naming when the export was consumed.
  So instead of:
  ```typescript
  export * as SomeNamespace_SomeMember from './exports';
  ```
  We do:
  ```typescript
  import * as SomeNamespace_SomeMember from './exports';

  export {
    SomeNamespace_SomeMember,
  };
  ```
  As if to say "yes, I definitely want you to adopt this naming convention"
  
  It also makes it consistent for top-level "index.ts" files where the namespace itself gets exported:
  ```typescript
  import * as SomeNamespace from './exports';

  export {
    SomeNamespace as default,
  };
- found while confirming precedent for #485 