### PR TITLE
refactor(library/vue): ensures all imports are behind facade

### DIFF
--- a/eslint.import.ts
+++ b/eslint.import.ts
@@ -38,7 +38,7 @@ const extraConfig: ConfigWithExtends = {
         ],
         'pathGroups': [
           {
-            pattern : '@/library/vue/**', // Allows Vue utilities to bubble to the very top of the <script setup> tag
+            pattern : '@/library/vue', // Allows Vue utilities to bubble to the very top of the <script setup> tag
             group   : 'builtin',
             position: 'before',
           },

--- a/src/components/DiscreteSlider.vue
+++ b/src/components/DiscreteSlider.vue
@@ -2,7 +2,7 @@
 import {
   get,
   set,
-} from '@/library/vue/reactivity.ts';
+} from '@/library/vue';
 
 import {
   VBtn,

--- a/src/components/NavigationPanel.vue
+++ b/src/components/NavigationPanel.vue
@@ -2,7 +2,7 @@
 import {
   reactive,
   type Reactive,
-} from 'vue';
+} from '@/library/vue';
 
 import {
   VNavigationDrawer,

--- a/src/features/TextToImage/components/TextToImageInputSection.vue
+++ b/src/features/TextToImage/components/TextToImageInputSection.vue
@@ -4,11 +4,8 @@ import {
   ref,
   set,
   type Ref,
-} from '@/library/vue';
-
-import {
   watch,
-} from 'vue';
+} from '@/library/vue';
 
 import {
   VCard,

--- a/src/features/TextToImage/components/TextToImageInputSection.vue
+++ b/src/features/TextToImage/components/TextToImageInputSection.vue
@@ -4,7 +4,7 @@ import {
   ref,
   set,
   type Ref,
-} from '@/library/vue/reactivity.ts';
+} from '@/library/vue';
 
 import {
   watch,

--- a/src/library/vue/index.ts
+++ b/src/library/vue/index.ts
@@ -1,0 +1,8 @@
+export {
+  type Ref,
+  ref,
+  get,
+  set,
+} from './reactivity';
+
+export * from './statefulAttempt';

--- a/src/library/vue/index.ts
+++ b/src/library/vue/index.ts
@@ -1,4 +1,12 @@
 export {
+  createApp,
+  type DefineComponent,
+  reactive,
+  type Reactive,
+  watch,
+} from 'vue';
+
+export {
   type Ref,
   ref,
   get,

--- a/src/library/vue/reactivity.ts
+++ b/src/library/vue/reactivity.ts
@@ -19,7 +19,7 @@ type Ref<
 const get = unref;
 
 /** Updates the wrapped instance */
-const set = <Any>(givenSubject: Ref<Any>, givenValue: Any): void => {
+const updateRef = <Any>(givenSubject: Ref<Any>, givenValue: Any): void => {
   givenSubject.value = givenValue;
 };
 
@@ -27,5 +27,5 @@ export {
   ref,
   type Ref,
   get,
-  set,
+  updateRef as set,
 };

--- a/src/library/vue/reactivity.ts
+++ b/src/library/vue/reactivity.ts
@@ -15,9 +15,6 @@ type Ref<
   SetterParameter
 >;
 
-/** Unwraps a reactive instance */
-const get = unref;
-
 /** Updates the wrapped instance */
 const updateRef = <Any>(givenSubject: Ref<Any>, givenValue: Any): void => {
   givenSubject.value = givenValue;
@@ -26,6 +23,6 @@ const updateRef = <Any>(givenSubject: Ref<Any>, givenValue: Any): void => {
 export {
   ref,
   type Ref,
-  get,
+  unref as get,
   updateRef as set,
 };

--- a/src/library/vue/reactivity.ts
+++ b/src/library/vue/reactivity.ts
@@ -1,19 +1,8 @@
 import {
-  ref as _ref,
+  ref,
   unref,
-  type Ref as _Ref,
+  type Ref,
 } from 'vue';
-
-/** Wraps an instance to make it reactive */
-const ref = _ref;
-
-type Ref<
-  GetterResult,
-  SetterParameter = GetterResult,
-> = _Ref<
-  GetterResult,
-  SetterParameter
->;
 
 /** Updates the wrapped instance */
 const updateRef = <Any>(givenSubject: Ref<Any>, givenValue: Any): void => {

--- a/src/library/vue/statefulAttempt.ts
+++ b/src/library/vue/statefulAttempt.ts
@@ -3,7 +3,7 @@ import {
   ref,
   set,
   type Ref,
-} from '@/library/vue/reactivity.ts';
+} from '@/library/vue';
 
 import Attempt from '@/library/Attempt';
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,6 @@
 import {
   createApp,
-} from 'vue';
+} from '@/library/vue';
 
 import App from './App.vue';
 

--- a/src/pages/TextToImagePage.vue
+++ b/src/pages/TextToImagePage.vue
@@ -3,11 +3,8 @@ import {
   get,
   ref,
   type Ref,
-} from '@/library/vue/reactivity.ts';
-
-import {
   useStatefulAttemptThatEventually,
-} from '@/library/vue/statefulAttempt';
+} from '@/library/vue';
 
 import {
   VBtn,

--- a/src/shims-vue.d.ts
+++ b/src/shims-vue.d.ts
@@ -1,7 +1,7 @@
 declare module '*.vue' {
   import type {
     DefineComponent,
-  } from 'vue';
+  } from '@/library/vue';
 
   const component: DefineComponent;
 


### PR DESCRIPTION
- the facade we have for 'vue' serves two purposes
  1. it allows us to easily intervene in the event that Vue's API drastically change
  2. it provides a way to supplement their API without taking on another external dependency such as [vueuse](https://vueuse.org/)
- found while drafting #492