### PR TITLE
ci(node): adds "build" step to workflow

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -60,6 +60,16 @@ jobs:
         run: |
           echo "::notice::Run \`npm run type-check\` in your dev environment for details about compiler issues"
           exit 1
+      - name: Try to build for production # "Build" in this context means "transpile, minify, tree-shake, and bundle"
+        if: steps.changed-files.outputs.any_changed == 'true'
+        id: build
+        run: npm run build-only
+        continue-on-error: true
+      - name: If building fails, highlight debug tools
+        if: steps.build.outcome == 'failure'
+        run: |
+          echo "::notice::Run \`npm run build-only\` in your dev environment for a detailed report about build failures"
+          exit 1
       - name: Try to pass all unit tests
         if: steps.changed-files.outputs.any_changed == 'true'
         id: test_units

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   analyze:
     runs-on: ubuntu-latest
-    name: Lint, Compile, and Test
+    name: Lint, Compile, Build, and Test
     steps:
       - uses: actions/checkout@v4
       - name: Check for changes to this workflow, dependencies, scripts, and single-file components


### PR DESCRIPTION
- this simple check will indicate whether the project can even be successfully built for production
- a follow-up for this could be creating a true nightly build

Pre-requisite for #641 