### PR TITLE
chore(deps-dev): pins @typescript-eslint/parser to ^8.39.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@types/jsdom": "^21.1.7",
         "@types/lodash.clonedeep": "^4.5.9",
         "@types/node": "^24.2.0",
-        "@typescript-eslint/parser": "^8.38.0",
+        "@typescript-eslint/parser": "^8.39.0",
         "@vitejs/plugin-vue": "^6.0.1",
         "@vitest/coverage-v8": "^3.2.4",
         "@vitest/eslint-plugin": "^1.3.4",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@types/jsdom": "^21.1.7",
     "@types/lodash.clonedeep": "^4.5.9",
     "@types/node": "^24.2.0",
-    "@typescript-eslint/parser": "^8.38.0",
+    "@typescript-eslint/parser": "^8.39.0",
     "@vitejs/plugin-vue": "^6.0.1",
     "@vitest/coverage-v8": "^3.2.4",
     "@vitest/eslint-plugin": "^1.3.4",


### PR DESCRIPTION
Follows-up on #623, which was automatically closed because `npm outdated` technically came back clean