### PR TITLE
fix(library/Range): enforces a semantic match for guard in `DiscreteRange.spanning(...)`

### DIFF
--- a/src/library/Range/DiscreteRange.ts
+++ b/src/library/Range/DiscreteRange.ts
@@ -37,7 +37,7 @@ class DiscreteRange
 
     if (
       isNegative(givenStepSize)
-    ) return Attempt.abandon('Step size must be positive');
+    ) return Attempt.abandon('Step size must be non-negative');
 
     const overstep = validRange.width % givenStepSize;
 


### PR DESCRIPTION
- before, there was a semantic mismatch between a guard's condition and the error message it would then generate