### PR TITLE
tests(library/math): specs handling of 0 in `greatestCommonDivisor`

### DIFF
--- a/src/library/math/operator/constructive/greatestCommonDivisor.test.ts
+++ b/src/library/math/operator/constructive/greatestCommonDivisor.test.ts
@@ -159,7 +159,24 @@ describe(greatestCommonDivisor, () => {
         .toBe(/**/greatestCommonDivisor(greatestCommonDivisor(primeB, primeC), primeA));
     });
 
-    it.todo('should return an operable answer when zero is an operand');
+    const combosOfTogglingFactors = [
+      [0, 1, 1],
+      [0, 0, 0],
+      [1, 0, 1],
+    ] as const;
+
+    it.each(combosOfTogglingFactors)('should return an operable answer when zero is an operand', (...eachComboOfTogglingFactors) => {
+      expect.assertions(1);
+
+      expect(
+        greatestCommonDivisor(
+          primeA * eachComboOfTogglingFactors[0],
+          primeA * eachComboOfTogglingFactors[1],
+        ),
+      ).toBe(
+        primeA * eachComboOfTogglingFactors[2],
+      );
+    });
 
     it.todo('should preserve the identity of matching operands');
 


### PR DESCRIPTION
- follows the convention for $$\text{gcd}(0,0)=0$$ mentioned in [this description](https://en.wikipedia.org/wiki/Greatest_common_divisor#Definition)