### PR TITLE
ci(dependabot): auto-approves minor bumps to typescript eslint

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -43,6 +43,7 @@ jobs:
         if: |
           contains(
             fromJSON('[
+              "@typescript-eslint/parser",
               "@types/node",
               "eslint",
               "eslint-plugin-vue"

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -46,7 +46,8 @@ jobs:
               "@typescript-eslint/parser",
               "@types/node",
               "eslint",
-              "eslint-plugin-vue"
+              "eslint-plugin-vue",
+              "typescript-eslint"
             ]'),
             steps.metadata.outputs.dependency-names
           )


### PR DESCRIPTION
- changes to typescript eslint (and its sub packages) that conflict with this codebase will always trigger the CI's linting step to fail
- typescript eslint doesn't directly affect runtime, so the testing pipeline will always yield the same result before and after the version bump
- because of this, minor and patch bumps are safe to automatically approve
- pairing that with auto-merge upon passing required checks, maintainers will seldom have to intervene for this frequently updated dependency 