### PR TITLE
refactor: avoids reaching directly into a module's "exports"

### DIFF
--- a/src/components/DiscreteSlider.vue
+++ b/src/components/DiscreteSlider.vue
@@ -2,7 +2,7 @@
 import {
   get,
   set,
-} from '@/library/vue/exports';
+} from '@/library/vue';
 
 import {
   VBtn,
@@ -16,8 +16,8 @@ import {
   VSlider,
 } from 'vuetify/components/VSlider';
 
+import type Range from '@/library/Range';
 import DiscreteRange from '@/library/Range/DiscreteRange.ts';
-import type Range from '@/library/Range/exports';
 
 import {
   shallowlyMerged,

--- a/src/components/NavigationPanel.vue
+++ b/src/components/NavigationPanel.vue
@@ -2,7 +2,7 @@
 import {
   reactive,
   type Reactive,
-} from '@/library/vue/exports';
+} from '@/library/vue';
 
 import {
   VNavigationDrawer,

--- a/src/features/TextToImage/client/exports.ts
+++ b/src/features/TextToImage/client/exports.ts
@@ -1,3 +1,3 @@
 export {
   default as SDXL,
-} from '@/features/TextToImage/models/SDXL/client/exports';
+} from '@/features/TextToImage/models/SDXL/client';

--- a/src/features/TextToImage/client/index.ts
+++ b/src/features/TextToImage/client/index.ts
@@ -1,0 +1,1 @@
+export * from './exports.ts';

--- a/src/features/TextToImage/components/TextToImageInputSection.vue
+++ b/src/features/TextToImage/components/TextToImageInputSection.vue
@@ -5,7 +5,7 @@ import {
   set,
   type Ref,
   watch,
-} from '@/library/vue/exports';
+} from '@/library/vue';
 
 import {
   VCard,
@@ -17,7 +17,7 @@ import {
 
 import type {
   Input,
-} from '../types/exports';
+} from '../types';
 
 type StandardizedInputText = Input['text'];
 

--- a/src/features/TextToImage/components/TextToImageOutputAlert.vue
+++ b/src/features/TextToImage/components/TextToImageOutputAlert.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import * as TextToImage from '@/features/TextToImage/exports';
+import * as TextToImage from '@/features/TextToImage';
 
 import TextToImageServerConnectionAlert from './TextToImageServerConnectionAlert.vue';
 import TextToImageServerSpecificationAlert from './TextToImageServerSpecificationAlert.vue';

--- a/src/features/TextToImage/components/TextToImageOutputImg.vue
+++ b/src/features/TextToImage/components/TextToImageOutputImg.vue
@@ -3,7 +3,7 @@ import {
   VImg,
 } from 'vuetify/components/VImg';
 
-import type * as TextToImage from '@/features/TextToImage/exports';
+import type * as TextToImage from '@/features/TextToImage';
 
 defineProps<{
   modelValue: TextToImage.Output['image'];

--- a/src/features/TextToImage/components/TextToImageServerConnectionAlert.vue
+++ b/src/features/TextToImage/components/TextToImageServerConnectionAlert.vue
@@ -3,7 +3,7 @@ import {
   VAlert,
 } from 'vuetify/components/VAlert';
 
-import type * as TextToImage from '@/features/TextToImage/exports';
+import type * as TextToImage from '@/features/TextToImage';
 
 defineProps<{
   error: TextToImage.Server.ConnectionError;

--- a/src/features/TextToImage/components/TextToImageServerSpecificationAlert.vue
+++ b/src/features/TextToImage/components/TextToImageServerSpecificationAlert.vue
@@ -3,7 +3,7 @@ import {
   VAlert,
 } from 'vuetify/components/VAlert';
 
-import type * as TextToImage from '@/features/TextToImage/exports';
+import type * as TextToImage from '@/features/TextToImage';
 
 defineProps<{
   error: TextToImage.Server.SpecificationError;

--- a/src/features/TextToImage/config/exports.ts
+++ b/src/features/TextToImage/config/exports.ts
@@ -1,3 +1,3 @@
-export * as DynamicConfig from './utilities/DynamicConfig/exports';
-export * as StaticConfig from './utilities/StaticConfig/exports';
+export * as DynamicConfig from './utilities/DynamicConfig';
+export * as StaticConfig from './utilities/StaticConfig';
 export * from './utilities/emptyConfig';

--- a/src/features/TextToImage/config/index.ts
+++ b/src/features/TextToImage/config/index.ts
@@ -1,0 +1,1 @@
+export * from './exports.ts';

--- a/src/features/TextToImage/config/types/Config.ts
+++ b/src/features/TextToImage/config/types/Config.ts
@@ -1,4 +1,4 @@
-import type * as WebAPI from '@/library/WebAPI/exports';
+import type * as WebAPI from '@/library/WebAPI';
 
 /** The user-provided settings for the text-to-image feature */
 class TextToImage_Config {

--- a/src/features/TextToImage/config/types/ConfigSchema.ts
+++ b/src/features/TextToImage/config/types/ConfigSchema.ts
@@ -1,5 +1,5 @@
 import Schema from '@/library/Schema';
-import * as WebAPI from '@/library/WebAPI/exports';
+import * as WebAPI from '@/library/WebAPI';
 
 import {
   TextToImage_Config,

--- a/src/features/TextToImage/config/types/index.ts
+++ b/src/features/TextToImage/config/types/index.ts
@@ -1,0 +1,1 @@
+export * from './exports.ts';

--- a/src/features/TextToImage/config/utilities/DynamicConfig/EndpointResponseError.ts
+++ b/src/features/TextToImage/config/utilities/DynamicConfig/EndpointResponseError.ts
@@ -2,7 +2,7 @@ import Attempt from '@/library/Attempt';
 
 import type {
   URLPath,
-} from '@/library/URLComponent/exports';
+} from '@/library/URLComponent';
 
 class DynamicConfig_EndpointResponseError
   extends Attempt.ActionableError<

--- a/src/features/TextToImage/config/utilities/DynamicConfig/FetchingError.ts
+++ b/src/features/TextToImage/config/utilities/DynamicConfig/FetchingError.ts
@@ -2,7 +2,7 @@ import Attempt from '@/library/Attempt';
 
 import type {
   URLPath,
-} from '@/library/URLComponent/exports';
+} from '@/library/URLComponent';
 
 class DynamicConfig_FetchingError
   extends Attempt.ActionableError<

--- a/src/features/TextToImage/config/utilities/DynamicConfig/exports.ts
+++ b/src/features/TextToImage/config/utilities/DynamicConfig/exports.ts
@@ -2,12 +2,12 @@ import Attempt from '@/library/Attempt';
 
 import {
   URLPath,
-} from '@/library/URLComponent/exports';
+} from '@/library/URLComponent';
 
 import {
   type Config,
   ConfigSchema,
-} from '../../types/exports';
+} from '../../types';
 
 import DynamicConfig_EndpointResponseError from './EndpointResponseError';
 import DynamicConfig_FetchingError from './FetchingError';

--- a/src/features/TextToImage/config/utilities/DynamicConfig/index.ts
+++ b/src/features/TextToImage/config/utilities/DynamicConfig/index.ts
@@ -1,0 +1,1 @@
+export * from './exports.ts';

--- a/src/features/TextToImage/config/utilities/StaticConfig/StaticConfigReadingError.ts
+++ b/src/features/TextToImage/config/utilities/StaticConfig/StaticConfigReadingError.ts
@@ -2,7 +2,7 @@ import Attempt from '@/library/Attempt';
 
 import type {
   URLPath,
-} from '@/library/URLComponent/exports';
+} from '@/library/URLComponent';
 
 class StaticConfigReadingError
   extends Attempt.ActionableError<

--- a/src/features/TextToImage/config/utilities/StaticConfig/exports.ts
+++ b/src/features/TextToImage/config/utilities/StaticConfig/exports.ts
@@ -2,12 +2,12 @@ import Attempt from '@/library/Attempt';
 
 import {
   URLPath,
-} from '@/library/URLComponent/exports';
+} from '@/library/URLComponent';
 
 import {
   type Config,
   ConfigSchema,
-} from '../../types/exports';
+} from '../../types';
 
 import StaticConfigReadingError from './StaticConfigReadingError';
 

