### PR TITLE
ci(dependabot): enables auto-merge for non-major version updates

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -1,0 +1,27 @@
+name: Dependabot
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: |
+      (github.event.pull_request.user.login == 'dependabot[bot]') &&
+      (!github.event.pull_request.head.repo.fork)
+    steps:
+      - name: Fetch metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+      - name: Enable "auto-merge" for non-major version updates # Assumes the repository requires checks to pass before merging
+        if: |
+          (steps.metadata.outputs.update-type == 'version-update:semver-patch') ||
+          (steps.metadata.outputs.update-type == 'version-update:semver-minor')
+        run: gh pr merge --merge --auto "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- context:
  - each PR must pass required checks
  - one of the required checks is passing code review
  - all dependabot PRs are subject to code review
- ergo, this new workflow automates the redundant step of enabling the auto-merge