### PR TITLE
fix(library/math): adds support for negative operands to `greatestCommonDivisor`

### DIFF
--- a/src/library/math/operator/constructive/absoluteValueOf.test.ts
+++ b/src/library/math/operator/constructive/absoluteValueOf.test.ts
@@ -1,0 +1,130 @@
+import {
+  describe,
+  it,
+  expect,
+} from 'vitest';
+
+import Attempt from '@/library/Attempt';
+
+import {
+  numberTaxonomy,
+} from '../../numberTaxonomy';
+
+import {
+  absoluteValueOf,
+} from './absoluteValueOf';
+
+describe(absoluteValueOf, () => {
+  const {
+    origin: neutralNumber,
+    signed,
+    fractional,
+    infinite,
+    runtime,
+    undefined: soleInoperableNumber,
+    ...remainingTaxonomy
+  } = numberTaxonomy;
+
+  it('should account for the complete number taxonomy', () => {
+    expect.assertions(1);
+
+    expect(remainingTaxonomy).toStrictEqual({});
+  });
+
+  describe('the sad outcomes', () => {
+    describe('when generated', () => {
+      describe('due to inoperable operands', () => {
+        it('should reject them', () => {
+          expect.assertions(1);
+
+          expect(() => absoluteValueOf(soleInoperableNumber)).toThrow(Error);
+        });
+
+        it('should safely propagate the error', () => {
+          expect.assertions(1);
+
+          expect(() => absoluteValueOf(soleInoperableNumber)).toThrow(Attempt.NonActionableError);
+        });
+
+        it('should communicate clearly with developers', () => {
+          expect.assertions(1);
+
+          expect(() => absoluteValueOf(soleInoperableNumber)).toThrow('Cannot determine distance of inoperable number from origin because it does not exist on the number line.');
+        });
+      });
+    });
+  });
+
+  describe('the happy outcomes', () => {
+    const infiniteMagnitudes = [
+      infinite.positive,
+      infinite.negative,
+    ];
+
+    const boundaryMagnitudes = [
+      runtime.min,
+      runtime.max,
+    ];
+
+    const fractionalMagnitudes = [
+      fractional.irrational,
+      fractional.rational,
+      fractional.transcendental,
+    ];
+
+    const neutralMagnitudes = [
+      neutralNumber,
+      neutralNumber * signed.positive,
+      neutralNumber * signed.negative,
+    ];
+
+    const signedMagnitudes = [
+      signed.positive,
+      signed.negative,
+    ];
+
+    const operableMagnitudes = [
+      ...infiniteMagnitudes,
+      ...boundaryMagnitudes,
+      ...fractionalMagnitudes,
+      ...neutralMagnitudes,
+      ...signedMagnitudes,
+    ];
+
+    it.each(operableMagnitudes)('should accept operable numbers', (eachOperableMagnitude) => {
+      expect.assertions(1);
+
+      expect(() => absoluteValueOf(eachOperableMagnitude)).not.toThrow();
+    });
+
+    it.each(infiniteMagnitudes)('should strip the sign from infinite numbers', (eachInfiniteMagnitude) => {
+      expect.assertions(1);
+
+      expect(absoluteValueOf(eachInfiniteMagnitude)).toBe(infinite.positive);
+    });
+
+    it.each(boundaryMagnitudes)('should preserve the identity of boundary numbers', (eachBoundaryMagnitude) => {
+      expect.assertions(1);
+
+      expect(absoluteValueOf(eachBoundaryMagnitude)).toBe(eachBoundaryMagnitude);
+    });
+
+    it.each(fractionalMagnitudes)('should preserve the identity of fractional numbers', (eachFractionalMagnitude) => {
+      expect.assertions(1);
+
+      expect(absoluteValueOf(eachFractionalMagnitude)).toBe(eachFractionalMagnitude);
+    });
+
+    it.each(neutralMagnitudes)('should preserve the identity of neutral numbers', (eachNeutralMagnitude) => {
+      expect.assertions(1);
+
+      expect(absoluteValueOf(eachNeutralMagnitude)).toBe(neutralNumber);
+    });
+
+    it.each(signedMagnitudes)('should convert a signed magnitude to a positive distance from origin', (eachSignedMagnitude) => {
+      expect.assertions(1);
+
+      expect(absoluteValueOf(eachSignedMagnitude)).toBe(signed.positive);
+    });
+  });
+});

