### PR TITLE
linter(vitest): preps for first unit tests

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -1,5 +1,3 @@
-import pluginVitest from '@vitest/eslint-plugin';
-
 import {
   configureVueProject,
   defineConfigWithVueTs,
@@ -15,6 +13,7 @@ import type {
 import pluginCypress from './cypress/eslint.config';
 import pluginImport from './eslint.import';
 import pluginStylistic from './eslint.stylistic';
+import pluginVitest from './eslint.vitest';
 
 const extraConfigForESLint: ConfigWithExtends = {
   name : 'shark-ui/eslint',
@@ -107,11 +106,7 @@ const configWithVueTS = defineConfigWithVueTs(
   vueTsConfigs.strictTypeChecked,
   vueTsConfigs.stylisticTypeChecked,
 
-  {
-    ...pluginVitest.configs.recommended,
-    files: ['src/**/__tests__/*'],
-  },
-
+  ...pluginVitest,
   ...pluginCypress,
 );
 

--- a/eslint.vitest.ts
+++ b/eslint.vitest.ts
@@ -6,7 +6,12 @@ import type {
 
 const pluginVitest: ConfigWithExtends[] = [
   {
-    ...vitest.configs.recommended,
+    ...vitest.configs.all,
+    settings: {
+      vitest: {
+        typecheck: true,
+      },
+    },
     files: [
       'src/**/*.test.*',
     ],

--- a/eslint.vitest.ts
+++ b/eslint.vitest.ts
@@ -1,0 +1,18 @@
+import vitest from '@vitest/eslint-plugin';
+
+import type {
+  ConfigWithExtends,
+} from 'typescript-eslint';
+
+const pluginVitest: ConfigWithExtends[] = [
+  {
+    ...vitest.configs.recommended,
+    files: [
+      'src/**/*.test.*',
+    ],
+  },
+];
+
+export {
+  pluginVitest as default,
+};


### PR DESCRIPTION
- ensures that best practices (at least the ones vitest was able to automate) are followed from the very beginning