### PR TITLE
refactor(library/Attempt): avoids useless adjacent barrel imports in non-"index" files

### DIFF
--- a/src/library/Attempt/error/ActionableError.ts
+++ b/src/library/Attempt/error/ActionableError.ts
@@ -3,8 +3,8 @@ import type {
 } from '@/library/typeUtilities/Branded';
 
 import {
-  NonActionableError,
-} from '.';
+  default as NonActionableError,
+} from './NonActionableError';
 
 /** Extend this class to describe errors from which callers ought to recover */
 abstract class ActionableError<

--- a/src/library/Attempt/error/assertions/assertActionable.ts
+++ b/src/library/Attempt/error/assertions/assertActionable.ts
@@ -1,6 +1,6 @@
 import type {
-  ActionableError,
-} from '..';
+  default as ActionableError,
+} from '../ActionableError';
 
 import type Attempt_ErrorInterpreter from '../Interpreter';
 import NonActionableBuiltInError from '../NonActionableBuiltInError';

--- a/src/library/Attempt/error/assertions/assertActionable.ts
+++ b/src/library/Attempt/error/assertions/assertActionable.ts
@@ -12,7 +12,7 @@ import type {
 
 import {
   assertPotentiallyActionable,
-} from '.';
+} from './assertPotentiallyActionable';
 
 const assertActionable = <
   SomeActionableError extends ActionableError<string>,

--- a/src/library/Attempt/error/assertions/assertActionable.ts
+++ b/src/library/Attempt/error/assertions/assertActionable.ts
@@ -1,10 +1,13 @@
-import {
-  NonActionableError,
-  type ActionableError,
+import type {
+  ActionableError,
 } from '..';
 
 import type Attempt_ErrorInterpreter from '../Interpreter';
 import NonActionableBuiltInError from '../NonActionableBuiltInError';
+
+import {
+  default as NonActionableError,
+} from '../NonActionableError';
 
 import type {
   AppropriatelyThrown,

--- a/src/library/Attempt/error/assertions/assertAppropriatelyThrown.ts
+++ b/src/library/Attempt/error/assertions/assertAppropriatelyThrown.ts
@@ -1,6 +1,6 @@
 import {
-  ActionableError,
-} from '..';
+  default as ActionableError,
+} from '../ActionableError';
 
 import type {
   AppropriatelyThrown,

--- a/src/library/Attempt/error/assertions/assertPotentiallyActionable.ts
+++ b/src/library/Attempt/error/assertions/assertPotentiallyActionable.ts
@@ -1,8 +1,8 @@
-import {
-  NonActionableError,
-} from '..';
-
 import AttemptCreationError from '../../factory/AttemptCreationError';
+
+import {
+  default as NonActionableError,
+} from '../NonActionableError';
 
 import type {
   PotentiallyActionable,


### PR DESCRIPTION
- the imports targeted in the affected files were taking a roundabout path to get to a sibling or pibling (parent's sibling) module that opened up the possibility of circular imports

Say we had the following file structure:
- src
  - ModuleA
    - index.ts
    - ModuleAA
      - index.ts
      - ModuleAAA.ts
      - ModuleAAB.ts
    - ModuleAB
      - index.ts
      - ...
    - ModuleAC.ts 
  - ModuleB.ts

From the perspective of "ModuleAAA.ts":
- "./index.ts" -> "ModuleAA/index.ts" -> "sibling barrel file"
- "../index.ts" -> "ModuleA/index.ts" -> "pibling barrel file"

These barrel files can create circular references:
- "./index.ts" will pull from contents of "ModuleAA", which includes the file importing from the barrel "ModuleAAA.ts"
- "../index.ts" will pull from contents of "ModuleA", which includes "ModuleAA" and, as shown above, "ModuleAAA"

In practice, the only imports that avoid these cycles would be ones like:
- "./ModuleAAB": a sibling module
- "../ModuleAB/index.ts": a pibling directory module
- "../ModuleAC.ts": a pibling single-file module

Any other arrangement is likely indicative of the need to reorganize the files.

Facilitates #593 