### PR TITLE
refactor(library/ShimmedStabilityAIClient): avoids specifying inferrable generic parameter in batched request converter 

### DIFF
--- a/src/library/ShimmedStabilityAIClient/definition.ts
+++ b/src/library/ShimmedStabilityAIClient/definition.ts
@@ -30,9 +30,7 @@ const emptyBatchGenerationRequest = new Shortfin.TextToImage.SDXL.Client.Request
 const toShortfinBatchGenerationRequestBody = (
   givenRequests: GenerateFromTextRequest['textToImageRequestBody'][],
 ): Shortfin.TextToImage.SDXL.Client.Request.Body.Batched => {
-  return givenRequests.reduce<
-    Shortfin.TextToImage.SDXL.Client.Request.Body.Batched
-  >((runningBatchRequest, eachStabilityAIRequest) => {
+  return givenRequests.reduce((runningBatchRequest, eachStabilityAIRequest) => {
     if (
       (eachStabilityAIRequest.height !== undefined)
       && (eachStabilityAIRequest.width !== undefined)


### PR DESCRIPTION
Follows up on #648 