### PR TITLE
refactor: avoids duplicate assignment of parameter properties

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -73,6 +73,9 @@ const extraConfigForTypeScriptESLint: ConfigWithExtends = {
     '@typescript-eslint/no-import-type-side-effects': [
       'error', // Avoids unexpected behavior, trims down the size of the bundle
     ],
+    '@typescript-eslint/no-unnecessary-parameter-property-assignment': [
+      'error', // See https://www.typescriptlang.org/docs/handbook/2/classes.html#parameter-properties for more information
+    ],
   },
 };
 

--- a/src/library/MediaType/index.ts
+++ b/src/library/MediaType/index.ts
@@ -20,13 +20,7 @@ class MediaType {
     public fileSubtype: string,
     public structureType: MediaType_StructuredSyntaxNameSuffix.Any | null,
     public parameters: Record<string, string> | null,
-  ) {
-    this.fileType = fileType;
-    this.tree = tree;
-    this.fileSubtype = fileSubtype;
-    this.structureType = structureType;
-    this.parameters = parameters;
-  }
+  ) {}
 
   public static readonly fileTypeSuffix = '/';
 

--- a/src/library/Range/DiscreteRange.ts
+++ b/src/library/Range/DiscreteRange.ts
@@ -13,8 +13,6 @@ class DiscreteRange
       lowerBound,
       upperBound,
     );
-
-    this.stepSize = stepSize;
   }
 
   public static override spanning(

--- a/src/library/Range/index.ts
+++ b/src/library/Range/index.ts
@@ -10,10 +10,7 @@ class Range {
   protected constructor(
     public readonly lowerBound: number,
     public readonly upperBound: number,
-  ) {
-    this.lowerBound = lowerBound;
-    this.upperBound = upperBound;
-  }
+  ) {}
 
   public static spanning(
     {


### PR DESCRIPTION
- found while drafting #488 