### PR TITLE
refactor(library/ShimmedStabilityAIClient): extracts concerns for Shortfin client request

### DIFF
--- a/src/library/ShimmedStabilityAIClient/definition.ts
+++ b/src/library/ShimmedStabilityAIClient/definition.ts
@@ -22,19 +22,6 @@ import {
   cloneOf,
 } from '@/library/utilitiesByType/reference.ts';
 
-type UnsignedInteger = number;
-type FloatingPoint = number;
-
-interface Shortfin_TextToImage_SDXL_Client_Request_Body_Batched {
-  prompt: /*        */ string[];
-  neg_prompt: /*    */ string[];
-  height: /*        */ UnsignedInteger[];
-  width: /*         */ UnsignedInteger[];
-  steps: /*         */ UnsignedInteger[];
-  guidance_scale: /**/ FloatingPoint[];
-  seed: /*          */ UnsignedInteger[];
-}
-
 const toSerializedPromptValue = (
   givenTextPrompts: TextToImageRequestBody['textPrompts'],
   given: {
@@ -47,7 +34,7 @@ const toSerializedPromptValue = (
     .join(',');
 };
 
-const emptyBatchGenerationRequest: Shortfin_TextToImage_SDXL_Client_Request_Body_Batched = {
+const emptyBatchGenerationRequest: Shortfin.TextToImage.SDXL.Client.Request.Body.Batched = {
   prompt        : [],
   neg_prompt    : [],
   height        : [],
@@ -59,9 +46,9 @@ const emptyBatchGenerationRequest: Shortfin_TextToImage_SDXL_Client_Request_Body
 
 const toBatchGenerationRequestBody = (
   givenRequests: GenerateFromTextRequest['textToImageRequestBody'][],
-): Shortfin_TextToImage_SDXL_Client_Request_Body_Batched => {
+): Shortfin.TextToImage.SDXL.Client.Request.Body.Batched => {
   return givenRequests.reduce<
-    Shortfin_TextToImage_SDXL_Client_Request_Body_Batched
+    Shortfin.TextToImage.SDXL.Client.Request.Body.Batched
   >((runningBatchRequest, eachRequest) => {
     if (
       (eachRequest.height !== undefined)

--- a/src/library/Shortfin/TextToImage/SDXL/Client/Request/Body/Batched.ts
+++ b/src/library/Shortfin/TextToImage/SDXL/Client/Request/Body/Batched.ts
@@ -1,0 +1,16 @@
+type UnsignedInteger = number;
+type FloatingPoint = number;
+
+interface Shortfin_TextToImage_SDXL_Client_Request_Body_Batched {
+  prompt: /*        */ string[];
+  neg_prompt: /*    */ string[];
+  height: /*        */ UnsignedInteger[];
+  width: /*         */ UnsignedInteger[];
+  steps: /*         */ UnsignedInteger[];
+  guidance_scale: /**/ FloatingPoint[];
+  seed: /*          */ UnsignedInteger[];
+}
+
+export type {
+  Shortfin_TextToImage_SDXL_Client_Request_Body_Batched,
+};

--- a/src/library/Shortfin/TextToImage/SDXL/Client/Request/Body/exports.ts
+++ b/src/library/Shortfin/TextToImage/SDXL/Client/Request/Body/exports.ts
@@ -1,0 +1,3 @@
+export type {
+  Shortfin_TextToImage_SDXL_Client_Request_Body_Batched as Batched,
+} from './Batched';

--- a/src/library/Shortfin/TextToImage/SDXL/Client/Request/Body/index.ts
+++ b/src/library/Shortfin/TextToImage/SDXL/Client/Request/Body/index.ts
@@ -1,0 +1,1 @@
+export type * as Shortfin_TextToImage_SDXL_Client_Request_Body from './exports.ts';

--- a/src/library/Shortfin/TextToImage/SDXL/Client/Request/exports.ts
+++ b/src/library/Shortfin/TextToImage/SDXL/Client/Request/exports.ts
@@ -1,0 +1,3 @@
+export type {
+  Shortfin_TextToImage_SDXL_Client_Request_Body as Body,
+} from './Body';

--- a/src/library/Shortfin/TextToImage/SDXL/Client/Request/index.ts
+++ b/src/library/Shortfin/TextToImage/SDXL/Client/Request/index.ts
@@ -1,0 +1,1 @@
+export type * as Shortfin_TextToImage_SDXL_Client_Request from './exports.ts';

--- a/src/library/Shortfin/TextToImage/SDXL/Client/exports.ts
+++ b/src/library/Shortfin/TextToImage/SDXL/Client/exports.ts
@@ -1,0 +1,3 @@
+export type {
+  Shortfin_TextToImage_SDXL_Client_Request as Request,
+} from './Request';

--- a/src/library/Shortfin/TextToImage/SDXL/Client/index.ts
+++ b/src/library/Shortfin/TextToImage/SDXL/Client/index.ts
@@ -1,0 +1,1 @@
+export type * as Shortfin_TextToImage_SDXL_Client from './exports.ts';

--- a/src/library/Shortfin/TextToImage/SDXL/exports.ts
+++ b/src/library/Shortfin/TextToImage/SDXL/exports.ts
@@ -1,3 +1,7 @@
 export type {
   Shortfin_TextToImage_SDXL_Pipeline as Pipeline,
 } from './Pipeline';
+
+export type {
+  Shortfin_TextToImage_SDXL_Client as Client,
+} from './Client';


### PR DESCRIPTION
- there were two basic ideas defined in this one file:
  1. the Shortfin library, with its types and schemas
  2. the shim for the library that makes it shaped like Stability AI's Client
- these two ideas are separable, and this change is the second phase in that separation after #630