### PR TITLE
ci(conventional-commit): adds "style" commit type

### DIFF
--- a/.github/workflows/conventional-commit.yml
+++ b/.github/workflows/conventional-commit.yml
@@ -18,4 +18,4 @@ jobs:
         uses:  ytanikin/pr-conventional-commits@1.4.0
         with:
           ## cspell:words prefeature
-          task_types: '["feature","prefeature","fix","docs","tests","build","ci","refactor","chore","revert","linter","types"]'
+          task_types: '["feature","prefeature","fix","docs","tests","build","ci","refactor","chore","revert","linter","types","style"]'


### PR DESCRIPTION
- useful when style was updated across codebase but a linter rule was not yet set to enforce it
- essentially means "sets style precedent without automatically enforcing it"