### PR TITLE
ci(dependabot): auto-approves minor bumps `@types/node`

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -43,6 +43,7 @@ jobs:
         if: |
           contains(
             fromJSON('[
+              "@types/node",
               "eslint",
               "eslint-plugin-vue"
             ]'),


### PR DESCRIPTION
- changes to `@types/node` that conflict with this codebase will always trigger the CI's compilation step to fail
- `@types/node` only affects compile-time, so the testing pipeline will always yield the same result before and after the version bump
- because of this, minor and patch bumps are safe to automatically approve
- pairing that with auto-merge upon passing required checks, maintainers will seldom have to intervene for this frequently updated dependency 