### PR TITLE
refactor(library/ShimmedStabilityAIClient): maps out namespaces for Shortfin

### DIFF
--- a/src/library/ShimmedStabilityAIClient/definition.ts
+++ b/src/library/ShimmedStabilityAIClient/definition.ts
@@ -24,7 +24,7 @@ import {
 type UnsignedInteger = number;
 type FloatingPoint = number;
 
-interface Shortfin_TextToImage_SDXL_Client_BatchRequest_Body {
+interface Shortfin_TextToImage_SDXL_Client_Request_Body_Batched {
   prompt: /*        */ string[];
   neg_prompt: /*    */ string[];
   height: /*        */ UnsignedInteger[];
@@ -48,7 +48,7 @@ const toSerializedPromptValue = (
     .join(',');
 };
 
-const emptyBatchGenerationRequest: Shortfin_TextToImage_SDXL_Client_BatchRequest_Body = {
+const emptyBatchGenerationRequest: Shortfin_TextToImage_SDXL_Client_Request_Body_Batched = {
   prompt        : [],
   neg_prompt    : [],
   height        : [],
@@ -60,9 +60,9 @@ const emptyBatchGenerationRequest: Shortfin_TextToImage_SDXL_Client_BatchRequest
 
 const toBatchGenerationRequestBody = (
   givenRequests: GenerateFromTextRequest['textToImageRequestBody'][],
-): Shortfin_TextToImage_SDXL_Client_BatchRequest_Body => {
+): Shortfin_TextToImage_SDXL_Client_Request_Body_Batched => {
   return givenRequests.reduce<
-    Shortfin_TextToImage_SDXL_Client_BatchRequest_Body
+    Shortfin_TextToImage_SDXL_Client_Request_Body_Batched
   >((runningBatchRequest, eachRequest) => {
     if (
       (eachRequest.height !== undefined)

--- a/src/library/ShimmedStabilityAIClient/definition.ts
+++ b/src/library/ShimmedStabilityAIClient/definition.ts
@@ -24,7 +24,7 @@ import {
 type UnsignedInteger = number;
 type FloatingPoint = number;
 
-interface Shortfin_TextToImage_SDXL_Client_ImageGenerationBatchRequest_Body {
+interface Shortfin_TextToImage_SDXL_Client_GenerationBatchRequest_Body {
   prompt: /*        */ string[];
   neg_prompt: /*    */ string[];
   height: /*        */ UnsignedInteger[];
@@ -48,7 +48,7 @@ const toSerializedPromptValue = (
     .join(',');
 };
 
-const emptyBatchGenerationRequest: Shortfin_TextToImage_SDXL_Client_ImageGenerationBatchRequest_Body = {
+const emptyBatchGenerationRequest: Shortfin_TextToImage_SDXL_Client_GenerationBatchRequest_Body = {
   prompt        : [],
   neg_prompt    : [],
   height        : [],
@@ -60,9 +60,9 @@ const emptyBatchGenerationRequest: Shortfin_TextToImage_SDXL_Client_ImageGenerat
 
 const toBatchGenerationRequestBody = (
   givenRequests: GenerateFromTextRequest['textToImageRequestBody'][],
-): Shortfin_TextToImage_SDXL_Client_ImageGenerationBatchRequest_Body => {
+): Shortfin_TextToImage_SDXL_Client_GenerationBatchRequest_Body => {
   return givenRequests.reduce<
-    Shortfin_TextToImage_SDXL_Client_ImageGenerationBatchRequest_Body
+    Shortfin_TextToImage_SDXL_Client_GenerationBatchRequest_Body
   >((runningBatchRequest, eachRequest) => {
     if (
       (eachRequest.height !== undefined)

--- a/src/library/ShimmedStabilityAIClient/definition.ts
+++ b/src/library/ShimmedStabilityAIClient/definition.ts
@@ -24,7 +24,7 @@ import {
 type UnsignedInteger = number;
 type FloatingPoint = number;
 
-interface Shortfin_SDClient_ImageGenerationBatchRequest_Body {
+interface Shortfin_TextToImage_SDClient_ImageGenerationBatchRequest_Body {
   prompt: /*        */ string[];
   neg_prompt: /*    */ string[];
   height: /*        */ UnsignedInteger[];
@@ -48,7 +48,7 @@ const toSerializedPromptValue = (
     .join(',');
 };
 
-const emptyBatchGenerationRequest: Shortfin_SDClient_ImageGenerationBatchRequest_Body = {
+const emptyBatchGenerationRequest: Shortfin_TextToImage_SDClient_ImageGenerationBatchRequest_Body = {
   prompt        : [],
   neg_prompt    : [],
   height        : [],
@@ -60,9 +60,9 @@ const emptyBatchGenerationRequest: Shortfin_SDClient_ImageGenerationBatchRequest
 
 const toBatchGenerationRequestBody = (
   givenRequests: GenerateFromTextRequest['textToImageRequestBody'][],
-): Shortfin_SDClient_ImageGenerationBatchRequest_Body => {
+): Shortfin_TextToImage_SDClient_ImageGenerationBatchRequest_Body => {
   return givenRequests.reduce<
-    Shortfin_SDClient_ImageGenerationBatchRequest_Body
+    Shortfin_TextToImage_SDClient_ImageGenerationBatchRequest_Body
   >((runningBatchRequest, eachRequest) => {
     if (
       (eachRequest.height !== undefined)

--- a/src/library/ShimmedStabilityAIClient/definition.ts
+++ b/src/library/ShimmedStabilityAIClient/definition.ts
@@ -24,7 +24,7 @@ import {
 type UnsignedInteger = number;
 type FloatingPoint = number;
 
-interface Shortfin_TextToImage_SDClient_ImageGenerationBatchRequest_Body {
+interface Shortfin_TextToImage_SDXL_Client_ImageGenerationBatchRequest_Body {
   prompt: /*        */ string[];
   neg_prompt: /*    */ string[];
   height: /*        */ UnsignedInteger[];
@@ -34,12 +34,12 @@ interface Shortfin_TextToImage_SDClient_ImageGenerationBatchRequest_Body {
   seed: /*          */ UnsignedInteger[];
 }
 
-type Shortfin_TextToImage_SD_Input_Text_SupportedWeight = 1 | -1;
+type Shortfin_TextToImage_SDXL_Input_Text_SupportedWeight = 1 | -1;
 
 const toSerializedPromptValue = (
   givenTextPrompts: TextToImageRequestBody['textPrompts'],
   given: {
-    weight: Shortfin_TextToImage_SD_Input_Text_SupportedWeight;
+    weight: Shortfin_TextToImage_SDXL_Input_Text_SupportedWeight;
   },
 ): string => {
   return givenTextPrompts
@@ -48,7 +48,7 @@ const toSerializedPromptValue = (
     .join(',');
 };
 
-const emptyBatchGenerationRequest: Shortfin_TextToImage_SDClient_ImageGenerationBatchRequest_Body = {
+const emptyBatchGenerationRequest: Shortfin_TextToImage_SDXL_Client_ImageGenerationBatchRequest_Body = {
   prompt        : [],
   neg_prompt    : [],
   height        : [],
@@ -60,9 +60,9 @@ const emptyBatchGenerationRequest: Shortfin_TextToImage_SDClient_ImageGeneration
 
 const toBatchGenerationRequestBody = (
   givenRequests: GenerateFromTextRequest['textToImageRequestBody'][],
-): Shortfin_TextToImage_SDClient_ImageGenerationBatchRequest_Body => {
+): Shortfin_TextToImage_SDXL_Client_ImageGenerationBatchRequest_Body => {
   return givenRequests.reduce<
-    Shortfin_TextToImage_SDClient_ImageGenerationBatchRequest_Body
+    Shortfin_TextToImage_SDXL_Client_ImageGenerationBatchRequest_Body
   >((runningBatchRequest, eachRequest) => {
     if (
       (eachRequest.height !== undefined)
@@ -92,7 +92,7 @@ const toBatchGenerationRequestBody = (
   }, cloneOf(emptyBatchGenerationRequest));
 };
 
-const Shortfin_TextToImage_Response_Body = {
+const Shortfin_TextToImage_SDXL_Response_Body = {
   SchemaMember: {
     image: Schema.string().transform((someSubject) => {
       return Base64CharacterEncodedByteSequence.parsedFrom(someSubject).forciblyUnwrap(/* Zod can safely propagate errors */);
@@ -125,7 +125,7 @@ class ImageClient
     });
 
     const newResource = outcomeOfSubmittingResource.forciblyUnwrap(/* matches error propagation of actual StabilityAI Client */);
-    const parsedResource = Shortfin_TextToImage_Response_Body.Schema.parse(newResource);
+    const parsedResource = Shortfin_TextToImage_SDXL_Response_Body.Schema.parse(newResource);
     const [soleGeneratedImage] = parsedResource.images;
 
     const soleGeneratedArtifact: StabilityAI_TextToImage_Pipeline_Output = {

--- a/src/library/ShimmedStabilityAIClient/definition.ts
+++ b/src/library/ShimmedStabilityAIClient/definition.ts
@@ -92,7 +92,7 @@ const toBatchGenerationRequestBody = (
   }, cloneOf(emptyBatchGenerationRequest));
 };
 
-const Shortfin_TextToImage_SDXL_Response_Body = {
+const Shortfin_TextToImage_SDXL_Client_Response_Body = {
   SchemaMember: {
     image: Schema.string().transform((someSubject) => {
       return Base64CharacterEncodedByteSequence.parsedFrom(someSubject).forciblyUnwrap(/* Zod can safely propagate errors */);
@@ -125,7 +125,7 @@ class ImageClient
     });
 
     const newResource = outcomeOfSubmittingResource.forciblyUnwrap(/* matches error propagation of actual StabilityAI Client */);
-    const parsedResource = Shortfin_TextToImage_SDXL_Response_Body.Schema.parse(newResource);
+    const parsedResource = Shortfin_TextToImage_SDXL_Client_Response_Body.Schema.parse(newResource);
     const [soleGeneratedImage] = parsedResource.images;
 
     const soleGeneratedArtifact: StabilityAI_TextToImage_Pipeline_Output = {

--- a/src/library/ShimmedStabilityAIClient/definition.ts
+++ b/src/library/ShimmedStabilityAIClient/definition.ts
@@ -34,12 +34,12 @@ interface Shortfin_TextToImage_SDXL_Client_ImageGenerationBatchRequest_Body {
   seed: /*          */ UnsignedInteger[];
 }
 
-type Shortfin_TextToImage_SDXL_Input_Text_SupportedWeight = 1 | -1;
+type Shortfin_TextToImage_SDXL_Pipeline_Input_Text_SupportedWeight = 1 | -1;
 
 const toSerializedPromptValue = (
   givenTextPrompts: TextToImageRequestBody['textPrompts'],
   given: {
-    weight: Shortfin_TextToImage_SDXL_Input_Text_SupportedWeight;
+    weight: Shortfin_TextToImage_SDXL_Pipeline_Input_Text_SupportedWeight;
   },
 ): string => {
   return givenTextPrompts

--- a/src/library/ShimmedStabilityAIClient/definition.ts
+++ b/src/library/ShimmedStabilityAIClient/definition.ts
@@ -24,7 +24,7 @@ import {
 type UnsignedInteger = number;
 type FloatingPoint = number;
 
-interface ShortfinSDClient_ImageGenerationBatchRequest_Body {
+interface Shortfin_SDClient_ImageGenerationBatchRequest_Body {
   prompt: /*        */ string[];
   neg_prompt: /*    */ string[];
   height: /*        */ UnsignedInteger[];
@@ -48,7 +48,7 @@ const toSerializedPromptValue = (
     .join(',');
 };
 
-const emptyBatchGenerationRequest: ShortfinSDClient_ImageGenerationBatchRequest_Body = {
+const emptyBatchGenerationRequest: Shortfin_SDClient_ImageGenerationBatchRequest_Body = {
   prompt        : [],
   neg_prompt    : [],
   height        : [],
@@ -60,9 +60,9 @@ const emptyBatchGenerationRequest: ShortfinSDClient_ImageGenerationBatchRequest_
 
 const toBatchGenerationRequestBody = (
   givenRequests: GenerateFromTextRequest['textToImageRequestBody'][],
-): ShortfinSDClient_ImageGenerationBatchRequest_Body => {
+): Shortfin_SDClient_ImageGenerationBatchRequest_Body => {
   return givenRequests.reduce<
-    ShortfinSDClient_ImageGenerationBatchRequest_Body
+    Shortfin_SDClient_ImageGenerationBatchRequest_Body
   >((runningBatchRequest, eachRequest) => {
     if (
       (eachRequest.height !== undefined)

--- a/src/library/ShimmedStabilityAIClient/definition.ts
+++ b/src/library/ShimmedStabilityAIClient/definition.ts
@@ -24,7 +24,7 @@ import {
 type UnsignedInteger = number;
 type FloatingPoint = number;
 
-interface Shortfin_TextToImage_SDXL_Client_GenerationBatchRequest_Body {
+interface Shortfin_TextToImage_SDXL_Client_BatchRequest_Body {
   prompt: /*        */ string[];
   neg_prompt: /*    */ string[];
   height: /*        */ UnsignedInteger[];
@@ -48,7 +48,7 @@ const toSerializedPromptValue = (
     .join(',');
 };
 
-const emptyBatchGenerationRequest: Shortfin_TextToImage_SDXL_Client_GenerationBatchRequest_Body = {
+const emptyBatchGenerationRequest: Shortfin_TextToImage_SDXL_Client_BatchRequest_Body = {
   prompt        : [],
   neg_prompt    : [],
   height        : [],
@@ -60,9 +60,9 @@ const emptyBatchGenerationRequest: Shortfin_TextToImage_SDXL_Client_GenerationBa
 
 const toBatchGenerationRequestBody = (
   givenRequests: GenerateFromTextRequest['textToImageRequestBody'][],
-): Shortfin_TextToImage_SDXL_Client_GenerationBatchRequest_Body => {
+): Shortfin_TextToImage_SDXL_Client_BatchRequest_Body => {
   return givenRequests.reduce<
-    Shortfin_TextToImage_SDXL_Client_GenerationBatchRequest_Body
+    Shortfin_TextToImage_SDXL_Client_BatchRequest_Body
   >((runningBatchRequest, eachRequest) => {
     if (
       (eachRequest.height !== undefined)


### PR DESCRIPTION
- Establishes the namespace hierarchy that will:
  - organize existing implementation
  - leave room for implementation that's not yet supported

Levels:
- "Shortfin": Named after the [SHARK AI sub-package](https://github.com/nod-ai/shark-ai/tree/main/shortfin)
   - "TextToImage": The inference mode. Leaving room for others like "TextToText", "ImageToVideo"
     - "SDXL": The relevant model. Leaves room for others like "Flux"
       - "Client": The implementation/interface for making network requests to a running service
         - "Request": Payload traveling from client to server
         - "Response": Payload traveling from server to client
       - "Pipeline": The interfaces for the inputs, configuration, and outputs of a pipeline behind a running service

Prerequisite for #630, #631, #632