### PR TITLE
tests(library/math): stubs complete coverage for `greatestCommonDivisor`

### DIFF
--- a/docs/testing/unit/seeds/functional.md
+++ b/docs/testing/unit/seeds/functional.md
@@ -85,9 +85,9 @@ describe(doSomething, () => {
       describe('due to <sadAdjectiveC> <pluralInputNoun>', () => {
         it.todo('should reject them');
 
-        it.todo('should conform to <some protocol or convention>');
+        it.todo('should safely propagate the error');
 
-        it.todo('should include a developer-friendly message');
+        it.todo('should communicate clearly with developers');
       });
     });
   });

--- a/docs/testing/unit/seeds/functional.md
+++ b/docs/testing/unit/seeds/functional.md
@@ -76,13 +76,13 @@ import {
 describe(doSomething, () => {
   describe('the sad outcomes', () => {
     describe('when delegated', () => {
-      it.todo('should reject <sadAdjectiveA> inputs');
+      it.todo('should reject <sadAdjectiveA> <pluralInputNoun>');
 
-      it.todo('should reject <sadAdjectiveB> inputs');
+      it.todo('should reject <sadAdjectiveB> <pluralInputNoun>');
     });
 
     describe('when generated', () => {
-      describe('due to <sadAdjectiveC> inputs', () => {
+      describe('due to <sadAdjectiveC> <pluralInputNoun>', () => {
         it.todo('should reject them');
 
         it.todo('should conform to <some protocol or convention>');
@@ -93,17 +93,17 @@ describe(doSomething, () => {
   });
 
   describe('the happy outcomes', () => {
-    it.todo('should accept <happyAdjective> inputs');
+    it.todo('should accept <happyAdjective> <pluralInputNoun>');
 
     it.todo('should exhibit <propertyA>');
 
     it.todo('should exhibit <propertyB>');
 
-    it.todo('should handle <specialAdjectiveA> inputs');
+    it.todo('should handle <specialAdjectiveA> <pluralInputNoun>');
 
-    it.todo('should handle <specialAdjectiveB> inputs');
+    it.todo('should handle <specialAdjectiveB> <pluralInputNoun>');
 
-    it.todo('should return <correctAnswer> for <commonalityAdjective> inputs');
+    it.todo('should return <correctAnswer> for <commonalityAdjective> <pluralInputNoun>');
   });
 });
 ```

--- a/src/library/math/operator/constructive/greatestCommonDivisor.test.ts
+++ b/src/library/math/operator/constructive/greatestCommonDivisor.test.ts
@@ -10,7 +10,9 @@ describe(greatestCommonDivisor, () => {
   describe('the sad outcomes', () => {
     describe.todo('when delegated');
 
-    describe.todo('when generated');
+    describe('when generated', () => {
+      describe.todo('due to fractional operands');
+    });
   });
 
   describe.todo('the happy outcomes');

--- a/src/library/math/operator/constructive/greatestCommonDivisor.test.ts
+++ b/src/library/math/operator/constructive/greatestCommonDivisor.test.ts
@@ -26,5 +26,21 @@ describe(greatestCommonDivisor, () => {
     });
   });
 
-  describe.todo('the happy outcomes');
+  describe('the happy outcomes', () => {
+    it.todo('should accept valid operands');
+
+    it.todo('should return the same answer regardless of the sign of each operand');
+
+    it.todo('should be commutative');
+
+    it.todo('should be associative');
+
+    it.todo('should return an operable answer when zero is an operand');
+
+    it.todo('should preserve the identity of matching operands');
+
+    it.todo('should return identity factor for co-prime operands');
+
+    it.todo('should extract a common factor applied to two distinct prime numbers');
+  });
 });

--- a/src/library/math/operator/constructive/greatestCommonDivisor.test.ts
+++ b/src/library/math/operator/constructive/greatestCommonDivisor.test.ts
@@ -9,7 +9,11 @@ import {
 
 describe(greatestCommonDivisor, () => {
   describe('the sad outcomes', () => {
-    describe.todo('when delegated');
+    describe('when delegated', () => {
+      it.todo('should reject inoperable operands');
+
+      it.todo('should reject infinite operands');
+    });
 
     describe('when generated', () => {
       describe('due to fractional operands', () => {

--- a/src/library/math/operator/constructive/greatestCommonDivisor.test.ts
+++ b/src/library/math/operator/constructive/greatestCommonDivisor.test.ts
@@ -1,5 +1,6 @@
 import {
   describe,
+  it,
 } from 'vitest';
 
 import {
@@ -11,7 +12,13 @@ describe(greatestCommonDivisor, () => {
     describe.todo('when delegated');
 
     describe('when generated', () => {
-      describe.todo('due to fractional operands');
+      describe('due to fractional operands', () => {
+        it.todo('should reject them');
+
+        it.todo('should safely propagate the error');
+
+        it.todo('should communicate clearly with developers');
+      });
     });
   });
 


### PR DESCRIPTION
- polishes a documentation introduced in #533 
    - "inputs" is an umbrella term that really means "the term used to refer to the inputs in this specific context"
    - i.e. if it's a mathematical operation, then the preferred term would be "operands"