### PR TITLE
ci(node): clarifies objective of each step

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Install all dependencies
         if: steps.changed-files.outputs.any_changed == 'true'
         run: npm clean-install
-      - name: Run the linter
+      - name: Try to pass linter
         if: steps.changed-files.outputs.any_changed == 'true'
         id: lint
         run: npx eslint . --max-warnings 0 --cache
@@ -50,7 +50,7 @@ jobs:
           echo "::notice::Enable lint-on-save in your editor for automatic fixes"
           echo "::notice::Run \`npm run lint\` in your dev environment for details about issues that aren't automatically fixable"
           exit 1
-      - name: Run the compiler
+      - name: Try to pass compiler
         if: steps.changed-files.outputs.any_changed == 'true'
         id: compile
         run: npx vue-tsc --build
@@ -60,7 +60,7 @@ jobs:
         run: |
           echo "::notice::Run \`npx vue-tsc --build\` in your dev environment for details about compiler issues"
           exit 1
-      - name: Run the unit tests
+      - name: Try to pass all unit tests
         if: steps.changed-files.outputs.any_changed == 'true'
         id: test_units
         run: npm run test:unit

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -44,7 +44,7 @@ jobs:
         id: lint
         run: npx eslint . --max-warnings 0 --cache
         continue-on-error: true
-      - name: If linter fails, highlight debug tools
+      - name: If linting fails, highlight debug tools
         if: steps.lint.outcome == 'failure'
         run: |
           echo "::notice::Enable lint-on-save in your editor for automatic fixes"

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -36,7 +36,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           cache: 'npm'
-      - name: Install all dependencies (which includes linters)
+      - name: Install all dependencies
         if: steps.changed-files.outputs.any_changed == 'true'
         run: npm clean-install
       - name: Run the linter


### PR DESCRIPTION
- before, the `name`s of each step simply repeated the semantics of the command they represented.
- this left a vague difference between "set-up" steps and "critical" steps 
- clarifying the "why" of each step makes it easier to see where new steps ought to go

Sets precedent for #642