### PR TITLE
refactor(library/ShimmedStabilityAIClient): highlights conversion boundaries

### DIFF
--- a/src/library/ShimmedStabilityAIClient/definition.ts
+++ b/src/library/ShimmedStabilityAIClient/definition.ts
@@ -44,7 +44,7 @@ const emptyBatchGenerationRequest: Shortfin.TextToImage.SDXL.Client.Request.Body
   seed          : [],
 };
 
-const toBatchGenerationRequestBody = (
+const toShortfinBatchGenerationRequestBody = (
   givenRequests: GenerateFromTextRequest['textToImageRequestBody'][],
 ): Shortfin.TextToImage.SDXL.Client.Request.Body.Batched => {
   return givenRequests.reduce<
@@ -101,7 +101,7 @@ class ImageClient
   public async forciblyGenerateFromText(
     givenRequest: GenerateFromTextRequest,
   ): Promise<GenerateFromTextResponse> {
-    const shimmedRequestBody = toBatchGenerationRequestBody([
+    const shimmedRequestBody = toShortfinBatchGenerationRequestBody([
       givenRequest.textToImageRequestBody,
     ]);
 

--- a/src/library/ShimmedStabilityAIClient/definition.ts
+++ b/src/library/ShimmedStabilityAIClient/definition.ts
@@ -22,7 +22,7 @@ import {
   cloneOf,
 } from '@/library/utilitiesByType/reference.ts';
 
-const toSerializedPromptValue = (
+const toShortfinSerializedPromptValue = (
   givenTextPrompts: TextToImageRequestBody['textPrompts'],
   given: {
     weight: Shortfin.TextToImage.SDXL.Pipeline.Input.Text.SupportedWeight;
@@ -57,11 +57,11 @@ const toShortfinBatchGenerationRequestBody = (
       && (eachStabilityAIRequest.cfgScale !== undefined)
       && (eachStabilityAIRequest.seed !== undefined)
     ) {
-      const positiveTextPrompts = toSerializedPromptValue(eachStabilityAIRequest.textPrompts, {
+      const positiveTextPrompts = toShortfinSerializedPromptValue(eachStabilityAIRequest.textPrompts, {
         weight: 1,
       });
 
-      const negativeTextPrompts = toSerializedPromptValue(eachStabilityAIRequest.textPrompts, {
+      const negativeTextPrompts = toShortfinSerializedPromptValue(eachStabilityAIRequest.textPrompts, {
         weight: -1,
       });
 

--- a/src/library/ShimmedStabilityAIClient/definition.ts
+++ b/src/library/ShimmedStabilityAIClient/definition.ts
@@ -49,29 +49,29 @@ const toBatchGenerationRequestBody = (
 ): Shortfin.TextToImage.SDXL.Client.Request.Body.Batched => {
   return givenRequests.reduce<
     Shortfin.TextToImage.SDXL.Client.Request.Body.Batched
-  >((runningBatchRequest, eachRequest) => {
+  >((runningBatchRequest, eachStabilityAIRequest) => {
     if (
-      (eachRequest.height !== undefined)
-      && (eachRequest.width !== undefined)
-      && (eachRequest.steps !== undefined)
-      && (eachRequest.cfgScale !== undefined)
-      && (eachRequest.seed !== undefined)
+      (eachStabilityAIRequest.height !== undefined)
+      && (eachStabilityAIRequest.width !== undefined)
+      && (eachStabilityAIRequest.steps !== undefined)
+      && (eachStabilityAIRequest.cfgScale !== undefined)
+      && (eachStabilityAIRequest.seed !== undefined)
     ) {
-      const positiveTextPrompts = toSerializedPromptValue(eachRequest.textPrompts, {
+      const positiveTextPrompts = toSerializedPromptValue(eachStabilityAIRequest.textPrompts, {
         weight: 1,
       });
 
-      const negativeTextPrompts = toSerializedPromptValue(eachRequest.textPrompts, {
+      const negativeTextPrompts = toSerializedPromptValue(eachStabilityAIRequest.textPrompts, {
         weight: -1,
       });
 
       (runningBatchRequest.prompt/*    */).push(positiveTextPrompts/* */);
       (runningBatchRequest.neg_prompt/**/).push(negativeTextPrompts/* */);
-      (runningBatchRequest.height/*    */).push(eachRequest.height/*  */);
-      (runningBatchRequest.width/*     */).push(eachRequest.width/*   */);
-      (runningBatchRequest.steps/*     */).push(eachRequest.steps/*   */);
-      (runningBatchRequest.guidance_scale).push(eachRequest.cfgScale/**/);
-      (runningBatchRequest.seed/*      */).push(eachRequest.seed/*    */);
+      (runningBatchRequest.height/*    */).push(eachStabilityAIRequest.height/*  */);
+      (runningBatchRequest.width/*     */).push(eachStabilityAIRequest.width/*   */);
+      (runningBatchRequest.steps/*     */).push(eachStabilityAIRequest.steps/*   */);
+      (runningBatchRequest.guidance_scale).push(eachStabilityAIRequest.cfgScale/**/);
+      (runningBatchRequest.seed/*      */).push(eachStabilityAIRequest.seed/*    */);
     }
 
     return runningBatchRequest;


### PR DESCRIPTION
- the overall challenge with this library is that lack of semantic domain separation
- a few key renamings helps enunciate these boundaries, which will aid in subsequent refactors

Facilitates #638