### PR TITLE
refactor: avoids misuse of "underscore prefix" convention

### DIFF
--- a/src/library/ShimmedStabilityAIClient/index.ts
+++ b/src/library/ShimmedStabilityAIClient/index.ts
@@ -139,11 +139,11 @@ class ImageClient
 
 class Version1Client
   extends HTTP.Client {
-  private _image?: ImageClient;
+  private cachedClient?: ImageClient;
 
   public get image(): ImageClient {
-    this._image ??= new ImageClient(this);
-    return this._image;
+    this.cachedClient ??= new ImageClient(this);
+    return this.cachedClient;
   }
 }
 

--- a/src/library/ShimmedStabilityAIClient/index.ts
+++ b/src/library/ShimmedStabilityAIClient/index.ts
@@ -160,11 +160,11 @@ class ShimmedStabilityAIClient
     });
   }
 
-  private _version1?: Version1Client;
+  private cachedClient?: Version1Client;
 
   public get version1(): Version1Client {
-    this._version1 ??= new Version1Client(this);
-    return this._version1;
+    this.cachedClient ??= new Version1Client(this);
+    return this.cachedClient;
   }
 }
 

--- a/src/library/customTypes/UniformResourceIdentifier/Data/index.ts
+++ b/src/library/customTypes/UniformResourceIdentifier/Data/index.ts
@@ -14,12 +14,12 @@ class DataURI
   extends UniformResourceIdentifier {
   public static readonly scheme = NonTrivialString.parsedFrom('data').forciblyUnwrap();
 
-  private readonly _mediaType: MediaType | null;
+  private readonly overridableMediaType: MediaType | null;
   private readonly _encoding: DataURI_EncodingIdentifier.Any;
   private readonly _data: Base64CharacterEncodedByteSequence;
 
   public constructor(
-    givenMediaType: DataURI['_mediaType'],
+    givenMediaType: DataURI['overridableMediaType'],
     givenEncoding: DataURI['_encoding'],
     givenData: DataURI['_data'],
   ) {
@@ -27,17 +27,17 @@ class DataURI
       DataURI.scheme,
     );
 
-    this._mediaType = givenMediaType;
+    this.overridableMediaType = givenMediaType;
     this._encoding = givenEncoding;
     this._data = givenData;
   }
 
-  public get mediaType(): Exclude<DataURI['_mediaType'], null> {
+  public get mediaType(): Exclude<DataURI['overridableMediaType'], null> {
     if (
-      this._mediaType === null
+      this.overridableMediaType === null
     ) return Attempt.abandon('Media type either needs to be initialized or overridden');
 
-    return this._mediaType;
+    return this.overridableMediaType;
   }
 
   public static readonly encodingPrefix = ';';

--- a/src/library/customTypes/UniformResourceIdentifier/index.ts
+++ b/src/library/customTypes/UniformResourceIdentifier/index.ts
@@ -12,20 +12,20 @@ import {
 class UniformResourceIdentifier {
   private readonly _scheme: /*   */ NonTrivialString;
   private readonly _authority: /**/ NonTrivialString | null;
-  private readonly _path: /*     */ NonTrivialString | null;
+  private readonly overridablePath: NonTrivialString | null;
   private readonly _query: /*    */ NonTrivialString | null;
   private readonly _fragment: /* */ NonTrivialString | null;
 
   public constructor(
     givenScheme: /*   */ UniformResourceIdentifier['_scheme'],
     givenAuthority: /**/ UniformResourceIdentifier['_authority'] = null,
-    givenPath: /*     */ UniformResourceIdentifier['_path'] = null,
+    givenPath: /*     */ UniformResourceIdentifier['overridablePath'] = null,
     givenQuery: /*    */ UniformResourceIdentifier['_query'] = null,
     givenFragment: /* */ UniformResourceIdentifier['_fragment'] = null,
   ) {
     this._scheme /*   */ = givenScheme;
     this._authority /**/ = givenAuthority;
-    this._path /*     */ = givenPath;
+    this.overridablePath = givenPath;
     this._query /*    */ = givenQuery;
     this._fragment /* */ = givenFragment;
   }
@@ -54,12 +54,12 @@ class UniformResourceIdentifier {
     return this.authority.prependedWith(UniformResourceIdentifier.authorityPrefix);
   }
 
-  public get path(): Exclude<UniformResourceIdentifier['_path'], null> {
+  public get path(): Exclude<UniformResourceIdentifier['overridablePath'], null> {
     if (
-      this._path === null
+      this.overridablePath === null
     ) return Attempt.abandon('`path` must either be a) provided via constructor or b) overridden via public getter');
 
-    return this._path;
+    return this.overridablePath;
   }
 
   public static readonly queryPrefix = '?';


### PR DESCRIPTION
- in modern TS, it's preferrable to a) use `private` over the `_...` convention and b) name the private members with enough context to suggest _why_ they're kept private
- found while drafting #492