### PR TITLE
refactor(library/math): separates concerns of "number taxonomy" from `isOperable` test suite

### DIFF
--- a/src/library/math/numberTaxonomy.ts
+++ b/src/library/math/numberTaxonomy.ts
@@ -1,0 +1,26 @@
+/** Examples from each classification of number */
+const numberTaxonomy = {
+  signed: {
+    negative: -1,
+    positive: +1,
+  },
+  fractional: {
+    rational      : 1 / 2,
+    irrational    : Math.PI,
+    transcendental: Math.E,
+  },
+  infinite: {
+    positive: Infinity,
+    negative: -Infinity,
+  },
+  runtime: {
+    min: Number.MIN_VALUE,
+    max: Number.MAX_VALUE,
+  },
+  origin   : 0,
+  undefined: NaN,
+} as const;
+
+export {
+  numberTaxonomy,
+};

--- a/src/library/math/operator/predicate/isOperable.test.ts
+++ b/src/library/math/operator/predicate/isOperable.test.ts
@@ -8,7 +8,7 @@ import {
   isOperable,
 } from './isOperable';
 
-const numericCategory = {
+const numberTaxonomy = {
   signed: {
     negative: /**/-1,
     positive: /**/+1,
@@ -31,19 +31,19 @@ const numericCategory = {
 } as const;
 
 describe(isOperable, () => {
-  const theSoleInoperableNumber = numericCategory.undefined;
+  const theSoleInoperableNumber = numberTaxonomy.undefined;
 
   const operableNumbers = [
-    numericCategory.origin,
-    numericCategory.signed.negative,
-    numericCategory.signed.positive,
-    numericCategory.fractional.rational,
-    numericCategory.fractional.irrational,
-    numericCategory.fractional.transcendental,
-    numericCategory.infinite.positive,
-    numericCategory.infinite.negative,
-    numericCategory.runtime.min,
-    numericCategory.runtime.max,
+    numberTaxonomy.origin,
+    numberTaxonomy.signed.negative,
+    numberTaxonomy.signed.positive,
+    numberTaxonomy.fractional.rational,
+    numberTaxonomy.fractional.irrational,
+    numberTaxonomy.fractional.transcendental,
+    numberTaxonomy.infinite.positive,
+    numberTaxonomy.infinite.negative,
+    numberTaxonomy.runtime.min,
+    numberTaxonomy.runtime.max,
   ];
 
   describe('the guaranteed behavior', () => {

--- a/src/library/math/operator/predicate/isOperable.test.ts
+++ b/src/library/math/operator/predicate/isOperable.test.ts
@@ -5,30 +5,12 @@ import {
 } from 'vitest';
 
 import {
+  numberTaxonomy,
+} from '../../numberTaxonomy';
+
+import {
   isOperable,
 } from './isOperable';
-
-const numberTaxonomy = {
-  signed: {
-    negative: /**/-1,
-    positive: /**/+1,
-  },
-  fractional: {
-    rational      : 1 / 2,
-    irrational    : Math.PI,
-    transcendental: Math.E,
-  },
-  infinite: {
-    positive: Infinity,
-    negative: -Infinity,
-  },
-  runtime: {
-    min: Number.MIN_VALUE,
-    max: Number.MAX_VALUE,
-  },
-  origin   : 0,
-  undefined: NaN,
-} as const;
 
 describe(isOperable, () => {
   const theSoleInoperableNumber = numberTaxonomy.undefined;


### PR DESCRIPTION
- facilitates #538