### PR TITLE
refactor: highlights `name` overrides for `Error` subclasses

### DIFF
--- a/src/features/TextToImage/config/utilities/DynamicConfig/EndpointResponseError.ts
+++ b/src/features/TextToImage/config/utilities/DynamicConfig/EndpointResponseError.ts
@@ -8,12 +8,13 @@ class DynamicConfig_EndpointResponseError
   extends Attempt.ActionableError<
   'DynamicConfig_EndpointResponseError'
 > {
+  public override name = 'DynamicConfig_EndpointResponseError' as const;
+
   public constructor(given: {
     endpoint: URLPath;
     response: Response;
   }) {
     super(`Expected JSON response from "${given.endpoint.toString()}", but received content-type: ${given.response.headers.get('Content-Type') ?? ''}`);
-    this.name = 'DynamicConfig_EndpointResponseError';
   }
 }
 

--- a/src/features/TextToImage/config/utilities/DynamicConfig/FetchingError.ts
+++ b/src/features/TextToImage/config/utilities/DynamicConfig/FetchingError.ts
@@ -8,11 +8,12 @@ class DynamicConfig_FetchingError
   extends Attempt.ActionableError<
   'DynamicConfigFetchError'
 > {
+  public override name = 'DynamicConfig_FetchingError' as const;
+
   public constructor(
     givenEndpoint: URLPath,
   ) {
     super(`Failed to fetch text-to-image config from endpoint: ${givenEndpoint.toString()}`);
-    this.name = 'DynamicConfig_FetchingError';
   }
 }
 

--- a/src/features/TextToImage/config/utilities/StaticConfig/StaticConfigReadingError.ts
+++ b/src/features/TextToImage/config/utilities/StaticConfig/StaticConfigReadingError.ts
@@ -8,12 +8,13 @@ class StaticConfigReadingError
   extends Attempt.ActionableError<
   'StaticConfigReadingError'
 > {
+  public override name = 'StaticConfigReadError' as const;
+
   public constructor(
     givenFile: URLPath,
     givenResponse: Response,
   ) {
     super(`Failed to read config at "${givenFile.toString()}". Cause: "${givenResponse.statusText}"`);
-    this.name = 'StaticConfigReadError';
   }
 }
 

--- a/src/features/TextToImage/webAPI/Server/ServerConnectionError.ts
+++ b/src/features/TextToImage/webAPI/Server/ServerConnectionError.ts
@@ -4,11 +4,12 @@ class TextToImage_Server_ConnectionError
   extends Attempt.ActionableError<
   'TextToImage_ServerConnectionError'
 > {
+  public override name = 'TextToImage_ServerConnectionError' as const;
+
   public constructor(
     public readonly endpoint: URL,
   ) {
     super(`Failed to reach the text-to-image server at "${endpoint.origin}".`);
-    this.name = 'TextToImage_ServerConnectionError';
   }
 }
 

--- a/src/features/TextToImage/webAPI/Server/ServerSpecificationError.ts
+++ b/src/features/TextToImage/webAPI/Server/ServerSpecificationError.ts
@@ -8,13 +8,14 @@ class TextToImage_Server_SpecificationError
   extends Attempt.ActionableError<
   'TextToImage_Server_SpecificationError'
 > {
+  public override name = 'TextToImage_Server_SpecificationError' as const;
+
   public constructor(
     public readonly environmentKey: string,
     public readonly file: URLPath,
     public readonly endpoint: URLPath,
   ) {
     super('Failed to determine text-to-image server');
-    this.name = 'TextToImage_Server_SpecificationError';
   }
 }
 

