### PR TITLE
linter(import): enforces grouping to capture internal modules

### DIFF
--- a/eslint.import.ts
+++ b/eslint.import.ts
@@ -38,7 +38,7 @@ const extraConfig: ConfigWithExtends = {
         ],
         'pathGroups': [
           {
-            pattern : '@/library/vue', // Allows Vue utilities to bubble to the very top of the <script setup> tag
+            pattern : '@/library/vue{,/**}', // Allows Vue utilities to bubble to the very top of the <script setup> tag
             group   : 'builtin',
             position: 'before',
           },

--- a/eslint.import.ts
+++ b/eslint.import.ts
@@ -48,7 +48,7 @@ const extraConfig: ConfigWithExtends = {
             position: 'after',
           },
           {
-            pattern : '@/!(features)/**', // Alias for "src/**"
+            pattern : '@/!(features)/**', // Highlights the supporting logic of the application
             group   : 'external',
             position: 'after',
           },

--- a/eslint.import.ts
+++ b/eslint.import.ts
@@ -48,7 +48,7 @@ const extraConfig: ConfigWithExtends = {
             position: 'after',
           },
           {
-            pattern : '@/!(features)/**', // Highlights the supporting logic of the application
+            pattern : '@/!(features){,/**}', // Highlights the supporting logic of the application
             group   : 'external',
             position: 'after',
           },


### PR DESCRIPTION
Follows up on #591