### PR TITLE
ci(dependabot): enables auto-approval for patch bumps to `vue-tsc`

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -7,6 +7,7 @@ permissions:
 
 jobs:
   auto-merge:
+    name: Merge sanctioned dependency-bump PRs automatically
     runs-on: ubuntu-latest
     if: |
       (github.event.pull_request.user.login == 'dependabot[bot]') &&

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -25,3 +25,16 @@ jobs:
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Approve PRs for select dependencies
+        if: |
+          contains(
+            fromJSON('[
+              "vue-tsc"
+            ]'),
+            steps.metadata.outputs.dependency-names
+          )
+          && (steps.metadata.outputs.update-type == 'version-update:semver-patch')
+        run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- Changes to `vue-tsc` are validated by the compilation step in [the node workflow](https://github.com/nod-ai/shark-ui/blob/integration/.github/workflows/node.yml)