### PR TITLE
refactor: avoids reaching directly into a namespace module's "definition"

### DIFF
--- a/src/components/DiscreteSlider.vue
+++ b/src/components/DiscreteSlider.vue
@@ -17,7 +17,7 @@ import {
 } from 'vuetify/components/VSlider';
 
 import DiscreteRange from '@/library/Range/DiscreteRange.ts';
-import type Range from '@/library/Range/definition';
+import type Range from '@/library/Range/exports';
 
 import {
   shallowlyMerged,

--- a/src/features/TextToImage/models/SDXL/client/conversions/StabilityAI_Client_Image.ts
+++ b/src/features/TextToImage/models/SDXL/client/conversions/StabilityAI_Client_Image.ts
@@ -1,7 +1,7 @@
 import type * as StabilityAIClient from 'stabilityai-client-typescript/models/components';
 
-import Base64CharacterEncodedByteSequence from '@/library/Base64CharacterEncodedByteSequence/definition';
-import ImageURI from '@/library/UniformResourceIdentifier/Data/Image/definition';
+import Base64CharacterEncodedByteSequence from '@/library/Base64CharacterEncodedByteSequence/exports';
+import ImageURI from '@/library/UniformResourceIdentifier/Data/Image/exports';
 
 import type {
   Output,

--- a/src/features/TextToImage/models/SDXL/client/exports.ts
+++ b/src/features/TextToImage/models/SDXL/client/exports.ts
@@ -4,7 +4,7 @@ import type {
 
 import Attempt from '@/library/Attempt';
 import HTTP from '@/library/HTTP';
-import ShimmedStabilityAIClient from '@/library/ShimmedStabilityAIClient/definition';
+import ShimmedStabilityAIClient from '@/library/ShimmedStabilityAIClient/exports';
 
 import type {
   Output,

--- a/src/features/TextToImage/types/Output/Image.ts
+++ b/src/features/TextToImage/types/Output/Image.ts
@@ -1,4 +1,4 @@
-import type ImageURI from '@/library/UniformResourceIdentifier/Data/Image/definition';
+import type ImageURI from '@/library/UniformResourceIdentifier/Data/Image/exports';
 
 interface TextToImage_Output_Image {
   uri: ImageURI;

--- a/src/features/TextToImage/types/Output/exports.ts
+++ b/src/features/TextToImage/types/Output/exports.ts
@@ -1,0 +1,1 @@
+export type * from './definition.ts';

--- a/src/features/TextToImage/types/exports.ts
+++ b/src/features/TextToImage/types/exports.ts
@@ -3,4 +3,4 @@ export type {
 } from './Input';
 export type {
   TextToImage_Output as Output,
-} from './Output/definition';
+} from './Output/exports';

--- a/src/library/Base64CharacterEncodedByteSequence/ParsingError.ts
+++ b/src/library/Base64CharacterEncodedByteSequence/ParsingError.ts
@@ -4,7 +4,7 @@ import Byte from '@/library/Byte';
 
 import {
   ParsingError,
-} from '@/library/Parser/definition';
+} from '@/library/Parser/exports';
 
 class Base64CharacterEncodedByteSequence_ParsingError
   extends ParsingError<

--- a/src/library/Base64CharacterEncodedByteSequence/exports.ts
+++ b/src/library/Base64CharacterEncodedByteSequence/exports.ts
@@ -1,0 +1,3 @@
+export {
+  default as default,
+} from './definition.ts';

--- a/src/library/ContentDescriptor/definition.ts
+++ b/src/library/ContentDescriptor/definition.ts
@@ -1,4 +1,4 @@
-import NonTrivialString from '@/library/NonTrivialString/definition';
+import NonTrivialString from '@/library/NonTrivialString/exports';
 
 import {
   concatenated,

--- a/src/library/ContentDescriptor/exports.ts
+++ b/src/library/ContentDescriptor/exports.ts
@@ -1,0 +1,3 @@
+export {
+  default as default,
+} from './definition.ts';

--- a/src/library/NonTrivialString/ParsingError.ts
+++ b/src/library/NonTrivialString/ParsingError.ts
@@ -1,6 +1,6 @@
 import {
   ParsingError,
-} from '@/library/Parser/definition';
+} from '@/library/Parser/exports';
 
 class NonTrivialString_ParsingError
   extends ParsingError<

--- a/src/library/NonTrivialString/exports.ts
+++ b/src/library/NonTrivialString/exports.ts
@@ -1,0 +1,3 @@
+export {
+  default as default,
+} from './definition.ts';

--- a/src/library/Parser/exports.ts
+++ b/src/library/Parser/exports.ts
@@ -1,0 +1,3 @@
+export {
+  default as ParsingError,
+} from './ParsingError';

--- a/src/library/Range/exports.ts
+++ b/src/library/Range/exports.ts
@@ -1,0 +1,3 @@
+export {
+  default as default,
+} from './definition.ts';

--- a/src/library/ShimmedStabilityAIClient/definition.ts
+++ b/src/library/ShimmedStabilityAIClient/definition.ts
@@ -7,7 +7,7 @@ import type {
   GenerateFromTextResponse,
 } from 'stabilityai-client-typescript/models/operations';
 
-import Base64CharacterEncodedByteSequence from '@/library/Base64CharacterEncodedByteSequence/definition';
+import Base64CharacterEncodedByteSequence from '@/library/Base64CharacterEncodedByteSequence/exports';
 import HTTP from '@/library/HTTP';
 import Schema from '@/library/Schema';
 

--- a/src/library/ShimmedStabilityAIClient/exports.ts
+++ b/src/library/ShimmedStabilityAIClient/exports.ts
@@ -1,0 +1,3 @@
+export {
+  default as default,
+} from './definition.ts';

--- a/src/library/URLComponent/URLOrigin.ts
+++ b/src/library/URLComponent/URLOrigin.ts
@@ -2,7 +2,7 @@ import Attempt from '@/library/Attempt';
 
 import {
   ParsingError,
-} from '@/library/Parser/definition';
+} from '@/library/Parser/exports';
 
 import type {
   StringParsable,

--- a/src/library/URLComponent/URLPath.ts
+++ b/src/library/URLComponent/URLPath.ts
@@ -2,7 +2,7 @@ import Attempt from '@/library/Attempt';
 
 import {
   ParsingError,
-} from '@/library/Parser/definition';
+} from '@/library/Parser/exports';
 
 import type {
   StringParsable,

--- a/src/library/UniformResourceIdentifier/Data/Image/definition.ts
+++ b/src/library/UniformResourceIdentifier/Data/Image/definition.ts
@@ -1,5 +1,5 @@
-import type Base64CharacterEncodedByteSequence from '@/library/Base64CharacterEncodedByteSequence/definition';
-import ContentDescriptor from '@/library/ContentDescriptor/definition';
+import type Base64CharacterEncodedByteSequence from '@/library/Base64CharacterEncodedByteSequence/exports';
+import ContentDescriptor from '@/library/ContentDescriptor/exports';
 
 import type {
   DataURI_EncodingIdentifier,

--- a/src/library/UniformResourceIdentifier/Data/Image/exports.ts
+++ b/src/library/UniformResourceIdentifier/Data/Image/exports.ts
@@ -1,0 +1,3 @@
+export {
+  default as default,
+} from './definition.ts';

--- a/src/library/UniformResourceIdentifier/Data/definition.ts
+++ b/src/library/UniformResourceIdentifier/Data/definition.ts
@@ -1,7 +1,7 @@
 import Attempt from '@/library/Attempt';
-import type Base64CharacterEncodedByteSequence from '@/library/Base64CharacterEncodedByteSequence/definition';
-import type ContentDescriptor from '@/library/ContentDescriptor/definition';
-import NonTrivialString from '@/library/NonTrivialString/definition';
+import type Base64CharacterEncodedByteSequence from '@/library/Base64CharacterEncodedByteSequence/exports';
+import type ContentDescriptor from '@/library/ContentDescriptor/exports';
+import NonTrivialString from '@/library/NonTrivialString/exports';
 
 import UniformResourceIdentifier from '../definition.ts';
 

--- a/src/library/UniformResourceIdentifier/definition.ts
+++ b/src/library/UniformResourceIdentifier/definition.ts
@@ -1,5 +1,5 @@
 import Attempt from '@/library/Attempt';
-import type NonTrivialString from '@/library/NonTrivialString/definition';
+import type NonTrivialString from '@/library/NonTrivialString/exports';
 
 import {
   concatenated,


### PR DESCRIPTION
- "definition.ts" is only present in directory modules that construct a namespace around a `class` or `interface` declaration
- "exports.ts" is meant for _every_ directory module
- These changes help the affected files match the less-severe but more widely prevalent anti-pattern of importing from "exports"

Facilitates #606