### PR TITLE
docs(library/Shortfin): clarifies context of members within batched request body

### DIFF
--- a/src/library/Shortfin/TextToImage/SDXL/Client/Request/Body/Batched.ts
+++ b/src/library/Shortfin/TextToImage/SDXL/Client/Request/Body/Batched.ts
@@ -6,15 +6,25 @@ interface Shortfin_TextToImage_SDXL_Client_Request_Body_Batched {
   prompt/*    */: string[];
   /** The text that will be fed to the model with an equal but opposite weight. */
   neg_prompt/**/: string[];
-  /** The vertical dimension of the output image. */
+  /**
+   * The vertical dimension of the output image.
+   */
   height/*    */: UnsignedInteger[];
-  /** The horizontal dimension of the output image. */
+  /**
+   * The horizontal dimension of the output image.
+   */
   width/*     */: UnsignedInteger[];
-  /** The number of diffusion slices upon which model inference is performed. */
+  /**
+   * The number of diffusion slices upon which model inference is performed.
+   */
   steps/*     */: UnsignedInteger[];
-  /** Configures the pipeline's classifier-free guidance scale for de-noising. */
+  /**
+   * Configures the pipeline's classifier-free guidance scale for de-noising.
+   */
   guidance_scale: FloatingPoint[];
-  /** The seed for random latents generation. */
+  /**
+   * The seed for random latents generation.
+   */
   seed/*      */: UnsignedInteger[];
 }
 

--- a/src/library/Shortfin/TextToImage/SDXL/Client/Request/Body/Batched.ts
+++ b/src/library/Shortfin/TextToImage/SDXL/Client/Request/Body/Batched.ts
@@ -7,14 +7,20 @@ interface Shortfin_TextToImage_SDXL_Client_Request_Body_Batched {
   neg_prompt/**/: string[];
   /**
    * The vertical dimension of the output image.
+   *
+   * Must be an integer.
    */
   height/*    */: UnsignedInteger[];
   /**
    * The horizontal dimension of the output image.
+   *
+   * Must be an integer.
    */
   width/*     */: UnsignedInteger[];
   /**
    * The number of diffusion slices upon which model inference is performed.
+   *
+   * Must be an integer in the range 1 <= n <= 100.
    */
   steps/*     */: UnsignedInteger[];
   /**
@@ -25,6 +31,8 @@ interface Shortfin_TextToImage_SDXL_Client_Request_Body_Batched {
   guidance_scale: number[];
   /**
    * The seed for random latents generation.
+   *
+   * Must be a positive integer.
    */
   seed/*      */: UnsignedInteger[];
 }

--- a/src/library/Shortfin/TextToImage/SDXL/Client/Request/Body/Batched.ts
+++ b/src/library/Shortfin/TextToImage/SDXL/Client/Request/Body/Batched.ts
@@ -1,5 +1,4 @@
 type UnsignedInteger = number;
-type FloatingPoint = number;
 
 interface Shortfin_TextToImage_SDXL_Client_Request_Body_Batched {
   /** The text that will be fed to the model. */
@@ -23,7 +22,7 @@ interface Shortfin_TextToImage_SDXL_Client_Request_Body_Batched {
    *
    * Must be in the range 0 <= x <= 10.
    */
-  guidance_scale: FloatingPoint[];
+  guidance_scale: number[];
   /**
    * The seed for random latents generation.
    */

--- a/src/library/Shortfin/TextToImage/SDXL/Client/Request/Body/Batched.ts
+++ b/src/library/Shortfin/TextToImage/SDXL/Client/Request/Body/Batched.ts
@@ -1,5 +1,3 @@
-type UnsignedInteger = number;
-
 interface Shortfin_TextToImage_SDXL_Client_Request_Body_Batched {
   /** The text that will be fed to the model. */
   prompt/*    */: string[];
@@ -10,19 +8,19 @@ interface Shortfin_TextToImage_SDXL_Client_Request_Body_Batched {
    *
    * Must be an integer.
    */
-  height/*    */: UnsignedInteger[];
+  height/*    */: number[];
   /**
    * The horizontal dimension of the output image.
    *
    * Must be an integer.
    */
-  width/*     */: UnsignedInteger[];
+  width/*     */: number[];
   /**
    * The number of diffusion slices upon which model inference is performed.
    *
    * Must be an integer in the range 1 <= n <= 100.
    */
-  steps/*     */: UnsignedInteger[];
+  steps/*     */: number[];
   /**
    * Configures the pipeline's classifier-free guidance scale for de-noising.
    *
@@ -34,7 +32,7 @@ interface Shortfin_TextToImage_SDXL_Client_Request_Body_Batched {
    *
    * Must be a positive integer.
    */
-  seed/*      */: UnsignedInteger[];
+  seed/*      */: number[];
 }
 
 export type {

--- a/src/library/Shortfin/TextToImage/SDXL/Client/Request/Body/Batched.ts
+++ b/src/library/Shortfin/TextToImage/SDXL/Client/Request/Body/Batched.ts
@@ -20,6 +20,8 @@ interface Shortfin_TextToImage_SDXL_Client_Request_Body_Batched {
   steps/*     */: UnsignedInteger[];
   /**
    * Configures the pipeline's classifier-free guidance scale for de-noising.
+   *
+   * Must be in the range 0 <= x <= 10.
    */
   guidance_scale: FloatingPoint[];
   /**


### PR DESCRIPTION
- Although the `FloatingPoint` and `UnsignedInteger` type aliases do carry some context, they don't get surfaced via intellisense because they both resolve to a primitive `number`
- A potential follow-up to this could be implementing true `FloatingPoint` and `UnsignedInteger` subclasses of `Number`

Follows-up on #631 