--- a/src/features/TextToImage/config/utilities/StaticConfig/index.ts
+++ b/src/features/TextToImage/config/utilities/StaticConfig/index.ts
@@ -1,0 +1,1 @@
+export * from './exports.ts';

--- a/src/features/TextToImage/config/utilities/emptyConfig.ts
+++ b/src/features/TextToImage/config/utilities/emptyConfig.ts
@@ -1,6 +1,6 @@
 import type {
   Config,
-} from '../types/exports';
+} from '../types';
 
 const emptyConfig: Config = {
   server: null,

--- a/src/features/TextToImage/exports.ts
+++ b/src/features/TextToImage/exports.ts
@@ -1,7 +1,7 @@
-export * as Client from './client/exports';
+export * as Client from './client';
 
 export {
   Server,
-} from './webAPI/exports';
+} from './webAPI';
 
-export type * from './types/exports';
+export type * from './types';

--- a/src/features/TextToImage/index.ts
+++ b/src/features/TextToImage/index.ts
@@ -1,0 +1,1 @@
+export * from './exports.ts';

--- a/src/features/TextToImage/models/SDXL/client/conversions/GenerateFromTextResponse.ts
+++ b/src/features/TextToImage/models/SDXL/client/conversions/GenerateFromTextResponse.ts
@@ -15,7 +15,7 @@ import {
 import type {
   Input,
   Output,
-} from '@/features/TextToImage/types/exports';
+} from '@/features/TextToImage/types';
 
 import {
   toOutputImage,

--- a/src/features/TextToImage/models/SDXL/client/conversions/StabilityAI_Client_Image.ts
+++ b/src/features/TextToImage/models/SDXL/client/conversions/StabilityAI_Client_Image.ts
@@ -1,11 +1,11 @@
 import type * as StabilityAIClient from 'stabilityai-client-typescript/models/components';
 
-import Base64CharacterEncodedByteSequence from '@/library/Base64CharacterEncodedByteSequence/exports';
-import ImageURI from '@/library/UniformResourceIdentifier/Data/Image/exports';
+import Base64CharacterEncodedByteSequence from '@/library/Base64CharacterEncodedByteSequence';
+import ImageURI from '@/library/UniformResourceIdentifier/Data/Image';
 
 import type {
   Output,
-} from '@/features/TextToImage/types/exports';
+} from '@/features/TextToImage/types';
 
 const toOutputImage = (
   givenImage: StabilityAIClient.Image,

--- a/src/features/TextToImage/models/SDXL/client/exports.ts
+++ b/src/features/TextToImage/models/SDXL/client/exports.ts
@@ -4,15 +4,15 @@ import type {
 
 import Attempt from '@/library/Attempt';
 import HTTP from '@/library/HTTP';
-import ShimmedStabilityAIClient from '@/library/ShimmedStabilityAIClient/exports';
+import ShimmedStabilityAIClient from '@/library/ShimmedStabilityAIClient';
 
 import type {
   Output,
-} from '@/features/TextToImage/types/exports';
+} from '@/features/TextToImage/types';
 
 import {
   Server,
-} from '@/features/TextToImage/webAPI/exports';
+} from '@/features/TextToImage/webAPI';
 
 import {
   firstTextToImageOutput,

--- a/src/features/TextToImage/models/SDXL/client/index.ts
+++ b/src/features/TextToImage/models/SDXL/client/index.ts
@@ -1,0 +1,3 @@
+export {
+  default as default,
+} from './exports.ts';

--- a/src/features/TextToImage/types/Output/Image.ts
+++ b/src/features/TextToImage/types/Output/Image.ts
@@ -1,4 +1,4 @@
-import type ImageURI from '@/library/UniformResourceIdentifier/Data/Image/exports';
+import type ImageURI from '@/library/UniformResourceIdentifier/Data/Image';
 
 interface TextToImage_Output_Image {
   uri: ImageURI;

--- a/src/features/TextToImage/types/Output/index.ts
+++ b/src/features/TextToImage/types/Output/index.ts
@@ -1,0 +1,1 @@
+export type * from './exports.ts';

--- a/src/features/TextToImage/types/exports.ts
+++ b/src/features/TextToImage/types/exports.ts
@@ -3,4 +3,4 @@ export type {
 } from './Input';
 export type {
   TextToImage_Output as Output,
-} from './Output/exports';
+} from './Output';

--- a/src/features/TextToImage/types/index.ts
+++ b/src/features/TextToImage/types/index.ts
@@ -1,0 +1,1 @@
+export type * from './exports.ts';

--- a/src/features/TextToImage/webAPI/Server/ServerSpecificationError.ts
+++ b/src/features/TextToImage/webAPI/Server/ServerSpecificationError.ts
@@ -2,7 +2,7 @@ import Attempt from '@/library/Attempt';
 
 import type {
   URLPath,
-} from '@/library/URLComponent/exports';
+} from '@/library/URLComponent';
 
 class TextToImage_Server_SpecificationError
   extends Attempt.ActionableError<

