### PR TITLE
docs(setup/for_devs): adds example for specifying custom port

### DIFF
--- a/docs/setup/for_developers.md
+++ b/docs/setup/for_developers.md
@@ -47,11 +47,13 @@ where:
     1. [installation](#installation)
     2. [configuration](#configuration)
 1. In [VSCode](https://code.visualstudio.com/), [add the extensions recommended by the project](https://code.visualstudio.com/docs/getstarted/tips-and-tricks#_extension-recommendations).
-1. Serve the project with [Hot Module Replacement](https://vite.dev/guide/features.html#hot-module-replacement) by using the default port (5173):
+1. Serve the project with [Hot Module Replacement](https://vite.dev/guide/features.html#hot-module-replacement) by:
 
-    ```shell
-    npm run dev
-    ```
+    - using the default port (5173):
+
+        ```shell
+        npm run dev
+        ```
 
     NOTE: Shows [Vue Dev Tools](https://devtools.vuejs.org/getting-started/features) for debugging UI
 

--- a/docs/setup/for_developers.md
+++ b/docs/setup/for_developers.md
@@ -55,6 +55,13 @@ where:
         npm run dev
         ```
 
+      OR
+    - specifying a custom port (e.g. 8080):
+
+        ```shell
+        npm run dev -- --port 8080
+        ```
+
     NOTE: Shows [Vue Dev Tools](https://devtools.vuejs.org/getting-started/features) for debugging UI
 
 ## Validation

--- a/docs/setup/for_developers.md
+++ b/docs/setup/for_developers.md
@@ -47,7 +47,7 @@ where:
     1. [installation](#installation)
     2. [configuration](#configuration)
 1. In [VSCode](https://code.visualstudio.com/), [add the extensions recommended by the project](https://code.visualstudio.com/docs/getstarted/tips-and-tricks#_extension-recommendations).
-1. Serve the project with [Hot Module Replacement](https://vite.dev/guide/features.html#hot-module-replacement) by running:
+1. Serve the project with [Hot Module Replacement](https://vite.dev/guide/features.html#hot-module-replacement) by using the default port (5173):
 
     ```shell
     npm run dev


### PR DESCRIPTION
- It was not obvious that the port can be customized
- Default port information was missing
- Encountered while testing last release
- See commits for details