### PR TITLE
ci(dependabot): auto-approves minor bumps to `eslint-plugin-vue`

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -43,7 +43,8 @@ jobs:
         if: |
           contains(
             fromJSON('[
-              "eslint"
+              "eslint",
+              "eslint-plugin-vue"
             ]'),
             steps.metadata.outputs.dependency-names
           )


### PR DESCRIPTION
- changes to `eslint-plugin-vue` that conflict with this codebase will always trigger the CI's linter step to fail
- `eslint-plugin-vue` doesn't actually affect any implementation, so the testing pipeline will always yield the same result before and after the version bump
- because of this, minor and patch bumps are safe to automatically approve
- pairing that with auto-merge upon passing required checks, maintainers will seldom have to intervene for this frequently updated dependency 