--- a/src/features/TextToImage/webAPI/Server/exports.ts
+++ b/src/features/TextToImage/webAPI/Server/exports.ts
@@ -2,13 +2,13 @@ import Attempt from '@/library/Attempt';
 
 import {
   Server,
-} from '@/library/WebAPI/exports';
+} from '@/library/WebAPI';
 
 import {
   DynamicConfig,
   StaticConfig,
   emptyConfig,
-} from '../../config/exports';
+} from '../../config';
 
 import TextToImage_Server_SpecificationError from './ServerSpecificationError';
 

--- a/src/features/TextToImage/webAPI/Server/index.ts
+++ b/src/features/TextToImage/webAPI/Server/index.ts
@@ -1,0 +1,1 @@
+export * from './exports.ts';

--- a/src/features/TextToImage/webAPI/exports.ts
+++ b/src/features/TextToImage/webAPI/exports.ts
@@ -1,1 +1,1 @@
-export * as Server from './Server/exports';
+export * as Server from './Server';

--- a/src/features/TextToImage/webAPI/index.ts
+++ b/src/features/TextToImage/webAPI/index.ts
@@ -1,0 +1,1 @@
+export * from './exports.ts';

--- a/src/library/Attempt/Outcome/Discriminable.ts
+++ b/src/library/Attempt/Outcome/Discriminable.ts
@@ -6,7 +6,7 @@ import type {
 
 import type {
   ActionableError,
-} from '../error/exports';
+} from '../error';
 
 type Attempt_Outcome_Discriminant = 'success' | 'failure';
 

