### PR TITLE
prefeature(library/Attempt): lets `NonActionableError` conform to "constructable"

### DIFF
--- a/src/library/Attempt/error/NonActionableError.ts
+++ b/src/library/Attempt/error/NonActionableError.ts
@@ -22,7 +22,7 @@ class NonActionableError
   public override name = 'NonActionableError';
   public readonly brand!: 'NonActionableError';
 
-  protected constructor(
+  public constructor(
     givenMessage: NonActionableError['message'],
     givenOptions?: ErrorOptions,
   ) {


### PR DESCRIPTION
- while `NonActionableError.throw` is the recommended way of constructing and propagating an instance, there's no inherent danger in directly constructing
- unblocks #538 
  - a common way to detect constructors is to check for conformance to an interface like:
    ```typescript
    interface DirectlyConstructable {
      new: (...parameters: any[]): any;
    }
    ```
    - useful in scenarios where constructors are passed to implementations that "reconstruct" an instance
  - any class that implements `DirectlyConstructable` will inherently conform to:
    ```typescript
    interface InstanceMatchable {
      [Symbol.hasInstance]: (...parameters: any[]): boolean;
    }
    ```
    - objects that conform to _this_ interface are guaranteed to be compatible with the `instanceOf` operator
  - a problem arises when a class regulates constructor usage via static factories
    - on the one hand, it's no longer "directly constructable"
    - but on the other, the class can still "have instances"
    - so, if the goal is to use `instanceOf` and not necessarily "reconstruct" an instance, then conformance to `DirectlyConstructable` is needlessly restrictive.