### PR TITLE
refactor(library/URI): avoids unnecessary private members

### DIFF
--- a/src/library/customTypes/UniformResourceIdentifier/Data/Image/index.ts
+++ b/src/library/customTypes/UniformResourceIdentifier/Data/Image/index.ts
@@ -15,7 +15,7 @@ class ImageURI
   extends DataURI {
   public static readonly fileType = 'image';
 
-  private readonly _format: ImageURI_Format.Any;
+  public readonly format: ImageURI_Format.Any;
 
   public constructor(
     givenFormat: ImageURI_Format.Any,
@@ -27,11 +27,7 @@ class ImageURI
       givenEncoding,
       givenData,
     );
-    this._format = givenFormat;
-  }
-
-  public get format(): ImageURI['_format'] {
-    return this._format;
+    this.format = givenFormat;
   }
 
   public override get mediaType(): DataURI['mediaType'] {

--- a/src/library/customTypes/UniformResourceIdentifier/Data/index.ts
+++ b/src/library/customTypes/UniformResourceIdentifier/Data/index.ts
@@ -15,12 +15,12 @@ class DataURI
   public static readonly scheme = NonTrivialString.parsedFrom('data').forciblyUnwrap();
 
   private readonly overridableMediaType: MediaType | null;
-  private readonly _encoding: DataURI_EncodingIdentifier.Any;
+  public readonly encoding: DataURI_EncodingIdentifier.Any;
   private readonly _data: Base64CharacterEncodedByteSequence;
 
   public constructor(
     givenMediaType: DataURI['overridableMediaType'],
-    givenEncoding: DataURI['_encoding'],
+    givenEncoding: DataURI['encoding'],
     givenData: DataURI['_data'],
   ) {
     super(
@@ -28,7 +28,7 @@ class DataURI
     );
 
     this.overridableMediaType = givenMediaType;
-    this._encoding = givenEncoding;
+    this.encoding = givenEncoding;
     this._data = givenData;
   }
 
@@ -41,10 +41,6 @@ class DataURI
   }
 
   public static readonly encodingPrefix = ';';