--- a/src/library/Attempt/Outcome/Failure/Transformer.ts
+++ b/src/library/Attempt/Outcome/Failure/Transformer.ts
@@ -1,6 +1,6 @@
 import type {
   ActionableError,
-} from '../../error/exports';
+} from '../../error';
 
 type CauseTransformer<
   TransformableActionableError extends ActionableError<string>,

--- a/src/library/Attempt/Outcome/Failure/exports.ts
+++ b/src/library/Attempt/Outcome/Failure/exports.ts
@@ -2,7 +2,7 @@
 
 import type {
   ActionableError,
-} from '../../error/exports';
+} from '../../error';
 
 import type {
   DiscriminableOutcome,

--- a/src/library/Attempt/Outcome/Failure/index.ts
+++ b/src/library/Attempt/Outcome/Failure/index.ts
@@ -1,0 +1,1 @@
+export * from './exports.ts';

--- a/src/library/Attempt/Outcome/Success/index.ts
+++ b/src/library/Attempt/Outcome/Success/index.ts
@@ -1,0 +1,1 @@
+export * from './exports.ts';

--- a/src/library/Attempt/Outcome/Transformer.ts
+++ b/src/library/Attempt/Outcome/Transformer.ts
@@ -1,6 +1,6 @@
 import type {
   ActionableError,
-} from '../error/exports';
+} from '../error';
 
 import type {
   Attempt_Failure_Transformer,

--- a/src/library/Attempt/Outcome/exports.ts
+++ b/src/library/Attempt/Outcome/exports.ts
@@ -1,20 +1,20 @@
 import type {
   ActionableError,
-} from '../error/exports';
+} from '../error';
 
 import {
   type Attempt_Failure,
   type Attempt_Failure_Transformer,
   failureDueTo,
   causeIdentity,
-} from './Failure/exports';
+} from './Failure';
 
 import {
   type Attempt_Success,
   type Attempt_Success_Transformer,
   successThatYielded,
   productIdentity,
-} from './Success/exports';
+} from './Success';
 
 import type {
   Attempt_Outcome_Transformer,

--- a/src/library/Attempt/Outcome/index.ts
+++ b/src/library/Attempt/Outcome/index.ts
@@ -1,0 +1,1 @@
+export * from './exports.ts';

--- a/src/library/Attempt/adapter/Config.ts
+++ b/src/library/Attempt/adapter/Config.ts
@@ -1,8 +1,8 @@
-import type Attempt_ErrorInterpreter from '../error/Interpreter';
-
 import type {
   ActionableError,
-} from '../error/exports';
+} from '../error';
+
+import type Attempt_ErrorInterpreter from '../error/Interpreter';
 
 interface Attempt_AdapterConfig<
   SomeActionableError extends ActionableError<string>,

