### PR TITLE
refactor(library/ShimmedStabilityAIClient): finalizes error propagation from budding Shortfin implementation

### DIFF
--- a/src/library/ShimmedStabilityAIClient/definition.ts
+++ b/src/library/ShimmedStabilityAIClient/definition.ts
@@ -43,7 +43,7 @@ class ImageClient
           outcomeOfSubmittingResource.isFailure
         ) return outcomeOfSubmittingResource;
 
-        const rawResource = outcomeOfSubmittingResource.forciblyUnwrap(/* TODO: propagate this error */);
+        const rawResource = outcomeOfSubmittingResource.unwrapped;
 
         const parsedResource = Shortfin.TextToImage.SDXL.Client.Response.Body.parsedFrom(rawResource)
           .forciblyUnwrap(/* Implementation must align with established contract. */);

--- a/src/library/ShimmedStabilityAIClient/definition.ts
+++ b/src/library/ShimmedStabilityAIClient/definition.ts
@@ -39,6 +39,10 @@ class ImageClient
           to       : generationEndpoint,
         });
 
+        if (
+          outcomeOfSubmittingResource.isFailure
+        ) return outcomeOfSubmittingResource;
+
         const rawResource = outcomeOfSubmittingResource.forciblyUnwrap(/* TODO: propagate this error */);
 
         const parsedResource = Shortfin.TextToImage.SDXL.Client.Response.Body.parsedFrom(rawResource)

--- a/src/library/ShimmedStabilityAIClient/definition.ts
+++ b/src/library/ShimmedStabilityAIClient/definition.ts
@@ -7,7 +7,7 @@ import type {
   GenerateFromTextResponse,
 } from 'stabilityai-client-typescript/models/operations';
 
-import type Base64CharacterEncodedByteSequence from '@/library/Base64CharacterEncodedByteSequence';
+import Attempt from '@/library/Attempt';
 import HTTP from '@/library/HTTP';
 import Shortfin from '@/library/Shortfin';
 
@@ -27,25 +27,27 @@ class ImageClient
       givenRequest.textToImageRequestBody,
     ]);
 
-    const generatedImage = await (async function (
+    const generatedImage = (await (async function (
       this: HTTP.Client,
       givenBatchedRequestBody: Shortfin.TextToImage.SDXL.Client.Request.Body.Batched,
-    ): Promise<Base64CharacterEncodedByteSequence> {
+    ): Promise<Shortfin.TextToImage.SDXL.Client.Request.Outcome> {
       const generationEndpoint = URLPath.parsedFrom('/generate').forciblyUnwrap();
 
-      const outcomeOfSubmittingResource = await this.submitResource({
-        bySending: givenBatchedRequestBody,
-        to       : generationEndpoint,
+      return Attempt.thatEventually(async (ends) => {
+        const outcomeOfSubmittingResource = await this.submitResource({
+          bySending: givenBatchedRequestBody,
+          to       : generationEndpoint,
+        });
+
+        const rawResource = outcomeOfSubmittingResource.forciblyUnwrap(/* TODO: propagate this error */);
+
+        const parsedResource = Shortfin.TextToImage.SDXL.Client.Response.Body.parsedFrom(rawResource)
+          .forciblyUnwrap(/* Implementation must align with established contract. */);
+
+        const [soleGeneratedImage] = parsedResource.images;
+        return ends.inSuccessWith(soleGeneratedImage);
       });
-
-      const rawResource = outcomeOfSubmittingResource.forciblyUnwrap(/* matches error propagation of actual StabilityAI Client */);
-
-      const parsedResource = Shortfin.TextToImage.SDXL.Client.Response.Body.parsedFrom(rawResource)
-        .forciblyUnwrap(/* Implementation must align with established contract. */);
-
-      const [soleGeneratedImage] = parsedResource.images;
-      return soleGeneratedImage;
-    }.bind(this))(derivedBatchedRequestBody);
+    }.bind(this))(derivedBatchedRequestBody)).forciblyUnwrap(/* matches error propagation of actual StabilityAI Client */);
 
     const soleGeneratedArtifact: StabilityAI_TextToImage_Pipeline_Output = {
       base64      : generatedImage.toString(),

--- a/src/library/ShimmedStabilityAIClient/definition.ts
+++ b/src/library/ShimmedStabilityAIClient/definition.ts
@@ -27,7 +27,7 @@ class ImageClient
       givenRequest.textToImageRequestBody,
     ]);
 
-    const generatedImage = (await (async function (
+    const outcomeOfGeneratingImage = await (async function (
       this: HTTP.Client,
       givenBatchedRequestBody: Shortfin.TextToImage.SDXL.Client.Request.Body.Batched,
     ): Promise<Shortfin.TextToImage.SDXL.Client.Request.Outcome> {
@@ -47,7 +47,9 @@ class ImageClient
         const [soleGeneratedImage] = parsedResource.images;
         return ends.inSuccessWith(soleGeneratedImage);
       });
-    }.bind(this))(derivedBatchedRequestBody)).forciblyUnwrap(/* matches error propagation of actual StabilityAI Client */);
+    }.bind(this))(derivedBatchedRequestBody);
+
+    const generatedImage = outcomeOfGeneratingImage.forciblyUnwrap(/* matches error propagation of actual StabilityAI Client */);
 
     const soleGeneratedArtifact: StabilityAI_TextToImage_Pipeline_Output = {
       base64      : generatedImage.toString(),

--- a/src/library/Shortfin/TextToImage/SDXL/Client/Request/Outcome.ts
+++ b/src/library/Shortfin/TextToImage/SDXL/Client/Request/Outcome.ts
@@ -1,0 +1,13 @@
+import type Attempt from '@/library/Attempt';
+import type Base64CharacterEncodedByteSequence from '@/library/Base64CharacterEncodedByteSequence';
+import type HTTP from '@/library/HTTP';
+
+type Shortfin_TextToImage_SDXL_Client_Request_Outcome = Attempt.Outcome<
+  Base64CharacterEncodedByteSequence,
+  | HTTP.Endpoint.RequestError
+  | HTTP.Endpoint.ResponseError
+>;
+
+export type {
+  Shortfin_TextToImage_SDXL_Client_Request_Outcome,
+};

--- a/src/library/Shortfin/TextToImage/SDXL/Client/Request/exports.ts
+++ b/src/library/Shortfin/TextToImage/SDXL/Client/Request/exports.ts
@@ -1,3 +1,7 @@
 export {
   Shortfin_TextToImage_SDXL_Client_Request_Body as Body,
 } from './Body';
+
+export type {
+  Shortfin_TextToImage_SDXL_Client_Request_Outcome as Outcome,
+} from './Outcome';


### PR DESCRIPTION
- it's up to the caller whether unsafe error propagation is appropriate

Facilitates #718