### PR TITLE
refactor(library/ShimmedStabilityAIClient): clarifies implementation within `ImageClient`

### DIFF
--- a/src/library/ShimmedStabilityAIClient/definition.ts
+++ b/src/library/ShimmedStabilityAIClient/definition.ts
@@ -122,10 +122,11 @@ class ImageClient
     });
 
     const newResource = outcomeOfSubmittingResource.forciblyUnwrap(/* matches error propagation of actual StabilityAI Client */);
+    const parsedResource = Shortfin_TextToImage_Response_Body.Schema.parse(newResource);
 
     const {
       images,
-    } = Shortfin_TextToImage_Response_Body.Schema.parse(newResource);
+    } = parsedResource;
 
     const [soleGeneratedImage] = images;
 

--- a/src/library/ShimmedStabilityAIClient/definition.ts
+++ b/src/library/ShimmedStabilityAIClient/definition.ts
@@ -1,4 +1,5 @@
 import type {
+  Image as StabilityAI_TextToImage_Pipeline_Output,
   TextToImageRequestBody,
 } from 'stabilityai-client-typescript/models/components';
 
@@ -125,15 +126,17 @@ class ImageClient
     const parsedResource = Shortfin_TextToImage_Response_Body.Schema.parse(newResource);
     const [soleGeneratedImage] = parsedResource.images;
 
+    const soleGeneratedArtifact: StabilityAI_TextToImage_Pipeline_Output = {
+      base64      : soleGeneratedImage.toString(),
+      finishReason: 'SUCCESS',
+      seed        : givenRequest.textToImageRequestBody.seed,
+    };
+
     return {
       headers: {},
       result : {
         artifacts: [
-          {
-            base64      : soleGeneratedImage.toString(),
-            finishReason: 'SUCCESS',
-            seed        : givenRequest.textToImageRequestBody.seed,
-          },
+          soleGeneratedArtifact,
         ],
       },
     };

--- a/src/library/ShimmedStabilityAIClient/definition.ts
+++ b/src/library/ShimmedStabilityAIClient/definition.ts
@@ -112,11 +112,13 @@ class ImageClient
   public async forciblyGenerateFromText(
     givenRequest: GenerateFromTextRequest,
   ): Promise<GenerateFromTextResponse> {
+    const shimmedRequestBody = toBatchGenerationRequestBody([
+      givenRequest.textToImageRequestBody,
+    ]);
+
     const outcomeOfSubmittingResource = await this.submitResource({
-      bySending: toBatchGenerationRequestBody([
-        givenRequest.textToImageRequestBody,
-      ]),
-      to: generationEndpoint,
+      bySending: shimmedRequestBody,
+      to       : generationEndpoint,
     });
 
     const newResource = outcomeOfSubmittingResource.forciblyUnwrap(/* matches error propagation of actual StabilityAI Client */);

--- a/src/library/ShimmedStabilityAIClient/definition.ts
+++ b/src/library/ShimmedStabilityAIClient/definition.ts
@@ -123,12 +123,7 @@ class ImageClient
 
     const newResource = outcomeOfSubmittingResource.forciblyUnwrap(/* matches error propagation of actual StabilityAI Client */);
     const parsedResource = Shortfin_TextToImage_Response_Body.Schema.parse(newResource);
-
-    const {
-      images,
-    } = parsedResource;
-
-    const [soleGeneratedImage] = images;
+    const [soleGeneratedImage] = parsedResource.images;
 
     return {
       headers: {},


### PR DESCRIPTION
- the intents for a few in-lined expressions were not sufficiently captured
- researching their purpose and baking that into the variable names helped pin this down
- see [the commits](https://github.com/nod-ai/shark-ui/pull/617/commits) for individual refactoring operations

Facilitates #616 