-
-  public get encoding(): DataURI['_encoding'] {
-    return this._encoding;
-  }
 
   public get serializableEncoding(): string | null {
     if (

--- a/src/library/customTypes/UniformResourceIdentifier/Data/index.ts
+++ b/src/library/customTypes/UniformResourceIdentifier/Data/index.ts
@@ -16,12 +16,12 @@ class DataURI
 
   private readonly overridableMediaType: MediaType | null;
   public readonly encoding: DataURI_EncodingIdentifier.Any;
-  private readonly _data: Base64CharacterEncodedByteSequence;
+  public readonly data: Base64CharacterEncodedByteSequence;
 
   public constructor(
     givenMediaType: DataURI['overridableMediaType'],
     givenEncoding: DataURI['encoding'],
-    givenData: DataURI['_data'],
+    givenData: DataURI['data'],
   ) {
     super(
       DataURI.scheme,
@@ -29,7 +29,7 @@ class DataURI
 
     this.overridableMediaType = givenMediaType;
     this.encoding = givenEncoding;
-    this._data = givenData;
+    this.data = givenData;
   }
 
   public get mediaType(): Exclude<DataURI['overridableMediaType'], null> {
@@ -51,10 +51,6 @@ class DataURI
   }
 
   public static readonly dataPrefix = ',';
-
-  public get data(): DataURI['_data'] {
-    return this._data;
-  }
 
   public get serializableData(): string {
     return this.data.prependedWith(DataURI.dataPrefix);

--- a/src/library/customTypes/UniformResourceIdentifier/index.ts
+++ b/src/library/customTypes/UniformResourceIdentifier/index.ts
@@ -10,28 +10,24 @@ import {
  * See [RFC 3986](https://www.rfc-editor.org/rfc/rfc3986) for more information
  */
 class UniformResourceIdentifier {
-  private readonly _scheme: /*   */ NonTrivialString;
+  public readonly scheme: /*     */ NonTrivialString;
   private readonly _authority: /**/ NonTrivialString | null;
   private readonly overridablePath: NonTrivialString | null;
   private readonly _query: /*    */ NonTrivialString | null;
   private readonly _fragment: /* */ NonTrivialString | null;
 
   public constructor(
-    givenScheme: /*   */ UniformResourceIdentifier['_scheme'],
+    givenScheme: /*   */ UniformResourceIdentifier['scheme'],
     givenAuthority: /**/ UniformResourceIdentifier['_authority'] = null,
     givenPath: /*     */ UniformResourceIdentifier['overridablePath'] = null,
     givenQuery: /*    */ UniformResourceIdentifier['_query'] = null,
     givenFragment: /* */ UniformResourceIdentifier['_fragment'] = null,
   ) {
-    this._scheme /*   */ = givenScheme;
+    this.scheme /*    */ = givenScheme;
     this._authority /**/ = givenAuthority;
     this.overridablePath = givenPath;
     this._query /*    */ = givenQuery;
     this._fragment /* */ = givenFragment;
-  }
-
-  public get scheme(): UniformResourceIdentifier['_scheme'] {
-    return this._scheme;
   }
 
   public static readonly schemeSuffix = ':';

--- a/src/library/customTypes/UniformResourceIdentifier/index.ts
+++ b/src/library/customTypes/UniformResourceIdentifier/index.ts
@@ -11,20 +11,20 @@ import {
  */
 class UniformResourceIdentifier {
   public readonly scheme: /*     */ NonTrivialString;
-  private readonly _authority: /**/ NonTrivialString | null;
+  public readonly authority: /*  */ NonTrivialString | null;
   private readonly overridablePath: NonTrivialString | null;
   private readonly _query: /*    */ NonTrivialString | null;
   private readonly _fragment: /* */ NonTrivialString | null;
 
   public constructor(
     givenScheme: /*   */ UniformResourceIdentifier['scheme'],
-    givenAuthority: /**/ UniformResourceIdentifier['_authority'] = null,
+    givenAuthority: /**/ UniformResourceIdentifier['authority'] = null,
     givenPath: /*     */ UniformResourceIdentifier['overridablePath'] = null,
     givenQuery: /*    */ UniformResourceIdentifier['_query'] = null,
     givenFragment: /* */ UniformResourceIdentifier['_fragment'] = null,
   ) {
     this.scheme /*    */ = givenScheme;
-    this._authority /**/ = givenAuthority;
+    this.authority /* */ = givenAuthority;
     this.overridablePath = givenPath;
     this._query /*    */ = givenQuery;
     this._fragment /* */ = givenFragment;
@@ -37,10 +37,6 @@ class UniformResourceIdentifier {
   }
 
   public static readonly authorityPrefix = '//';
-
-  public get authority(): UniformResourceIdentifier['_authority'] {
-    return this._authority;
-  }
 
   private get serializableAuthority(): string | null {
     if (

--- a/src/library/customTypes/UniformResourceIdentifier/index.ts
+++ b/src/library/customTypes/UniformResourceIdentifier/index.ts
@@ -13,20 +13,20 @@ class UniformResourceIdentifier {
   public readonly scheme: /*     */ NonTrivialString;
   public readonly authority: /*  */ NonTrivialString | null;
   private readonly overridablePath: NonTrivialString | null;
-  private readonly _query: /*    */ NonTrivialString | null;
+  public readonly query: /*      */ NonTrivialString | null;
   private readonly _fragment: /* */ NonTrivialString | null;
 
   public constructor(
     givenScheme: /*   */ UniformResourceIdentifier['scheme'],
     givenAuthority: /**/ UniformResourceIdentifier['authority'] = null,
     givenPath: /*     */ UniformResourceIdentifier['overridablePath'] = null,
-    givenQuery: /*    */ UniformResourceIdentifier['_query'] = null,
+    givenQuery: /*    */ UniformResourceIdentifier['query'] = null,
     givenFragment: /* */ UniformResourceIdentifier['_fragment'] = null,
   ) {
     this.scheme /*    */ = givenScheme;
     this.authority /* */ = givenAuthority;
     this.overridablePath = givenPath;
-    this._query /*    */ = givenQuery;
+    this.query /*     */ = givenQuery;
     this._fragment /* */ = givenFragment;
   }
 
@@ -55,10 +55,6 @@ class UniformResourceIdentifier {
   }
 
   public static readonly queryPrefix = '?';
-
-  public get query(): UniformResourceIdentifier['_query'] {
-    return this._query;
-  }
 
   private get serializableQuery(): string | null {
     if (

--- a/src/library/customTypes/UniformResourceIdentifier/index.ts
+++ b/src/library/customTypes/UniformResourceIdentifier/index.ts
@@ -14,20 +14,20 @@ class UniformResourceIdentifier {
   public readonly authority: /*  */ NonTrivialString | null;
   private readonly overridablePath: NonTrivialString | null;
   public readonly query: /*      */ NonTrivialString | null;
-  private readonly _fragment: /* */ NonTrivialString | null;
+  public readonly fragment: /*   */ NonTrivialString | null;
 
   public constructor(
     givenScheme: /*   */ UniformResourceIdentifier['scheme'],
     givenAuthority: /**/ UniformResourceIdentifier['authority'] = null,
     givenPath: /*     */ UniformResourceIdentifier['overridablePath'] = null,
     givenQuery: /*    */ UniformResourceIdentifier['query'] = null,
-    givenFragment: /* */ UniformResourceIdentifier['_fragment'] = null,
+    givenFragment: /* */ UniformResourceIdentifier['fragment'] = null,
   ) {
     this.scheme /*    */ = givenScheme;
     this.authority /* */ = givenAuthority;
     this.overridablePath = givenPath;
     this.query /*     */ = givenQuery;
-    this._fragment /* */ = givenFragment;
+    this.fragment /*  */ = givenFragment;
   }
 
   public static readonly schemeSuffix = ':';
@@ -65,10 +65,6 @@ class UniformResourceIdentifier {
   }
 
   public static readonly fragmentPrefix = '#';
-
-  public get fragment(): UniformResourceIdentifier['_fragment'] {
-    return this._fragment;
-  }
 
   private get serializableFragment(): string | null {
     if (


### PR DESCRIPTION
- a `private readonly` member that's only ever read through a single `public` getter is effectively a `public readonly` member
- facilitates #491