### PR TITLE
linter(import): enforces placement of "@/**" imports between external and internal imports

### DIFF
--- a/eslint.import.ts
+++ b/eslint.import.ts
@@ -54,7 +54,7 @@ const extraConfig: ConfigWithExtends = {
           },
           {
             pattern : '@/features/**', // Highlights the business logic of the application
-            group   : 'internal',
+            group   : 'external',
             position: 'after',
           },
         ],

--- a/eslint.import.ts
+++ b/eslint.import.ts
@@ -48,7 +48,7 @@ const extraConfig: ConfigWithExtends = {
             position: 'after',
           },
           {
-            pattern : '@/!{features}/**', // Alias for "src/**"
+            pattern : '@/!(features)/**', // Alias for "src/**"
             group   : 'internal',
             position: 'after',
           },

--- a/eslint.import.ts
+++ b/eslint.import.ts
@@ -49,7 +49,7 @@ const extraConfig: ConfigWithExtends = {
           },
           {
             pattern : '@/!(features)/**', // Alias for "src/**"
-            group   : 'internal',
+            group   : 'external',
             position: 'after',
           },
           {

--- a/src/features/TextToImage/components/TextToImageOutputAlert.vue
+++ b/src/features/TextToImage/components/TextToImageOutputAlert.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
+import * as TextToImage from '@/features/TextToImage';
+
 import TextToImageServerConnectionAlert from './TextToImageServerConnectionAlert.vue';
 import TextToImageServerSpecificationAlert from './TextToImageServerSpecificationAlert.vue';
-
-import * as TextToImage from '@/features/TextToImage';
 
 type OutputError =
   | TextToImage.Server.ConnectionError

--- a/src/features/TextToImage/models/SDXL/client/conversions/GenerateFromTextResponse.ts
+++ b/src/features/TextToImage/models/SDXL/client/conversions/GenerateFromTextResponse.ts
@@ -9,10 +9,6 @@ import {
 } from '@/library/utilitiesByType/array';
 
 import {
-  toOutputImage,
-} from './StabilityAI_Client_Image';
-
-import {
   allSerialized,
 } from '@/features/TextToImage/models/SDXL/client/conversions/TextPrompt';
 
@@ -20,6 +16,10 @@ import type {
   Input,
   Output,
 } from '@/features/TextToImage/types';
+
+import {
+  toOutputImage,
+} from './StabilityAI_Client_Image';
 
 const toNullableOutput = (
   givenImage: Output['image'] | null,

--- a/src/features/TextToImage/models/SDXL/client/index.ts
+++ b/src/features/TextToImage/models/SDXL/client/index.ts
@@ -6,10 +6,6 @@ import Attempt from '@/library/Attempt';
 import HTTP from '@/library/HTTP';
 import ShimmedStabilityAIClient from '@/library/ShimmedStabilityAIClient/index.ts';
 
-import {
-  firstTextToImageOutput,
-} from './conversions/GenerateFromTextResponse';
-
 import type {
   Output,
 } from '@/features/TextToImage/types';
@@ -17,6 +13,10 @@ import type {
 import {
   Server,
 } from '@/features/TextToImage/webAPI';
+
+import {
+  firstTextToImageOutput,
+} from './conversions/GenerateFromTextResponse';
 
 const initializeShimmedStabilityAIClient = async (): Promise<
   Attempt.Outcome<ShimmedStabilityAIClient, Server.SpecificationError>


### PR DESCRIPTION
- the prior config was putting "@" imports _after_ internal (parent, sibling) imports
- the imports _should_ be grouped from largest to smallest scope, so the config needed to be corrected