### PR TITLE
ci(node): triggers workflow for security updates

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -7,6 +7,7 @@ on:
     paths:
       - '.github/workflows/node.yml' # Trigger workflow when it's modified
       - 'package.json'               # For dependency changes
+      - 'package-lock.json'          # For nested dependency changes, like security updates
       - '**/*.js'                    # For scripts
       - '**/*.ts'                    # For scripts
       - '**/*.cjs'                   # For scripts
@@ -24,6 +25,7 @@ on:
     paths:
       - '.github/workflows/node.yml' # Trigger workflow when it's modified
       - 'package.json'               # For dependency changes
+      - 'package-lock.json'          # For nested dependency changes, like security updates
       - '**/*.js'                    # For scripts
       - '**/*.ts'                    # For scripts
       - '**/*.cjs'                   # For scripts


### PR DESCRIPTION
- some updates to `npm` dependencies don't involve an explicit version bump in "package.json", but still bump the version in the lock file
- this is usually the case for vulnerability patches
- linting/compiling/testing should still be triggered in this context
- discovered while reviewing #548