### PR TITLE
refactor(library/ShimmedStabilityAIClient): prefers "batched" to mean "member-wise batch"

### DIFF
--- a/src/library/ShimmedStabilityAIClient/definition.ts
+++ b/src/library/ShimmedStabilityAIClient/definition.ts
@@ -82,12 +82,12 @@ class ImageClient
   public async forciblyGenerateFromText(
     givenRequest: GenerateFromTextRequest,
   ): Promise<GenerateFromTextResponse> {
-    const shimmedRequestBody = toShortfinBatchedGenerationRequestBody([
+    const shimmedBatchedRequestBody = toShortfinBatchedGenerationRequestBody([
       givenRequest.textToImageRequestBody,
     ]);
 
     const outcomeOfSubmittingResource = await this.submitResource({
-      bySending: shimmedRequestBody,
+      bySending: shimmedBatchedRequestBody,
       to       : generationEndpoint,
     });
 

--- a/src/library/ShimmedStabilityAIClient/definition.ts
+++ b/src/library/ShimmedStabilityAIClient/definition.ts
@@ -27,7 +27,7 @@ import {
 
 const emptyBatchedGenerationRequest = new Shortfin.TextToImage.SDXL.Client.Request.Body.Batched();
 
-const toShortfinBatchGenerationRequestBody = (
+const toShortfinBatchedGenerationRequestBody = (
   givenRequests: GenerateFromTextRequest['textToImageRequestBody'][],
 ): Shortfin.TextToImage.SDXL.Client.Request.Body.Batched => {
   return givenRequests.reduce((runningBatchRequest, eachStabilityAIRequest) => {
@@ -82,7 +82,7 @@ class ImageClient
   public async forciblyGenerateFromText(
     givenRequest: GenerateFromTextRequest,
   ): Promise<GenerateFromTextResponse> {
-    const shimmedRequestBody = toShortfinBatchGenerationRequestBody([
+    const shimmedRequestBody = toShortfinBatchedGenerationRequestBody([
       givenRequest.textToImageRequestBody,
     ]);
 

--- a/src/library/ShimmedStabilityAIClient/definition.ts
+++ b/src/library/ShimmedStabilityAIClient/definition.ts
@@ -30,7 +30,7 @@ const emptyBatchedGenerationRequest = new Shortfin.TextToImage.SDXL.Client.Reque
 const toShortfinBatchedGenerationRequestBody = (
   givenRequests: GenerateFromTextRequest['textToImageRequestBody'][],
 ): Shortfin.TextToImage.SDXL.Client.Request.Body.Batched => {
-  return givenRequests.reduce((runningBatchRequest, eachStabilityAIRequest) => {
+  return givenRequests.reduce((runningBatchedRequest, eachStabilityAIRequest) => {
     if (
       (eachStabilityAIRequest.height !== undefined)
       && (eachStabilityAIRequest.width !== undefined)
@@ -46,16 +46,16 @@ const toShortfinBatchedGenerationRequestBody = (
         weight: -1,
       });
 
-      (runningBatchRequest.prompt/*    */).push(positiveTextPrompts/* */);
-      (runningBatchRequest.neg_prompt/**/).push(negativeTextPrompts/* */);
-      (runningBatchRequest.height/*    */).push(eachStabilityAIRequest.height/*  */);
-      (runningBatchRequest.width/*     */).push(eachStabilityAIRequest.width/*   */);
-      (runningBatchRequest.steps/*     */).push(eachStabilityAIRequest.steps/*   */);
-      (runningBatchRequest.guidance_scale).push(eachStabilityAIRequest.cfgScale/**/);
-      (runningBatchRequest.seed/*      */).push(eachStabilityAIRequest.seed/*    */);
+      (runningBatchedRequest.prompt/*    */).push(positiveTextPrompts/* */);
+      (runningBatchedRequest.neg_prompt/**/).push(negativeTextPrompts/* */);
+      (runningBatchedRequest.height/*    */).push(eachStabilityAIRequest.height/*  */);
+      (runningBatchedRequest.width/*     */).push(eachStabilityAIRequest.width/*   */);
+      (runningBatchedRequest.steps/*     */).push(eachStabilityAIRequest.steps/*   */);
+      (runningBatchedRequest.guidance_scale).push(eachStabilityAIRequest.cfgScale/**/);
+      (runningBatchedRequest.seed/*      */).push(eachStabilityAIRequest.seed/*    */);
     }
 
-    return runningBatchRequest;
+    return runningBatchedRequest;
   }, cloneOf(emptyBatchedGenerationRequest));
 };
 

--- a/src/library/ShimmedStabilityAIClient/definition.ts
+++ b/src/library/ShimmedStabilityAIClient/definition.ts
@@ -25,7 +25,7 @@ import {
   toShortfinRequestBodyPrompt,
 } from './conversions';
 
-const emptyBatchGenerationRequest = new Shortfin.TextToImage.SDXL.Client.Request.Body.Batched();
+const emptyBatchedGenerationRequest = new Shortfin.TextToImage.SDXL.Client.Request.Body.Batched();
 
 const toShortfinBatchGenerationRequestBody = (
   givenRequests: GenerateFromTextRequest['textToImageRequestBody'][],
@@ -56,7 +56,7 @@ const toShortfinBatchGenerationRequestBody = (
     }
 
     return runningBatchRequest;
-  }, cloneOf(emptyBatchGenerationRequest));
+  }, cloneOf(emptyBatchedGenerationRequest));
 };
 
 const Shortfin_TextToImage_SDXL_Client_Response_Body = {


### PR DESCRIPTION
- pinning down the semantics helps communicate the role of each unit, making it easier to determine how they can be extracted and modularized
- "batch request body" would mean an "a list of request bodies" which would just be "request bodies"
- "batch**ed** request body" would mean "a request body whose members are batched", which more accurately represents the data structure