### PR TITLE
fix(library/math): guards against inoperable operands in `greatestCommonDivisor`

### DIFF
--- a/docs/testing/unit/seeds/functional.md
+++ b/docs/testing/unit/seeds/functional.md
@@ -32,6 +32,29 @@ describe(doSomething, () => {
 });
 ```
 
+or, for units that guarantee "happy outcomes" only:
+
+```typescript
+import {
+  describe,
+  it,
+} from 'vitest';
+
+import {
+  doSomething,
+} from './doSomething';
+
+describe(doSomething, () => {
+  describe('the guaranteed behavior', () => {
+    it.todo('should never fail');
+  });
+
+  describe.todo('the expected classifications');
+});
+```
+
+These are general templates that can then be form-fitted to the needs of the specific unit being test.
+
 ## Rationale
 
 1. Follows guidance given by linter

--- a/src/library/math/operator/constructive/greatestCommonDivisor.test.ts
+++ b/src/library/math/operator/constructive/greatestCommonDivisor.test.ts
@@ -1,6 +1,7 @@
 import {
   describe,
   it,
+  expect,
 } from 'vitest';
 
 import {
@@ -10,7 +11,15 @@ import {
 describe(greatestCommonDivisor, () => {
   describe('the sad outcomes', () => {
     describe('when delegated', () => {
-      it.todo('should reject inoperable operands');
+      it.each([
+        [NaN, 100],
+        [NaN, NaN],
+        [100, NaN],
+      ])('should reject inoperable operands', (operandA, operandB) => {
+        expect.assertions(1);
+
+        expect(() => greatestCommonDivisor(operandA, operandB)).toThrow(Error);
+      });
 
       it.todo('should reject infinite operands');
     });

--- a/src/library/math/operator/constructive/greatestCommonDivisor.ts
+++ b/src/library/math/operator/constructive/greatestCommonDivisor.ts
@@ -1,7 +1,21 @@
+import Attempt from '@/library/Attempt';
+
+import {
+  isOperable,
+} from '../predicate';
+
 const greatestCommonDivisor = (
   leftHandOperand: number,
   rightHandOperand: number,
 ): number => {
+  if (
+    !isOperable(leftHandOperand)
+  ) return Attempt.abandon('Left operand must be operable.');
+
+  if (
+    !isOperable(rightHandOperand)
+  ) return Attempt.abandon('Right operand must be operable.');
+
   let nextDividend = leftHandOperand;
   let previousRemainder = rightHandOperand;
 

--- a/src/library/math/operator/index.ts
+++ b/src/library/math/operator/index.ts
@@ -1,1 +1,3 @@
+export * from './predicate';
+
 export * from './constructive';

--- a/src/library/math/operator/predicate/index.ts
+++ b/src/library/math/operator/predicate/index.ts
@@ -1,0 +1,1 @@
+export * from './isOperable';

--- a/src/library/math/operator/predicate/isOperable.test.ts
+++ b/src/library/math/operator/predicate/isOperable.test.ts
@@ -1,0 +1,73 @@
+import {
+  describe,
+  it,
+  expect,
+} from 'vitest';
+
+import {
+  isOperable,
+} from './isOperable';
+
+const numericCategory = {
+  signed: {
+    negative: /**/-1,
+    positive: /**/+1,
+  },
+  fractional: {
+    rational      : 1 / 2,
+    irrational    : Math.PI,
+    transcendental: Math.E,
+  },
+  infinite: {
+    positive: Infinity,
+    negative: -Infinity,
+  },
+  runtime: {
+    min: Number.MIN_VALUE,
+    max: Number.MAX_VALUE,
+  },
+  origin   : 0,
+  undefined: NaN,
+} as const;
+
+describe(isOperable, () => {
+  const theSoleInoperableNumber = numericCategory.undefined;
+
+  const operableNumbers = [
+    numericCategory.origin,
+    numericCategory.signed.negative,
+    numericCategory.signed.positive,
+    numericCategory.fractional.rational,
+    numericCategory.fractional.irrational,
+    numericCategory.fractional.transcendental,
+    numericCategory.infinite.positive,
+    numericCategory.infinite.negative,
+    numericCategory.runtime.min,
+    numericCategory.runtime.max,
+  ];
+
+  describe('the guaranteed behavior', () => {
+    it.each([
+      theSoleInoperableNumber,
+      ...operableNumbers,
+    ])('should never fail', (someOperand) => {
+      expect.assertions(1);
+
+      expect(() => isOperable(someOperand)).not.toThrow(Error);
+    });
+  });
+
+  describe('the expected classifications', () => {
+    it('should detect inoperable operands', () => {
+      expect.assertions(1);
+
+      expect(isOperable(theSoleInoperableNumber)).toBe(false);
+    });
+
+    it.each(operableNumbers)('should detect operable operands', (eachOperableNumber) => {
+      expect.assertions(1);
+
+      expect(isOperable(eachOperableNumber)).toBe(true);
+    });
+  });
+});

--- a/src/library/math/operator/predicate/isOperable.ts
+++ b/src/library/math/operator/predicate/isOperable.ts
@@ -1,0 +1,10 @@
+/** Whether the given operand can be mathematically operated upon in a useful way. */
+const isOperable = (
+  givenOperand: number,
+): boolean => {
+  return !Number.isNaN(givenOperand);
+};
+
+export {
+  isOperable,
+};


### PR DESCRIPTION
- builds on #532 by adding simplified template for testing suite of a functional unit