### PR TITLE
ci(dependabot): auto-approves minor bumps to vite

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -45,7 +45,8 @@ jobs:
               "eslint",
               "eslint-plugin-vue",
               "typescript-eslint",
-              "typescript"
+              "typescript",
+              "vite",
             ]'),
             steps.metadata.outputs.dependency-names
           )


### PR DESCRIPTION
- `vite` doesn't directly affect runtime, so the testing pipeline will always yield the same result before and after the version bump
- changes to `vite` that conflict with this codebase will always fail the CI's "analysis" job at the linting, compilation, or build steps
- because of this, minor and patch bumps are safe to automatically approve
- pairing that with auto-merge upon passing required checks, maintainers will seldom have to intervene for this frequently updated dependency

Incited by #640 