### PR TITLE
tests(library/math): specs preservation of operand identity in `greatestCommonDivisor`

### DIFF
--- a/src/library/math/operator/constructive/greatestCommonDivisor.test.ts
+++ b/src/library/math/operator/constructive/greatestCommonDivisor.test.ts
@@ -178,7 +178,11 @@ describe(greatestCommonDivisor, () => {
       );
     });
 
-    it.todo('should preserve the identity of matching operands');
+    it('should preserve the identity of matching operands', () => {
+      expect.assertions(1);
+
+      expect(greatestCommonDivisor(primeA, primeA)).toBe(primeA);
+    });
 
     it.todo('should return identity factor for co-prime operands');
 


### PR DESCRIPTION
- describes [property](https://en.wikipedia.org/wiki/Greatest_common_divisor#Properties) where, for positive integers $$a$$, $$\text{gcd}(a, a) = a$$.