--- a/src/library/Attempt/error/NonActionableError.ts
+++ b/src/library/Attempt/error/NonActionableError.ts
@@ -19,6 +19,7 @@ class NonActionableError
   implements Branded<
   'NonActionableError'
 > {
+  public override name = 'NonActionableError';
   public readonly brand!: 'NonActionableError';
 
   protected constructor(
@@ -26,7 +27,6 @@ class NonActionableError
     givenOptions?: ErrorOptions,
   ) {
     super(givenMessage, givenOptions);
-    this.name = 'NonActionableError';
   }
 
   public throw(): never {

--- a/src/library/Attempt/factory/AttemptCreationError.ts
+++ b/src/library/Attempt/factory/AttemptCreationError.ts
@@ -2,6 +2,7 @@ import NonActionableError from '../error/NonActionableError';
 
 class AttemptCreationError
   extends NonActionableError {
+  public override name = 'AttemptCreationError' as const;
   public override readonly cause: Error;
 
   private constructor(
@@ -11,7 +12,6 @@ class AttemptCreationError
     },
   ) {
     super(givenMessage, givenOptions);
-    this.name = 'AttemptCreationError';
     this.cause = givenOptions.cause;
   }
 

--- a/src/library/Base64/CharacterSequence/ConformanceError.ts
+++ b/src/library/Base64/CharacterSequence/ConformanceError.ts
@@ -6,9 +6,10 @@ class Base64_CharacterSequence_ConformanceError
   extends Attempt.ActionableError<
   'Base64_CharacterSequence_ConformanceError'
 > {
+  public override name = 'Base64_CharacterSequence_ConformanceError' as const;
+
   public constructor() {
     super(`Sequence contained 1+ character(s) outside of the Base64 Alphabet: ${Base64_Alphabet.pattern.toString()}`);
-    this.name = 'Base64_CharacterSequence_ConformanceError';
   }
 }
 

--- a/src/library/Base64CharacterEncodedByteSequence/ParsingError.ts
+++ b/src/library/Base64CharacterEncodedByteSequence/ParsingError.ts
@@ -10,12 +10,13 @@ class Base64CharacterEncodedByteSequence_ParsingError
   extends ParsingError<
   'Base64CharacterEncodedByteSequence'
 > {
+  public override name = 'Base64CharacterEncodedByteSequence_ParsingError' as const;
+
   public constructor(
     givenMessage: string,
     givenCause?: Error,
   ) {
     super(givenMessage, givenCause);
-    this.name = 'Base64CharacterEncodedByteSequence_ParsingError';
   }
 
   public static thatEscorts(

--- a/src/library/Byte/Sequence/EncodingCompatibilityError.ts
+++ b/src/library/Byte/Sequence/EncodingCompatibilityError.ts
@@ -8,12 +8,13 @@ class Byte_Sequence_EncodingCompatibilityError
   extends Attempt.ActionableError<
   'Byte_Sequence_EncodingCompatibilityError'
 > {
+  public override name = 'Byte_Sequence_CompatibilityError' as const;
+
   public constructor(
     givenBitWidth: number,
   ) {
     const byteCofactor = Byte_cofactorTo(givenBitWidth);
     super(`Character count for ${givenBitWidth.toString()}-bit sequence must be a multiple of ${byteCofactor.toString()} to be byte encodable`);
-    this.name = 'Byte_Sequence_CompatibilityError';
   }
 }
 

--- a/src/library/HTTP/Endpoint/RequestError.ts
+++ b/src/library/HTTP/Endpoint/RequestError.ts
@@ -4,11 +4,12 @@ class HTTP_Endpoint_RequestError
   extends Attempt.ActionableError<
   'HTTP_Endpoint_RequestError'
 > {
+  public override name = 'HTTP_Endpoint_RequestError' as const;
+
   public constructor(
     public readonly endpoint: URL,
   ) {
     super(`Failed to fetch from "${endpoint.toString()}".`);
-    this.name = 'HTTP_Endpoint_RequestError';
   }
 }
 

--- a/src/library/HTTP/Endpoint/ResponseError.ts
+++ b/src/library/HTTP/Endpoint/ResponseError.ts
@@ -8,12 +8,13 @@ class HTTP_Endpoint_ResponseError
   extends Attempt.ActionableError<
   'HTTP_Endpoint_ResponseError'
 > {
+  public override name = 'HTTP_Endpoint_ResponseError' as const;
+
   public constructor(
     givenMessage: string,
     public readonly status: HTTP_Response.StatusCode.Error.Any,
   ) {
     super(givenMessage);
-    this.name = 'HTTP_Endpoint_ResponseError';
   }
 }
 

--- a/src/library/NonTrivialString/ParsingError.ts
+++ b/src/library/NonTrivialString/ParsingError.ts
@@ -6,11 +6,12 @@ class NonTrivialString_ParsingError
   extends ParsingError<
   'NonTrivialString'
 > {
+  public override name = 'NonTrivialString_ParsingError' as const;
+
   public constructor(
     givenCulprit: string,
   ) {
     super(`Expected string to contain something beyond just whitespace, got "${givenCulprit}"`);
-    this.name = 'NonTrivialString_ParsingError';
   }
 }
 

--- a/src/library/Parser/ParsingError.ts
+++ b/src/library/Parser/ParsingError.ts
@@ -10,7 +10,6 @@ abstract class ParsingError<
     givenCause?: Error,
   ) {
     super(givenMessage, givenCause);
-    this.name = 'ParsingError';
   }
 }
 

--- a/src/library/URLComponent/URLOrigin.ts
+++ b/src/library/URLComponent/URLOrigin.ts
@@ -14,12 +14,13 @@ class URLOrigin_ParsingError
   extends ParsingError<
   'URLOrigin'
 > {
+  public override name = 'URLOrigin_ParsingError' as const;
+
   public constructor(given: {
     expectation: string;
     reality: string;
   }) {
     super(`Expected pure origin "${given.expectation}", got "${given.reality}"`);
-    this.name = 'URLOrigin_ParsingError';
   }
 }
 

--- a/src/library/URLComponent/URLPath.ts
+++ b/src/library/URLComponent/URLPath.ts
@@ -14,12 +14,13 @@ class URLPath_ParsingError
   extends ParsingError<
   'URLPath'
 > {
+  public override name = 'URLPath_ParsingError' as const;
+
   public constructor(given: {
     expectation: string;
     reality: string;
   }) {
     super(`Expected pure path: "${given.expectation}", got "${given.reality}"`);
-    this.name = 'URLPath_ParsingError';
   }
 }
 


### PR DESCRIPTION
- makes the access more explicit
- makes the fact that it's an override more explicit
- puts it closer to the class identifier, which makes it easier to tell that it matches
- keeps noise out of the constructor body
- follows up on #196 