### PR TITLE
refactor: ensures all internal "definition" imports have explicit file extensions

### DIFF
--- a/src/library/Parser/string/StringParser.ts
+++ b/src/library/Parser/string/StringParser.ts
@@ -1,5 +1,5 @@
 import type ParsingError from '../ParsingError';
-import type Parser from '../definition';
+import type Parser from '../definition.ts';
 
 type StringParser<
   SomeParsedOutput,


### PR DESCRIPTION
- single-file modules are importable via "**/ModuleA.ts" or "**/ModuleA"
- directory modules are importable via "**/ModuleA/index.ts" or "**/ModuleA"
- for modules that might be converted from one form or another, the shared syntax is preferrable to reduce unnecessary noise in diffs
- but for modules that inherently _must_ pick a form, it's preferred to use the discerning import path to communicate this
- ideal "definition" modules must be single-file because they should only ever house a single `class`/`interface`/`type` declaration.
- "definition" modules that are converted to a directory are undoubtedly breaking the single declaration rule and are likely misnamed or poorly defined

Follows-up on precedent established in #608