### PR TITLE
chore(deps): removes unused `jiti` package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,6 @@
         "eslint-plugin-import": "^2.32.0",
         "eslint-plugin-vue": "^10.3.0",
         "husky": "^9.1.7",
-        "jiti": "^2.4.2",
         "jsdom": "^26.1.0",
         "lint-staged": "^16.1.2",
         "markdownlint-cli2": "^0.18.1",
@@ -7808,8 +7807,9 @@
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.4.2.tgz",
       "integrity": "sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A==",
-      "devOptional": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }

--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
     "eslint-plugin-import": "^2.32.0",
     "eslint-plugin-vue": "^10.3.0",
     "husky": "^9.1.7",
-    "jiti": "^2.4.2",
     "jsdom": "^26.1.0",
     "lint-staged": "^16.1.2",
     "markdownlint-cli2": "^0.18.1",


### PR DESCRIPTION
- [jiti](https://github.com/unjs/jiti) was included from the very first commit when the project was initialized from the `vue` starter template
- while it _is_ an optional peer dependency for [vite](https://github.com/vitejs/vite), there's never been a need to use it directly via `npx jiti someScript.ts`
- if the need to execute a .ts script without transpiling it first ever presents itself, reinstalling `jiti` would be perfectly justified
- until then, it's just another dependency to maintain without any kind of payoff

Brought to light by #576