### PR TITLE
refactor(library/ShimmedStabilityAIClient): moves concerns of empty batched requests to Shortfin

### DIFF
--- a/src/library/ShimmedStabilityAIClient/definition.ts
+++ b/src/library/ShimmedStabilityAIClient/definition.ts
@@ -10,7 +10,7 @@ import type {
 import Base64CharacterEncodedByteSequence from '@/library/Base64CharacterEncodedByteSequence';
 import HTTP from '@/library/HTTP';
 import Schema from '@/library/Schema';
-import type Shortfin from '@/library/Shortfin';
+import Shortfin from '@/library/Shortfin';
 
 import {
   URLOrigin,
@@ -25,15 +25,15 @@ import {
   toShortfinRequestBodyPrompt,
 } from './conversions';
 
-const emptyBatchGenerationRequest: Shortfin.TextToImage.SDXL.Client.Request.Body.Batched = {
-  prompt        : [],
-  neg_prompt    : [],
-  height        : [],
-  width         : [],
-  steps         : [],
-  guidance_scale: [],
-  seed          : [],
-};
+const emptyBatchGenerationRequest = new Shortfin.TextToImage.SDXL.Client.Request.Body.Batched(
+  [],
+  [],
+  [],
+  [],
+  [],
+  [],
+  [],
+);
 
 const toShortfinBatchGenerationRequestBody = (
   givenRequests: GenerateFromTextRequest['textToImageRequestBody'][],

--- a/src/library/ShimmedStabilityAIClient/definition.ts
+++ b/src/library/ShimmedStabilityAIClient/definition.ts
@@ -25,15 +25,7 @@ import {
   toShortfinRequestBodyPrompt,
 } from './conversions';
 
-const emptyBatchGenerationRequest = new Shortfin.TextToImage.SDXL.Client.Request.Body.Batched(
-  [],
-  [],
-  [],
-  [],
-  [],
-  [],
-  [],
-);
+const emptyBatchGenerationRequest = new Shortfin.TextToImage.SDXL.Client.Request.Body.Batched();
 
 const toShortfinBatchGenerationRequestBody = (
   givenRequests: GenerateFromTextRequest['textToImageRequestBody'][],

--- a/src/library/Shortfin/TextToImage/SDXL/Client/Request/Body/Batched.ts
+++ b/src/library/Shortfin/TextToImage/SDXL/Client/Request/Body/Batched.ts
@@ -12,19 +12,19 @@ implements Batched<
 > {
   public constructor(
     /** @inheritdoc Number of elements defines the size of the batch. */
-    public prompt/*    */: string[],
+    public prompt/*    */: string[] = [],
     /** @inheritdoc Number of elements must match the size of the batch. */
-    public neg_prompt/**/: string[],
+    public neg_prompt/**/: string[] = [],
     /** @inheritdoc Number of elements must match the size of the batch. */
-    public height/*    */: number[],
+    public height/*    */: number[] = [],
     /** @inheritdoc Number of elements must match the size of the batch. */
-    public width/*     */: number[],
+    public width/*     */: number[] = [],
     /** @inheritdoc Number of elements must match the size of the batch. */
-    public steps/*     */: number[],
+    public steps/*     */: number[] = [],
     /** @inheritdoc Number of elements must match the size of the batch. */
-    public guidance_scale: number[],
+    public guidance_scale: number[] = [],
     /** @inheritdoc Number of elements must match the size of the batch. */
-    public seed/*      */: number[],
+    public seed/*      */: number[] = [],
   ) {}
 }
 


### PR DESCRIPTION
- `ShimmedStabilityAIClient` doesn't need to _how_ to create an empty batched request, only that it _needs_ an empty batched request