### PR TITLE
refactor(library/ShimmedStabilityAIClient): extracts concerns for Shortfin pipeline

### DIFF
--- a/src/library/ShimmedStabilityAIClient/definition.ts
+++ b/src/library/ShimmedStabilityAIClient/definition.ts
@@ -11,6 +11,7 @@ import type {
 import Base64CharacterEncodedByteSequence from '@/library/Base64CharacterEncodedByteSequence';
 import HTTP from '@/library/HTTP';
 import Schema from '@/library/Schema';
+import type Shortfin from '@/library/Shortfin';
 
 import {
   URLOrigin,
@@ -34,12 +35,10 @@ interface Shortfin_TextToImage_SDXL_Client_Request_Body_Batched {
   seed: /*          */ UnsignedInteger[];
 }
 
-type Shortfin_TextToImage_SDXL_Pipeline_Input_Text_SupportedWeight = 1 | -1;
-
 const toSerializedPromptValue = (
   givenTextPrompts: TextToImageRequestBody['textPrompts'],
   given: {
-    weight: Shortfin_TextToImage_SDXL_Pipeline_Input_Text_SupportedWeight;
+    weight: Shortfin.TextToImage.SDXL.Pipeline.Input.Text.SupportedWeight;
   },
 ): string => {
   return givenTextPrompts

--- a/src/library/Shortfin/TextToImage/SDXL/Pipeline/Input/Text/SupportedWeight.ts
+++ b/src/library/Shortfin/TextToImage/SDXL/Pipeline/Input/Text/SupportedWeight.ts
@@ -1,0 +1,5 @@
+type Shortfin_TextToImage_SDXL_Pipeline_Input_Text_SupportedWeight = 1 | -1;
+
+export type {
+  Shortfin_TextToImage_SDXL_Pipeline_Input_Text_SupportedWeight,
+};

--- a/src/library/Shortfin/TextToImage/SDXL/Pipeline/Input/Text/exports.ts
+++ b/src/library/Shortfin/TextToImage/SDXL/Pipeline/Input/Text/exports.ts
@@ -1,0 +1,3 @@
+export type {
+  Shortfin_TextToImage_SDXL_Pipeline_Input_Text_SupportedWeight as SupportedWeight,
+} from './SupportedWeight';

--- a/src/library/Shortfin/TextToImage/SDXL/Pipeline/Input/Text/index.ts
+++ b/src/library/Shortfin/TextToImage/SDXL/Pipeline/Input/Text/index.ts
@@ -1,0 +1,1 @@
+export type * as Shortfin_TextToImage_SDXL_Pipeline_Input_Text from './exports.ts';

--- a/src/library/Shortfin/TextToImage/SDXL/Pipeline/Input/exports.ts
+++ b/src/library/Shortfin/TextToImage/SDXL/Pipeline/Input/exports.ts
@@ -1,0 +1,3 @@
+export type {
+  Shortfin_TextToImage_SDXL_Pipeline_Input_Text as Text,
+} from './Text';

--- a/src/library/Shortfin/TextToImage/SDXL/Pipeline/Input/index.ts
+++ b/src/library/Shortfin/TextToImage/SDXL/Pipeline/Input/index.ts
@@ -1,0 +1,1 @@
+export type * as Shortfin_TextToImage_SDXL_Pipeline_Input from './exports.ts';

--- a/src/library/Shortfin/TextToImage/SDXL/Pipeline/exports.ts
+++ b/src/library/Shortfin/TextToImage/SDXL/Pipeline/exports.ts
@@ -1,0 +1,3 @@
+export type {
+  Shortfin_TextToImage_SDXL_Pipeline_Input as Input,
+} from './Input';

--- a/src/library/Shortfin/TextToImage/SDXL/Pipeline/index.ts
+++ b/src/library/Shortfin/TextToImage/SDXL/Pipeline/index.ts
@@ -1,0 +1,1 @@
+export type * as Shortfin_TextToImage_SDXL_Pipeline from './exports.ts';

--- a/src/library/Shortfin/TextToImage/SDXL/exports.ts
+++ b/src/library/Shortfin/TextToImage/SDXL/exports.ts
@@ -1,0 +1,3 @@
+export type {
+  Shortfin_TextToImage_SDXL_Pipeline as Pipeline,
+} from './Pipeline';

--- a/src/library/Shortfin/TextToImage/SDXL/index.ts
+++ b/src/library/Shortfin/TextToImage/SDXL/index.ts
@@ -1,0 +1,1 @@
+export type * as Shortfin_TextToImage_SDXL from './exports.ts';

--- a/src/library/Shortfin/TextToImage/exports.ts
+++ b/src/library/Shortfin/TextToImage/exports.ts
@@ -1,0 +1,3 @@
+export type {
+  Shortfin_TextToImage_SDXL as SDXL,
+} from './SDXL';

--- a/src/library/Shortfin/TextToImage/index.ts
+++ b/src/library/Shortfin/TextToImage/index.ts
@@ -1,0 +1,1 @@
+export type * as Shortfin_TextToImage from './exports.ts';

--- a/src/library/Shortfin/exports.ts
+++ b/src/library/Shortfin/exports.ts
@@ -1,0 +1,3 @@
+export type {
+  Shortfin_TextToImage as TextToImage,
+} from './TextToImage';

--- a/src/library/Shortfin/index.ts
+++ b/src/library/Shortfin/index.ts
@@ -1,0 +1,5 @@
+import type * as Shortfin from './exports.ts';
+
+export type {
+  Shortfin as default,
+};


### PR DESCRIPTION
- there were two basic ideas defined in this one file:
  1. the Shortfin library, with its types and schemas
  2. the shim for the library that makes it shaped like Stability AI's Client
- these two ideas are separable, and this change is the first phase in that separation 