### PR TITLE
ci(dependabot): enables auto-approval for minor bumps to `eslint`

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -26,7 +26,7 @@ jobs:
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Approve PRs for select dependencies
+      - name: Approve patches for select dependencies
         if: |
           contains(
             fromJSON('[

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -43,6 +43,7 @@ jobs:
         if: |
           contains(
             fromJSON('[
+              "eslint"
             ]'),
             steps.metadata.outputs.dependency-names
           )

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -39,3 +39,15 @@ jobs:
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Approve minor updates for select dependencies
+        if: |
+          contains(
+            fromJSON('[
+            ]'),
+            steps.metadata.outputs.dependency-names
+          )
+          && (steps.metadata.outputs.update-type == 'version-update:semver-minor')
+        run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- changes to `eslint` that conflict with this codebase will always trigger the CI's linter step to fail
- `eslint` doesn't actually affect any implementation, so the testing pipeline will always yield the same result before and after the version bump
- because of this, minor and patch bumps are safe to automatically approve
- pairing that with auto-merge upon passing required checks, maintainers will seldom have to intervene for this frequently updated dependency 