### PR TITLE
tests(library/math): clarifies labels for `greatestCommonDivisor` suite

### DIFF
--- a/src/library/math/operator/constructive/greatestCommonDivisor.test.ts
+++ b/src/library/math/operator/constructive/greatestCommonDivisor.test.ts
@@ -17,10 +17,10 @@ describe(greatestCommonDivisor, () => {
         [100, NaN],
       ] as const;
 
-      it.each(combosOfInoperableNumbers)('should reject inoperable operands', (operandA, operandB) => {
+      it.each(combosOfInoperableNumbers)('should reject inoperable operands', (...$0) => {
         expect.assertions(1);
 
-        expect(() => greatestCommonDivisor(operandA, operandB)).toThrow(Error);
+        expect(() => greatestCommonDivisor(...$0)).toThrow(Error);
       });
 
       const combosOfInfiniteNumbers = [
@@ -29,10 +29,10 @@ describe(greatestCommonDivisor, () => {
         [10000000, Infinity],
       ] as const;
 
-      it.each(combosOfInfiniteNumbers)('should reject infinite operands', (operandA, operandB) => {
+      it.each(combosOfInfiniteNumbers)('should reject infinite operands', (...$0) => {
         expect.assertions(1);
 
-        expect(() => greatestCommonDivisor(operandA, operandB)).toThrow(Error);
+        expect(() => greatestCommonDivisor(...$0)).toThrow(Error);
       });
     });
 

--- a/src/library/math/operator/constructive/greatestCommonDivisor.test.ts
+++ b/src/library/math/operator/constructive/greatestCommonDivisor.test.ts
@@ -11,11 +11,13 @@ import {
 describe(greatestCommonDivisor, () => {
   describe('the sad outcomes', () => {
     describe('when delegated', () => {
-      it.each([
+      const combosOfInoperableNumbers = [
         [NaN, 100],
         [NaN, NaN],
         [100, NaN],
-      ])('should reject inoperable operands', (operandA, operandB) => {
+      ] as const;
+
+      it.each(combosOfInoperableNumbers)('should reject inoperable operands', (operandA, operandB) => {
         expect.assertions(1);
 
         expect(() => greatestCommonDivisor(operandA, operandB)).toThrow(Error);

--- a/src/library/math/operator/constructive/greatestCommonDivisor.test.ts
+++ b/src/library/math/operator/constructive/greatestCommonDivisor.test.ts
@@ -23,11 +23,13 @@ describe(greatestCommonDivisor, () => {
         expect(() => greatestCommonDivisor(operandA, operandB)).toThrow(Error);
       });
 
-      it.each([
+      const combosOfInfiniteNumbers = [
         [Infinity, 10000000],
         [Infinity, Infinity],
         [10000000, Infinity],
-      ])('should reject infinite operands', (operandA, operandB) => {
+      ] as const;
+
+      it.each(combosOfInfiniteNumbers)('should reject infinite operands', (operandA, operandB) => {
         expect.assertions(1);
 
         expect(() => greatestCommonDivisor(operandA, operandB)).toThrow(Error);


### PR DESCRIPTION
- sets precedent for the tests that will follow
- facilitates #542