### PR TITLE
refactor(library/ContentDescriptor): clarifies `serializableParameters` implementation

### DIFF
--- a/src/library/ContentDescriptor/index.ts
+++ b/src/library/ContentDescriptor/index.ts
@@ -59,11 +59,11 @@ class ContentDescriptor {
       this.parameters === null
     ) return null;
 
-    const prefixedKeyValuePairs = Object.entries(this.parameters)
+    const serializableParameterEntries = Object.entries(this.parameters)
       .map($0 => $0.join(ContentDescriptor.parameterKeyValueDelimiter))
       .map($0 => ContentDescriptor.parameterPrefix.concat($0));
 
-    const serializedKeyValuePairs = concatenated(...prefixedKeyValuePairs);
+    const serializedKeyValuePairs = concatenated(...serializableParameterEntries);
     return serializedKeyValuePairs;
   }
 

--- a/src/library/ContentDescriptor/index.ts
+++ b/src/library/ContentDescriptor/index.ts
@@ -63,8 +63,7 @@ class ContentDescriptor {
       .map($0 => $0.join(ContentDescriptor.parameterKeyValueDelimiter))
       .map($0 => ContentDescriptor.parameterPrefix.concat($0));
 
-    const serializedKeyValuePairs = concatenated(...serializableParameterEntries);
-    return serializedKeyValuePairs;
+    return concatenated(...serializableParameterEntries);
   }
 
   public get serialized(): NonTrivialString {


### PR DESCRIPTION
- encountered while drafting #477 