--- a/src/library/Attempt/adapter/asynchronous.ts
+++ b/src/library/Attempt/adapter/asynchronous.ts
@@ -1,18 +1,18 @@
 import type {
   Attempt_Outcome,
-} from '../Outcome/exports';
-
-import {
-  assertActionable,
-} from '../error/assertions/exports';
+} from '../Outcome';
 
 import type {
   ActionableError,
-} from '../error/exports';
+} from '../error';
+
+import {
+  assertActionable,
+} from '../error/assertions';
 
 import {
   Attempt_thatEventually,
-} from '../factory/exports';
+} from '../factory';
 
 import {
   sanctionedAsync,

--- a/src/library/Attempt/adapter/index.ts
+++ b/src/library/Attempt/adapter/index.ts
@@ -1,0 +1,1 @@
+export * from './exports.ts';

--- a/src/library/Attempt/adapter/synchronous.ts
+++ b/src/library/Attempt/adapter/synchronous.ts
@@ -1,18 +1,18 @@
 import type {
   Attempt_Outcome,
-} from '../Outcome/exports';
-
-import {
-  assertActionable,
-} from '../error/assertions/exports';
+} from '../Outcome';
 
 import type {
   ActionableError,
-} from '../error/exports';
+} from '../error';
+
+import {
+  assertActionable,
+} from '../error/assertions';
 
 import {
   Attempt_that,
-} from '../factory/exports';
+} from '../factory';
 
 import {
   sanctioned,

--- a/src/library/Attempt/ended.ts
+++ b/src/library/Attempt/ended.ts
@@ -1,10 +1,10 @@
 import {
   Attempt_Outcome,
-} from './Outcome/exports';
+} from './Outcome';
 
 import {
   NonActionableError,
-} from './error/exports';
+} from './error';
 
 /**
  * (noun) Defines the relationship between:

--- a/src/library/Attempt/error/Interpreter.ts
+++ b/src/library/Attempt/error/Interpreter.ts
@@ -2,7 +2,7 @@ import type ActionableError from './ActionableError';
 
 import type {
   PotentiallyActionable,
-} from './modifier/exports';
+} from './modifier';
 
 type Attempt_ErrorInterpreter<
   SomeActionableError extends ActionableError<string>,

--- a/src/library/Attempt/error/assertions/assertActionable.ts
+++ b/src/library/Attempt/error/assertions/assertActionable.ts
@@ -11,7 +11,7 @@ import {
 
 import type {
   AppropriatelyThrown,
-} from '../modifier/exports';
+} from '../modifier';
 
 import {
   assertPotentiallyActionable,

--- a/src/library/Attempt/error/assertions/assertAppropriatelyThrown.ts
+++ b/src/library/Attempt/error/assertions/assertAppropriatelyThrown.ts
@@ -4,7 +4,7 @@ import {
 
 import type {
   AppropriatelyThrown,
-} from '../modifier/exports';
+} from '../modifier';
 
 /**
  * Expects `ActionableError`s to be propagated within the confines of the type system.

--- a/src/library/Attempt/error/assertions/assertPotentiallyActionable.ts
+++ b/src/library/Attempt/error/assertions/assertPotentiallyActionable.ts
@@ -6,7 +6,7 @@ import {
 
 import type {
   PotentiallyActionable,
-} from '../modifier/exports';
+} from '../modifier';
 
 const assertPotentiallyActionable = <
   SomeError extends Error,

--- a/src/library/Attempt/error/assertions/index.ts
+++ b/src/library/Attempt/error/assertions/index.ts
@@ -1,0 +1,1 @@
+export * from './exports.ts';

--- a/src/library/Attempt/error/index.ts
+++ b/src/library/Attempt/error/index.ts
@@ -1,0 +1,1 @@
+export * from './exports.ts';

--- a/src/library/Attempt/error/modifier/index.ts
+++ b/src/library/Attempt/error/modifier/index.ts
@@ -1,0 +1,1 @@
+export type * from './exports.ts';

--- a/src/library/Attempt/exports.ts
+++ b/src/library/Attempt/exports.ts
@@ -12,24 +12,24 @@ export {
   Attempt_Outcome as Outcome,
   type Attempt_Success as Success,
   type Attempt_Failure as Failure,
-} from './Outcome/exports';
+} from './Outcome';
 
 export {
   attemptTo as to,
   attemptToEventually as toEventually,
   attemptToSettle as toSettle,
   type AdapterConfig,
-} from './adapter/exports';
+} from './adapter';
 
 export {
   NonActionableError,
   ActionableError,
   type ErrorInterpreter,
-} from './error/exports';
+} from './error';
 
 export {
   Attempt_that as that,
   Attempt_thatEventually as thatEventually,
   type Attempt_EndGetter as EndGetter,
   type Attempt_EndRetriever as EndRetriever,
-} from './factory/exports';
+} from './factory';

--- a/src/library/Attempt/factory/asynchronous.ts
+++ b/src/library/Attempt/factory/asynchronous.ts
@@ -2,7 +2,7 @@ import type {
   Attempt_Outcome,
   CauseOf,
   ProductOf,
-} from '../Outcome/exports';
+} from '../Outcome';
 
 import {
   Attempt_ended as handles,
@@ -10,7 +10,7 @@ import {
 
 import type {
   ActionableError,
-} from '../error/exports';
+} from '../error';
 
 import {
   sanctionedAsync,

--- a/src/library/Attempt/factory/index.ts
+++ b/src/library/Attempt/factory/index.ts
@@ -1,0 +1,1 @@
+export * from './exports.ts';

--- a/src/library/Attempt/factory/synchronous.ts
+++ b/src/library/Attempt/factory/synchronous.ts
@@ -2,7 +2,7 @@ import type {
   Attempt_Outcome,
   CauseOf,
   ProductOf,
-} from '../Outcome/exports';
+} from '../Outcome';
 
 import {
   Attempt_ended as handles,
@@ -10,7 +10,7 @@ import {
 
 import type {
   ActionableError,
-} from '../error/exports';
+} from '../error';
 
 import {
   sanctioned,

--- a/src/library/Attempt/utilities/sanctionedTryCatch.ts
+++ b/src/library/Attempt/utilities/sanctionedTryCatch.ts
@@ -4,11 +4,11 @@ import {
 
 import {
   assertAppropriatelyThrown,
-} from '../error/assertions/exports';
+} from '../error/assertions';
 
 import type {
   AppropriatelyThrown,
-} from '../error/modifier/exports';
+} from '../error/modifier';
 
 const sanctioned = <
   TryBlockOutput,

--- a/src/library/Base64/CharacterSequence/index.ts
+++ b/src/library/Base64/CharacterSequence/index.ts
@@ -1,0 +1,1 @@
+export * from './exports.ts';

--- a/src/library/Base64/exports.ts
+++ b/src/library/Base64/exports.ts
@@ -1,5 +1,5 @@
 import Base64_Alphabet from './Alphabet';
-import * as Base64_CharacterSequence from './CharacterSequence/exports';
+import * as Base64_CharacterSequence from './CharacterSequence';
 
 const Base64_bitWidth = Math.log2(Base64_Alphabet.length);
 

--- a/src/library/Base64CharacterEncodedByteSequence/ParsingError.ts
+++ b/src/library/Base64CharacterEncodedByteSequence/ParsingError.ts
@@ -4,7 +4,7 @@ import Byte from '@/library/Byte';
 
 import {
   ParsingError,
-} from '@/library/Parser/exports';
+} from '@/library/Parser';
 
 class Base64CharacterEncodedByteSequence_ParsingError
   extends ParsingError<

--- a/src/library/Base64CharacterEncodedByteSequence/definition.ts
+++ b/src/library/Base64CharacterEncodedByteSequence/definition.ts
@@ -4,7 +4,7 @@ import Byte from '@/library/Byte';
 
 import type {
   StringParsable,
-} from '@/library/Parser/string/exports';
+} from '@/library/Parser/string';
 
 import StringSubset from '@/library/StringSubset';
 

--- a/src/library/Base64CharacterEncodedByteSequence/index.ts
+++ b/src/library/Base64CharacterEncodedByteSequence/index.ts
@@ -1,0 +1,3 @@
+export {
+  default as default,
+} from './exports.ts';

--- a/src/library/Byte/Sequence/index.ts
+++ b/src/library/Byte/Sequence/index.ts
@@ -1,0 +1,1 @@
+export * from './exports.ts';

--- a/src/library/Byte/exports.ts
+++ b/src/library/Byte/exports.ts
@@ -1,4 +1,4 @@
-export * as Sequence from './Sequence/exports';
+export * as Sequence from './Sequence';
 
 export {
   Byte_cofactorTo as cofactorTo,

--- a/src/library/Byte/utilities/cofactorTo.ts
+++ b/src/library/Byte/utilities/cofactorTo.ts
@@ -1,6 +1,6 @@
 import {
   cofactor,
-} from '@/library/math/exports';
+} from '@/library/math';
 
 const Byte_bitWidth = 8 as const;
 

--- a/src/library/ContentDescriptor/definition.ts
+++ b/src/library/ContentDescriptor/definition.ts
@@ -1,4 +1,4 @@
-import NonTrivialString from '@/library/NonTrivialString/exports';
+import NonTrivialString from '@/library/NonTrivialString';
 
 import {
   concatenated,

--- a/src/library/ContentDescriptor/index.ts
+++ b/src/library/ContentDescriptor/index.ts
@@ -1,0 +1,3 @@
+export {
+  default as default,
+} from './exports.ts';

--- a/src/library/HTTP/Client.ts
+++ b/src/library/HTTP/Client.ts
@@ -3,7 +3,7 @@ import Attempt from '@/library/Attempt';
 import type {
   URLOrigin,
   URLPath,
-} from '@/library/URLComponent/exports';
+} from '@/library/URLComponent';
 
 import {
   HTTP_Endpoint,

--- a/src/library/NonTrivialString/ParsingError.ts
+++ b/src/library/NonTrivialString/ParsingError.ts
@@ -1,6 +1,6 @@
 import {
   ParsingError,
-} from '@/library/Parser/exports';
+} from '@/library/Parser';
 
 class NonTrivialString_ParsingError
   extends ParsingError<

--- a/src/library/NonTrivialString/definition.ts
+++ b/src/library/NonTrivialString/definition.ts
@@ -2,7 +2,7 @@ import Attempt from '@/library/Attempt';
 
 import type {
   StringParsable,
-} from '@/library/Parser/string/exports';
+} from '@/library/Parser/string';
 
 import StringSubset from '@/library/StringSubset';
 

--- a/src/library/NonTrivialString/index.ts
+++ b/src/library/NonTrivialString/index.ts
@@ -1,0 +1,3 @@
+export {
+  default as default,
+} from './exports.ts';

--- a/src/library/Parser/index.ts
+++ b/src/library/Parser/index.ts
@@ -1,0 +1,1 @@
+export * from './exports.ts';

--- a/src/library/Parser/string/index.ts
+++ b/src/library/Parser/string/index.ts
@@ -1,0 +1,1 @@
+export type * from './exports.ts';

--- a/src/library/Range/DiscreteRange.ts
+++ b/src/library/Range/DiscreteRange.ts
@@ -2,7 +2,7 @@ import Attempt from '@/library/Attempt';
 
 import {
   isNegative,
-} from '@/library/math/exports';
+} from '@/library/math';
 
 import Range from './definition.ts';
 

--- a/src/library/Range/definition.ts
+++ b/src/library/Range/definition.ts
@@ -2,7 +2,7 @@ import Attempt from '@/library/Attempt';
 
 import {
   arithmeticMeanOf,
-} from '@/library/math/exports';
+} from '@/library/math';
 
 type RangeBound = 'exclusive' | 'inclusive';
 

--- a/src/library/Range/index.ts
+++ b/src/library/Range/index.ts
@@ -1,0 +1,3 @@
+export {
+  default as default,
+} from './exports.ts';

--- a/src/library/ShimmedStabilityAIClient/definition.ts
+++ b/src/library/ShimmedStabilityAIClient/definition.ts
@@ -7,14 +7,14 @@ import type {
   GenerateFromTextResponse,
 } from 'stabilityai-client-typescript/models/operations';
 
-import Base64CharacterEncodedByteSequence from '@/library/Base64CharacterEncodedByteSequence/exports';
+import Base64CharacterEncodedByteSequence from '@/library/Base64CharacterEncodedByteSequence';
 import HTTP from '@/library/HTTP';
 import Schema from '@/library/Schema';
 
 import {
   URLOrigin,
   URLPath,
-} from '@/library/URLComponent/exports';
+} from '@/library/URLComponent';
 
 import {
   cloneOf,

--- a/src/library/ShimmedStabilityAIClient/index.ts
+++ b/src/library/ShimmedStabilityAIClient/index.ts
@@ -1,0 +1,3 @@
+export {
+  default as default,
+} from './exports.ts';

--- a/src/library/URLComponent/URLOrigin.ts
+++ b/src/library/URLComponent/URLOrigin.ts
@@ -2,11 +2,11 @@ import Attempt from '@/library/Attempt';
 
 import {
   ParsingError,
-} from '@/library/Parser/exports';
+} from '@/library/Parser';
 
 import type {
   StringParsable,
-} from '@/library/Parser/string/exports';
+} from '@/library/Parser/string';
 
 import StringSubset from '@/library/StringSubset';
 

--- a/src/library/URLComponent/URLPath.ts
+++ b/src/library/URLComponent/URLPath.ts
@@ -2,11 +2,11 @@ import Attempt from '@/library/Attempt';
 
 import {
   ParsingError,
-} from '@/library/Parser/exports';
+} from '@/library/Parser';
 
 import type {
   StringParsable,
-} from '@/library/Parser/string/exports';
+} from '@/library/Parser/string';
 
 import StringSubset from '@/library/StringSubset';
 

--- a/src/library/URLComponent/index.ts
+++ b/src/library/URLComponent/index.ts
@@ -1,0 +1,1 @@
+export * from './exports.ts';

--- a/src/library/UniformResourceIdentifier/Data/Image/definition.ts
+++ b/src/library/UniformResourceIdentifier/Data/Image/definition.ts
@@ -1,5 +1,5 @@
-import type Base64CharacterEncodedByteSequence from '@/library/Base64CharacterEncodedByteSequence/exports';
-import ContentDescriptor from '@/library/ContentDescriptor/exports';
+import type Base64CharacterEncodedByteSequence from '@/library/Base64CharacterEncodedByteSequence';
+import ContentDescriptor from '@/library/ContentDescriptor';
 
 import type {
   DataURI_EncodingIdentifier,

--- a/src/library/UniformResourceIdentifier/Data/Image/index.ts
+++ b/src/library/UniformResourceIdentifier/Data/Image/index.ts
@@ -1,0 +1,3 @@
+export {
+  default as default,
+} from './exports.ts';

--- a/src/library/UniformResourceIdentifier/Data/definition.ts
+++ b/src/library/UniformResourceIdentifier/Data/definition.ts
@@ -1,7 +1,7 @@
 import Attempt from '@/library/Attempt';
-import type Base64CharacterEncodedByteSequence from '@/library/Base64CharacterEncodedByteSequence/exports';
-import type ContentDescriptor from '@/library/ContentDescriptor/exports';
-import NonTrivialString from '@/library/NonTrivialString/exports';
+import type Base64CharacterEncodedByteSequence from '@/library/Base64CharacterEncodedByteSequence';
+import type ContentDescriptor from '@/library/ContentDescriptor';
+import NonTrivialString from '@/library/NonTrivialString';
 
 import UniformResourceIdentifier from '../definition.ts';
 

--- a/src/library/UniformResourceIdentifier/definition.ts
+++ b/src/library/UniformResourceIdentifier/definition.ts
@@ -1,5 +1,5 @@
 import Attempt from '@/library/Attempt';
-import type NonTrivialString from '@/library/NonTrivialString/exports';
+import type NonTrivialString from '@/library/NonTrivialString';
 
 import {
   concatenated,

--- a/src/library/WebAPI/index.ts
+++ b/src/library/WebAPI/index.ts
@@ -1,0 +1,1 @@
+export * from './exports.ts';

--- a/src/library/math/aggregator/index.ts
+++ b/src/library/math/aggregator/index.ts
@@ -1,0 +1,1 @@
+export * from './exports.ts';

--- a/src/library/math/exports.ts
+++ b/src/library/math/exports.ts
@@ -1,3 +1,3 @@
-export * from './operator/exports';
+export * from './operator';
 
-export * from './aggregator/exports';
+export * from './aggregator';

--- a/src/library/math/index.ts
+++ b/src/library/math/index.ts
@@ -1,0 +1,1 @@
+export * from './exports.ts';

--- a/src/library/math/operator/constructive/absoluteValueOf.ts
+++ b/src/library/math/operator/constructive/absoluteValueOf.ts
@@ -2,7 +2,7 @@ import Attempt from '@/library/Attempt';
 
 import {
   isOperable,
-} from '../predicate/exports';
+} from '../predicate';
 
 /** The distance the given value is from the 1-dimensional origin */
 const absoluteValueOf = (

--- a/src/library/math/operator/constructive/greatestCommonDivisor.test.ts
+++ b/src/library/math/operator/constructive/greatestCommonDivisor.test.ts
@@ -12,7 +12,7 @@ import {
 
 import {
   squared,
-} from '../hyper/exports';
+} from '../hyper';
 
 import * as GCDAlias from './greatestCommonDivisor';
 

--- a/src/library/math/operator/constructive/greatestCommonDivisor.ts
+++ b/src/library/math/operator/constructive/greatestCommonDivisor.ts
@@ -2,7 +2,7 @@ import Attempt from '@/library/Attempt';
 
 import {
   isWhole,
-} from '../predicate/exports';
+} from '../predicate';
 
 import {
   absoluteValueOf,

--- a/src/library/math/operator/constructive/index.ts
+++ b/src/library/math/operator/constructive/index.ts
@@ -1,0 +1,1 @@
+export * from './exports.ts';

--- a/src/library/math/operator/exports.ts
+++ b/src/library/math/operator/exports.ts
@@ -1,5 +1,5 @@
-export * from './predicate/exports';
+export * from './predicate';
 
-export * from './hyper/exports';
+export * from './hyper';
 
-export * from './constructive/exports';
+export * from './constructive';

--- a/src/library/math/operator/hyper/exports.ts
+++ b/src/library/math/operator/hyper/exports.ts
@@ -1,1 +1,1 @@
-export * from './rank3/exports';
+export * from './rank3';

--- a/src/library/math/operator/hyper/index.ts
+++ b/src/library/math/operator/hyper/index.ts
@@ -1,0 +1,1 @@
+export * from './exports.ts';

--- a/src/library/math/operator/hyper/rank3/index.ts
+++ b/src/library/math/operator/hyper/rank3/index.ts
@@ -1,0 +1,1 @@
+export * from './exports.ts';

--- a/src/library/math/operator/hyper/rank3/squared.ts
+++ b/src/library/math/operator/hyper/rank3/squared.ts
@@ -2,7 +2,7 @@ import Attempt from '@/library/Attempt';
 
 import {
   isOperable,
-} from '../../predicate/exports';
+} from '../../predicate';
 
 const squared = (
   givenOperand: number,

--- a/src/library/math/operator/index.ts
+++ b/src/library/math/operator/index.ts
@@ -1,0 +1,1 @@
+export * from './exports.ts';

--- a/src/library/math/operator/predicate/index.ts
+++ b/src/library/math/operator/predicate/index.ts
@@ -1,0 +1,1 @@
+export * from './exports.ts';

--- a/src/library/vue/index.ts
+++ b/src/library/vue/index.ts
@@ -1,0 +1,1 @@
+export * from './exports.ts';

--- a/src/library/vue/statefulAttempt.ts
+++ b/src/library/vue/statefulAttempt.ts
@@ -3,7 +3,7 @@ import {
   ref,
   set,
   type Ref,
-} from '@/library/vue/exports';
+} from '@/library/vue';
 
 import Attempt from '@/library/Attempt';
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,6 @@
 import {
   createApp,
-} from '@/library/vue/exports';
+} from '@/library/vue';
 
 import {
   asError,

--- a/src/pages/TextToImagePage.vue
+++ b/src/pages/TextToImagePage.vue
@@ -4,7 +4,7 @@ import {
   ref,
   type Ref,
   useStatefulAttemptThatEventually,
-} from '@/library/vue/exports';
+} from '@/library/vue';
 
 import {
   VBtn,
@@ -31,10 +31,10 @@ import SDXLDiffusionStepCount from '@/library/ShimmedStabilityAIClient/models/SD
 import DiscreteSlider from '@/components/DiscreteSlider.vue';
 import NavigationPanel from '@/components/NavigationPanel.vue';
 
+import * as TextToImage from '@/features/TextToImage';
 import TextToImageInputSection from '@/features/TextToImage/components/TextToImageInputSection.vue';
 import TextToImageOutputAlert from '@/features/TextToImage/components/TextToImageOutputAlert.vue';
 import TextToImageOutputImg from '@/features/TextToImage/components/TextToImageOutputImg.vue';
-import * as TextToImage from '@/features/TextToImage/exports';
 
 const currentPrompt: Ref<TextToImage.Input['text'] | null> = ref(null);
 

--- a/src/shims-vue.d.ts
+++ b/src/shims-vue.d.ts
@@ -1,7 +1,7 @@
 declare module '*.vue' {
   import type {
     DefineComponent,
-  } from '@/library/vue/exports';
+  } from '@/library/vue';
 
   const component: DefineComponent;
 


### PR DESCRIPTION
- "exports" sub-modules are only for defining which sub-modules are accessible to external modules
- "index" sub-modules, however, determine the final shape of the top-level API for the module:
  - which sub-modules is `default` if any
  - whether to construct a namespace or just offer a "toolbox" of pure functions
- ergo, only an (implicit) "index" is appropriate for import from external modules