--- a/src/library/math/operator/constructive/absoluteValueOf.ts
+++ b/src/library/math/operator/constructive/absoluteValueOf.ts
@@ -1,0 +1,28 @@
+import Attempt from '@/library/Attempt';
+
+import {
+  isOperable,
+} from '../predicate';
+
+/** The distance the given value is from the 1-dimensional origin */
+const absoluteValueOf = (
+  givenOperand: number,
+): number => {
+  if (
+    !isOperable(givenOperand)
+  ) return Attempt.abandon('Cannot determine distance of inoperable number from origin because it does not exist on the number line.');
+
+  return Math.abs(givenOperand);
+};
+
+/** Alias for {@link absoluteValueOf} */
+const unsigned = absoluteValueOf;
+
+/** Alias for {@link absoluteValueOf} */
+const modulusOf = absoluteValueOf;
+
+export {
+  absoluteValueOf,
+  modulusOf,
+  unsigned,
+};

--- a/src/library/math/operator/constructive/greatestCommonDivisor.test.ts
+++ b/src/library/math/operator/constructive/greatestCommonDivisor.test.ts
@@ -129,7 +129,20 @@ describe(greatestCommonDivisor, () => {
       expect(() => greatestCommonDivisor(primeA, primeB)).not.toThrow();
     });
 
-    it.todo('should return the same answer regardless of the sign of each operand');
+    const combosOfSignedIdentityFactors = symmetricPairCombos({
+      of    : numberTaxonomy.signed.negative,
+      filler: numberTaxonomy.signed.positive,
+    });
+
+    it.each(combosOfSignedIdentityFactors)('should return the same answer regardless of the sign of each operand', (...eachComboOfSignedIdentityFactors) => {
+      expect.assertions(1);
+
+      const signedA = eachComboOfSignedIdentityFactors[0] * primeA;
+      const signedB = eachComboOfSignedIdentityFactors[1] * primeB;
+
+      expect(/* */greatestCommonDivisor(/**/signedA, /**/signedB))
+        .toBe(/**/greatestCommonDivisor(/* */primeA, /* */primeB));
+    });
 
     it.todo('should be commutative');
 

--- a/src/library/math/operator/constructive/greatestCommonDivisor.ts
+++ b/src/library/math/operator/constructive/greatestCommonDivisor.ts
@@ -4,6 +4,10 @@ import {
   isWhole,
 } from '../predicate';
 
+import {
+  absoluteValueOf,
+} from './absoluteValueOf';
+
 const greatestCommonDivisor = (
   leftHandOperand: number,
   rightHandOperand: number,
@@ -16,8 +20,11 @@ const greatestCommonDivisor = (
     !isWhole(rightHandOperand)
   ) return Attempt.abandon('Right operand must be whole.');
 
-  let nextDividend = leftHandOperand;
-  let previousRemainder = rightHandOperand;
+  const leftHandMagnitude = absoluteValueOf(leftHandOperand);
+  const rightHandMagnitude = absoluteValueOf(rightHandOperand);
+
+  let nextDividend = leftHandMagnitude;
+  let previousRemainder = rightHandMagnitude;
 
   while (previousRemainder !== 0) {
     const eachDivisor = previousRemainder;

--- a/src/library/math/operator/constructive/index.ts
+++ b/src/library/math/operator/constructive/index.ts
@@ -1,3 +1,5 @@
+export * from './absoluteValueOf';
+
 export * from './greatestCommonDivisor';
 
 export * from './leastCommonMultiple';


### PR DESCRIPTION
- [The definition of the GCD](https://en.wikipedia.org/wiki/Greatest_common_divisor#Definition) states that the output is always positive
- [Euclid's algorithm](https://en.wikipedia.org/wiki/Greatest_common_divisor#Euclid's_algorithm) assumes "two positive integers"
- Negative numbers have a factor of $$-1$$, so we can simply drop that factor before proceeding