### PR TITLE
refactor: prefers semantic numeric comparisons

### DIFF
--- a/src/library/Range/DiscreteRange.ts
+++ b/src/library/Range/DiscreteRange.ts
@@ -1,5 +1,9 @@
 import Attempt from '@/library/Attempt';
 
+import {
+  isNegative,
+} from '@/library/math';
+
 import Range from './index.ts';
 
 class DiscreteRange
@@ -32,7 +36,7 @@ class DiscreteRange
     });
 
     if (
-      givenStepSize < 0
+      isNegative(givenStepSize)
     ) return Attempt.abandon('Step size must be positive');
 
     const overstep = validRange.width % givenStepSize;

--- a/src/library/math/operator/predicate/index.ts
+++ b/src/library/math/operator/predicate/index.ts
@@ -2,4 +2,6 @@ export * from './isOperable';
 
 export * from './isFinite';
 
+export * from './isNegative';
+
 export * from './isWhole';

--- a/src/library/math/operator/predicate/isNegative.test.ts
+++ b/src/library/math/operator/predicate/isNegative.test.ts
@@ -1,0 +1,118 @@
+import {
+  describe,
+  it,
+  expect,
+} from 'vitest';
+
+import Attempt from '@/library/Attempt';
+
+import {
+  numberTaxonomy,
+} from '../../numberTaxonomy';
+
+import {
+  isNegative,
+} from './isNegative';
+
+describe(isNegative, () => {
+  const {
+    origin: neutralNumber,
+    signed,
+    fractional,
+    infinite,
+    runtime,
+    undefined: soleInoperableNumber,
+    ...remainingTaxonomy
+  } = numberTaxonomy;
+
+  it('should account for the complete number taxonomy', () => {
+    expect.assertions(1);
+
+    expect(remainingTaxonomy).toStrictEqual({});
+  });
+
+  describe('the sad outcomes', () => {
+    describe('when generated due to inoperable operands', () => {
+      it('should reject the operand', () => {
+        expect.assertions(1);
+
+        expect(() => isNegative(soleInoperableNumber)).toThrow(Error);
+      });
+
+      it('should safely propagate the error', () => {
+        expect.assertions(1);
+
+        expect(() => isNegative(soleInoperableNumber)).toThrow(Attempt.NonActionableError);
+      });
+
+      it('should communicate clearly with developers', () => {
+        expect.assertions(1);
+
+        expect(() => isNegative(soleInoperableNumber)).toThrow('Operand must be operable');
+      });
+    });
+  });
+
+  describe('the happy outcomes', () => {
+    const infiniteAssertions = [
+      [infinite.negative, true],
+      [infinite.positive, false],
+    ] as const;
+
+    const infiniteNumbers = infiniteAssertions.map($0 => $0[0]);
+
+    const neutralFiniteNumbers = [
+      neutralNumber,
+      neutralNumber * signed.positive,
+      neutralNumber * signed.negative,
+    ];
+
+    const positiveFiniteNumbers = [
+      signed.positive,
+      fractional.rational,
+      fractional.irrational,
+      fractional.transcendental,
+      runtime.min,
+      runtime.max,
+    ];
+
+    const negativeFiniteNumbers = positiveFiniteNumbers.map($0 => $0 * signed.negative);
+
+    const operableNumbers = [
+      ...infiniteNumbers,
+      ...negativeFiniteNumbers,
+      ...neutralFiniteNumbers,
+      ...positiveFiniteNumbers,
+    ];
+
+    it.each(operableNumbers)('should accept valid operands', (eachOperableNumber) => {
+      expect.assertions(1);
+
+      expect(() => isNegative(eachOperableNumber)).not.toThrow();
+    });
+
+    it.each(infiniteAssertions)('should support infinite operands', (eachInfiniteNumber, eachExpectOutput) => {
+      expect.assertions(1);
+
+      expect(isNegative(eachInfiniteNumber)).toBe(eachExpectOutput);
+    });
+
+    it.each(neutralFiniteNumbers)('should detect neutral operands', (eachNeutralNumber) => {
+      expect.assertions(1);
+
+      expect(isNegative(eachNeutralNumber)).toBe(false);
+    });
+
+    it.each(positiveFiniteNumbers)('should detect positive operands', (eachPositiveNumber) => {
+      expect.assertions(1);
+
+      expect(isNegative(eachPositiveNumber)).toBe(false);
+    });
+
+    it.each(negativeFiniteNumbers)('should detect negative operands', (eachNegativeNumber) => {
+      expect.assertions(1);
+
+      expect(isNegative(eachNegativeNumber)).toBe(true);
+    });
+  });
+});

--- a/src/library/math/operator/predicate/isNegative.ts
+++ b/src/library/math/operator/predicate/isNegative.ts
@@ -1,0 +1,19 @@
+import Attempt from '@/library/Attempt';
+
+import {
+  isOperable,
+} from './isOperable';
+
+const isNegative = (
+  givenOperand: number,
+): boolean => {
+  if (
+    !isOperable(givenOperand)
+  ) return Attempt.abandon('Operand must be operable');
+
+  return (givenOperand < 0);
+};
+
+export {
+  isNegative,
+};


### PR DESCRIPTION
- phrases like "negative", "positive", "non-negative", "non-positive" can make it easier to spot semantic mismatches in error messages

Facilitates #580
Built while drafting #567 but was ultimately not needed for that particular set of changes