### PR TITLE
refactor: standardizes remaining "index" files

### DIFF
--- a/src/library/Attempt/index.ts
+++ b/src/library/Attempt/index.ts
@@ -1,4 +1,4 @@
-import * as Attempt from './exports';
+import * as Attempt from './exports.ts';
 
 export {
   Attempt as default,

--- a/src/library/Attempt/index.ts
+++ b/src/library/Attempt/index.ts
@@ -1,5 +1,1 @@
-import * as Attempt from './exports.ts';
-
-export {
-  Attempt as default,
-};
+export * as default from './exports.ts';

--- a/src/library/Base64/index.ts
+++ b/src/library/Base64/index.ts
@@ -1,4 +1,4 @@
-import * as Base64 from './exports';
+import * as Base64 from './exports.ts';
 
 export {
   Base64 as default,

--- a/src/library/Base64/index.ts
+++ b/src/library/Base64/index.ts
@@ -1,5 +1,1 @@
-import * as Base64 from './exports.ts';
-
-export {
-  Base64 as default,
-};
+export * as default from './exports.ts';

--- a/src/library/Byte/index.ts
+++ b/src/library/Byte/index.ts
@@ -1,4 +1,4 @@
-import * as Byte from './exports';
+import * as Byte from './exports.ts';
 
 export {
   Byte as default,

--- a/src/library/Byte/index.ts
+++ b/src/library/Byte/index.ts
@@ -1,5 +1,1 @@
-import * as Byte from './exports.ts';
-
-export {
-  Byte as default,
-};
+export * as default from './exports.ts';

--- a/src/library/ContentDescriptor/StructuredSyntaxNameSuffix/index.ts
+++ b/src/library/ContentDescriptor/StructuredSyntaxNameSuffix/index.ts
@@ -1,5 +1,1 @@
-import * as ContentDescriptor_StructuredSyntaxNameSuffix from './exports.ts';
-
-export {
-  ContentDescriptor_StructuredSyntaxNameSuffix,
-};
+export * as ContentDescriptor_StructuredSyntaxNameSuffix from './exports.ts';

--- a/src/library/ContentDescriptor/StructuredSyntaxNameSuffix/index.ts
+++ b/src/library/ContentDescriptor/StructuredSyntaxNameSuffix/index.ts
@@ -1,4 +1,4 @@
-import * as ContentDescriptor_StructuredSyntaxNameSuffix from './exports';
+import * as ContentDescriptor_StructuredSyntaxNameSuffix from './exports.ts';
 
 export {
   ContentDescriptor_StructuredSyntaxNameSuffix,

--- a/src/library/ContentDescriptor/TopLevel/Composite/index.ts
+++ b/src/library/ContentDescriptor/TopLevel/Composite/index.ts
@@ -1,4 +1,4 @@
-import * as ContentDescriptor_TopLevel_Composite from './exports';
+import * as ContentDescriptor_TopLevel_Composite from './exports.ts';
 
 export {
   ContentDescriptor_TopLevel_Composite,

--- a/src/library/ContentDescriptor/TopLevel/Composite/index.ts
+++ b/src/library/ContentDescriptor/TopLevel/Composite/index.ts
@@ -1,5 +1,1 @@
-import * as ContentDescriptor_TopLevel_Composite from './exports.ts';
-
-export {
-  ContentDescriptor_TopLevel_Composite,
-};
+export * as ContentDescriptor_TopLevel_Composite from './exports.ts';

--- a/src/library/ContentDescriptor/TopLevel/Discrete/index.ts
+++ b/src/library/ContentDescriptor/TopLevel/Discrete/index.ts
@@ -1,4 +1,4 @@
-import * as ContentDescriptor_TopLevel_Discrete from './exports';
+import * as ContentDescriptor_TopLevel_Discrete from './exports.ts';
 
 export {
   ContentDescriptor_TopLevel_Discrete,

--- a/src/library/ContentDescriptor/TopLevel/Discrete/index.ts
+++ b/src/library/ContentDescriptor/TopLevel/Discrete/index.ts
@@ -1,5 +1,1 @@
-import * as ContentDescriptor_TopLevel_Discrete from './exports.ts';
-
-export {
-  ContentDescriptor_TopLevel_Discrete,
-};
+export * as ContentDescriptor_TopLevel_Discrete from './exports.ts';

--- a/src/library/ContentDescriptor/TopLevel/index.ts
+++ b/src/library/ContentDescriptor/TopLevel/index.ts
@@ -1,5 +1,1 @@
-import * as ContentDescriptor_TopLevel from './exports.ts';
-
-export {
-  ContentDescriptor_TopLevel,
-};
+export * as ContentDescriptor_TopLevel from './exports.ts';

--- a/src/library/ContentDescriptor/TopLevel/index.ts
+++ b/src/library/ContentDescriptor/TopLevel/index.ts
@@ -1,4 +1,4 @@
-import * as ContentDescriptor_TopLevel from './exports';
+import * as ContentDescriptor_TopLevel from './exports.ts';
 
 export {
   ContentDescriptor_TopLevel,

--- a/src/library/HTTP/Endpoint/index.ts
+++ b/src/library/HTTP/Endpoint/index.ts
@@ -1,4 +1,4 @@
-import * as HTTP_Endpoint from './exports';
+import * as HTTP_Endpoint from './exports.ts';
 
 export {
   HTTP_Endpoint,

--- a/src/library/HTTP/Endpoint/index.ts
+++ b/src/library/HTTP/Endpoint/index.ts
@@ -1,5 +1,1 @@
-import * as HTTP_Endpoint from './exports.ts';
-
-export {
-  HTTP_Endpoint,
-};
+export * as HTTP_Endpoint from './exports.ts';

--- a/src/library/HTTP/Request/index.ts
+++ b/src/library/HTTP/Request/index.ts
@@ -1,4 +1,4 @@
-import * as HTTP_Request from './exports';
+import * as HTTP_Request from './exports.ts';
 
 export {
   HTTP_Request,

--- a/src/library/HTTP/Request/index.ts
+++ b/src/library/HTTP/Request/index.ts
@@ -1,5 +1,1 @@
-import * as HTTP_Request from './exports.ts';
-
-export {
-  HTTP_Request,
-};
+export * as HTTP_Request from './exports.ts';

--- a/src/library/HTTP/Response/StatusCode/Error/index.ts
+++ b/src/library/HTTP/Response/StatusCode/Error/index.ts
@@ -1,4 +1,4 @@
-import * as HTTP_Response_StatusCode_Error from './exports';
+import * as HTTP_Response_StatusCode_Error from './exports.ts';
 
 export {
   HTTP_Response_StatusCode_Error,

--- a/src/library/HTTP/Response/StatusCode/Error/index.ts
+++ b/src/library/HTTP/Response/StatusCode/Error/index.ts
@@ -1,5 +1,1 @@
-import * as HTTP_Response_StatusCode_Error from './exports.ts';
-
-export {
-  HTTP_Response_StatusCode_Error,
-};
+export * as HTTP_Response_StatusCode_Error from './exports.ts';

--- a/src/library/HTTP/Response/StatusCode/index.ts
+++ b/src/library/HTTP/Response/StatusCode/index.ts
@@ -1,5 +1,1 @@
-import * as HTTP_Response_StatusCode from './exports.ts';
-
-export {
-  HTTP_Response_StatusCode,
-};
+export * as HTTP_Response_StatusCode from './exports.ts';

--- a/src/library/HTTP/Response/StatusCode/index.ts
+++ b/src/library/HTTP/Response/StatusCode/index.ts
@@ -1,4 +1,4 @@
-import * as HTTP_Response_StatusCode from './exports';
+import * as HTTP_Response_StatusCode from './exports.ts';
 
 export {
   HTTP_Response_StatusCode,

--- a/src/library/HTTP/Response/index.ts
+++ b/src/library/HTTP/Response/index.ts
@@ -1,5 +1,1 @@
-import * as HTTP_Response from './exports.ts';
-
-export {
-  HTTP_Response,
-};
+export * as HTTP_Response from './exports.ts';

--- a/src/library/HTTP/Response/index.ts
+++ b/src/library/HTTP/Response/index.ts
@@ -1,4 +1,4 @@
-import * as HTTP_Response from './exports';
+import * as HTTP_Response from './exports.ts';
 
 export {
   HTTP_Response,

--- a/src/library/HTTP/index.ts
+++ b/src/library/HTTP/index.ts
@@ -1,5 +1,1 @@
-import * as HTTP from './exports.ts';
-
-export {
-  HTTP as default,
-};
+export * as default from './exports.ts';

--- a/src/library/HTTP/index.ts
+++ b/src/library/HTTP/index.ts
@@ -1,4 +1,4 @@
-import * as HTTP from './exports';
+import * as HTTP from './exports.ts';
 
 export {
   HTTP as default,

--- a/src/library/UniformResourceIdentifier/Data/EncodingIdentifier/index.ts
+++ b/src/library/UniformResourceIdentifier/Data/EncodingIdentifier/index.ts
@@ -1,5 +1,1 @@
-import * as DataURI_EncodingIdentifier from './exports.ts';
-
-export {
-  DataURI_EncodingIdentifier,
-};
+export * as DataURI_EncodingIdentifier from './exports.ts';

--- a/src/library/UniformResourceIdentifier/Data/EncodingIdentifier/index.ts
+++ b/src/library/UniformResourceIdentifier/Data/EncodingIdentifier/index.ts
@@ -1,4 +1,4 @@
-import * as DataURI_EncodingIdentifier from './exports';
+import * as DataURI_EncodingIdentifier from './exports.ts';
 
 export {
   DataURI_EncodingIdentifier,

--- a/src/library/UniformResourceIdentifier/Data/Image/Format/index.ts
+++ b/src/library/UniformResourceIdentifier/Data/Image/Format/index.ts
@@ -1,5 +1,1 @@
-import * as ImageURI_Format from './exports.ts';
-
-export {
-  ImageURI_Format,
-};
+export * as ImageURI_Format from './exports.ts';

--- a/src/library/UniformResourceIdentifier/Data/Image/Format/index.ts
+++ b/src/library/UniformResourceIdentifier/Data/Image/Format/index.ts
@@ -1,4 +1,4 @@
-import * as ImageURI_Format from './exports';
+import * as ImageURI_Format from './exports.ts';
 
 export {
   ImageURI_Format,


### PR DESCRIPTION
- In a similar vein as #609, well-defined "exports" modules must _also_ be single-file since they don't actually hold any implementation of their own
- Also, since they just dictate what's exposed to external modules, there's no need to `import` and `export` separately
- "exports" modules should consist of nothing but re-`export`s

Sets precedent for #606