### PR TITLE
prefeature(library/typeUtilities): adds class support to `Batched`

### DIFF
--- a/src/library/typeUtilities/Batched.ts
+++ b/src/library/typeUtilities/Batched.ts
@@ -1,7 +1,7 @@
 type Batched<
-  SomeRecord extends object,
+  SomeObject extends object,
 > = {
-  [EachKeyOfSomeRecord in keyof SomeRecord]: SomeRecord[EachKeyOfSomeRecord][];
+  [EachKeyOfSomeRecord in keyof SomeObject]: SomeObject[EachKeyOfSomeRecord][];
 };
 
 export type {

--- a/src/library/typeUtilities/Batched.ts
+++ b/src/library/typeUtilities/Batched.ts
@@ -1,7 +1,7 @@
 type Batched<
   SomeObject extends object,
 > = {
-  [EachKeyOfSomeRecord in keyof SomeObject]: SomeObject[EachKeyOfSomeRecord][];
+  [EachKeyOfSomeObject in keyof SomeObject]: SomeObject[EachKeyOfSomeObject][];
 };
 
 export type {

--- a/src/library/typeUtilities/Batched.ts
+++ b/src/library/typeUtilities/Batched.ts
@@ -1,5 +1,5 @@
 type Batched<
-  SomeRecord extends Record<string, NonNullable<unknown>>,
+  SomeRecord extends object,
 > = {
   [EachKeyOfSomeRecord in keyof SomeRecord]: SomeRecord[EachKeyOfSomeRecord][];
 };


### PR DESCRIPTION
- `class`es don't have a catch-all `string` index signature, so `Record<string, ...>` is too restrictive

Pre-requisite for #648