### PR TITLE
refactor(library/ShimmedStabilityAIClient): aligns semantics with intent for request body prompt converter

### DIFF
--- a/src/library/ShimmedStabilityAIClient/definition.ts
+++ b/src/library/ShimmedStabilityAIClient/definition.ts
@@ -27,7 +27,7 @@ const toShortfinSerializedPromptValue = (
   given: {
     weight: Shortfin.TextToImage.SDXL.Pipeline.Input.Text.SupportedWeight;
   },
-): string => {
+): Shortfin.TextToImage.SDXL.Client.Request.Body['prompt'] => {
   return givenTextPrompts
     .filter($0 => $0.weight === given.weight)
     .map($0 => $0.text.trim())

--- a/src/library/ShimmedStabilityAIClient/definition.ts
+++ b/src/library/ShimmedStabilityAIClient/definition.ts
@@ -22,7 +22,7 @@ import {
   cloneOf,
 } from '@/library/utilitiesByType/reference.ts';
 
-const toShortfinSerializedPromptValue = (
+const toShortfinRequestBodyPrompt = (
   givenTextPrompts: TextToImageRequestBody['textPrompts'],
   given: {
     weight: Shortfin.TextToImage.SDXL.Pipeline.Input.Text.SupportedWeight;
@@ -57,11 +57,11 @@ const toShortfinBatchGenerationRequestBody = (
       && (eachStabilityAIRequest.cfgScale !== undefined)
       && (eachStabilityAIRequest.seed !== undefined)
     ) {
-      const positiveTextPrompts = toShortfinSerializedPromptValue(eachStabilityAIRequest.textPrompts, {
+      const positiveTextPrompts = toShortfinRequestBodyPrompt(eachStabilityAIRequest.textPrompts, {
         weight: 1,
       });
 
-      const negativeTextPrompts = toShortfinSerializedPromptValue(eachStabilityAIRequest.textPrompts, {
+      const negativeTextPrompts = toShortfinRequestBodyPrompt(eachStabilityAIRequest.textPrompts, {
         weight: -1,
       });
 


### PR DESCRIPTION
- there was a linguistic code smell that made it tough to figure out where the converter should go
- previous name had:
  - "serialized" because it's going to travel over the wire, but "request" denotes that more directly
  - "prompt value" because it was to be mapped to `prompt` or `neg_prompt`, but "body prompt" denotes that better
- and none of this was obvious until the `string` return type had some context

Facilitates #637 