### PR TITLE
linter(import): conforms config to precedent from package documentation

### DIFF
--- a/eslint.import.ts
+++ b/eslint.import.ts
@@ -16,7 +16,6 @@ const extendedConfig: ConfigWithExtends = {
   settings: {
     'import/resolver': {
       'typescript'                         : true,
-      'node'                               : true,
       'eslint-import-resolver-custom-alias': {
         alias: {
           '@': './src',

--- a/eslint.import.ts
+++ b/eslint.import.ts
@@ -9,6 +9,10 @@ const extraConfig: ConfigWithExtends = {
   files: [
     '**/*.{ts,vue}',
   ],
+  extends: [
+    importPlugin.flatConfigs.recommended,
+    importPlugin.flatConfigs.typescript,
+  ],
   settings: {
     'import/resolver': {
       'typescript'                         : true,
@@ -74,8 +78,6 @@ const extraConfig: ConfigWithExtends = {
 };
 
 const pluginImport: ConfigWithExtends[] = [
-  importPlugin.flatConfigs.recommended,
-  importPlugin.flatConfigs.typescript,
   extraConfig,
 ];
 

--- a/eslint.import.ts
+++ b/eslint.import.ts
@@ -4,7 +4,7 @@ import type {
   ConfigWithExtends,
 } from 'typescript-eslint';
 
-const extraConfig: ConfigWithExtends = {
+const extendedConfig: ConfigWithExtends = {
   name : 'shark-ui/import',
   files: [
     '**/*.{ts,vue}',
@@ -78,7 +78,7 @@ const extraConfig: ConfigWithExtends = {
 };
 
 const pluginImport: ConfigWithExtends[] = [
-  extraConfig,
+  extendedConfig,
 ];
 
 export {

--- a/eslint.import.ts
+++ b/eslint.import.ts
@@ -5,8 +5,10 @@ import type {
 } from 'typescript-eslint';
 
 const extraConfig: ConfigWithExtends = {
-  name    : 'shark-ui/import',
-  files   : ['**/*.{ts,vue}'],
+  name : 'shark-ui/import',
+  files: [
+    '**/*.{ts,vue}',
+  ],
   settings: {
     'import/resolver': {
       'typescript'                         : true,
@@ -15,7 +17,10 @@ const extraConfig: ConfigWithExtends = {
         alias: {
           '@': './src',
         },
-        extensions: ['.ts', '.vue'],
+        extensions: [
+          '.ts',
+          '.vue',
+        ],
       },
     },
   },

--- a/eslint.import.ts
+++ b/eslint.import.ts
@@ -15,7 +15,9 @@ const extendedConfig: ConfigWithExtends = {
   ],
   settings: {
     'import/resolver': {
-      'typescript'                         : true,
+      'typescript': {
+        project: './tsconfig.json',
+      },
       'eslint-import-resolver-custom-alias': {
         alias: {
           '@': './src',

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "@types/jsdom": "^21.1.7",
         "@types/lodash.clonedeep": "^4.5.9",
         "@types/node": "^24.1.0",
+        "@typescript-eslint/parser": "^8.38.0",
         "@vitejs/plugin-vue": "^6.0.1",
         "@vitest/coverage-v8": "^3.2.4",
         "@vitest/eslint-plugin": "^1.3.4",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@types/jsdom": "^21.1.7",
     "@types/lodash.clonedeep": "^4.5.9",
     "@types/node": "^24.1.0",
+    "@typescript-eslint/parser": "^8.38.0",
     "@vitejs/plugin-vue": "^6.0.1",
     "@vitest/coverage-v8": "^3.2.4",
     "@vitest/eslint-plugin": "^1.3.4",


### PR DESCRIPTION
- specified in [docs for setting up config](https://github.com/import-js/eslint-plugin-import#typescript)

Discovered while drafting #598 
- This was done in an attempt to narrow down the reason for the limitations of the proposed new rule