### PR TITLE
refactor(library/math): calls out assumed operand order in `greatestCommonDivisor`

### DIFF
--- a/src/library/math/operator/constructive/greatestCommonDivisor.ts
+++ b/src/library/math/operator/constructive/greatestCommonDivisor.ts
@@ -23,6 +23,10 @@ const greatestCommonDivisor = (
   const leftHandMagnitude = absoluteValueOf(leftHandOperand);
   const rightHandMagnitude = absoluteValueOf(rightHandOperand);
 
+  if (
+    rightHandMagnitude > leftHandMagnitude
+  ) return greatestCommonDivisor(rightHandMagnitude, leftHandMagnitude);
+
   let nextDividend = leftHandMagnitude;
   let previousRemainder = rightHandMagnitude;
 


### PR DESCRIPTION
- [Euclid's algorithm](https://en.wikipedia.org/wiki/Greatest_common_divisor#Euclid's_algorithm) is predicated upon the operands being in descending order
- before, the way the algorithm corrects operand order was not obvious
- now, we explicitly order the operands accordingly