### PR TITLE
refactor(main): prefers absolute paths

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -6,7 +6,7 @@ import {
   asError,
 } from '@/library/utilitiesByType/error.ts';
 
-import App from './App.vue';
+import App from '@/App.vue';
 
 import {
   promptUserToReport,

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,13 +7,12 @@ import {
 } from '@/library/utilitiesByType/error.ts';
 
 import App from '@/App.vue';
+import vuetify from '@/plugins/vuetify.ts';
+import router from '@/router';
 
 import {
   promptUserToReport,
 } from './features/reporting.ts';
-
-import vuetify from './plugins/vuetify.ts';
-import router from './router';
 
 const app = createApp(App);
 app.use(router);

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,7 +12,7 @@ import router from '@/router';
 
 import {
   promptUserToReport,
-} from './features/reporting.ts';
+} from '@/features/reporting.ts';
 
 const app = createApp(App);
 app.use(router);

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,15 +2,15 @@ import {
   createApp,
 } from '@/library/vue';
 
+import {
+  asError,
+} from '@/library/utilitiesByType/error.ts';
+
 import App from './App.vue';
 
 import {
   promptUserToReport,
 } from './features/reporting.ts';
-
-import {
-  asError,
-} from './library/utilitiesByType/error.ts';
 
 import vuetify from './plugins/vuetify.ts';
 import router from './router';


### PR DESCRIPTION
- relative paths are reserved for submodules that access peers within any given module
- while `main.ts` _does_ access peers, it does _not_ have any `export` declarations, hence it doesn't qualify as a "module" in that sense

Facilitates #595 