### PR TITLE
ci(dependabot): auto-approves minor bumps to typescript

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -47,7 +47,8 @@ jobs:
               "@types/node",
               "eslint",
               "eslint-plugin-vue",
-              "typescript-eslint"
+              "typescript-eslint",
+              "typescript"
             ]'),
             steps.metadata.outputs.dependency-names
           )


### PR DESCRIPTION
- changes to typescript that conflict with this codebase will always trigger the CI's compiler step to fail
- typescript only affects compile-time, so the testing pipeline will always yield the same result before and after the version bump
- because of this, minor and patch bumps are safe to automatically approve
- pairing that with auto-merge upon passing required checks, maintainers will seldom have to intervene for this frequently updated dependency 