### PR TITLE
refactor(library/ShimmedStabilityAIClient): prefers "body" to mean "payload of a request"

### DIFF
--- a/src/library/ShimmedStabilityAIClient/definition.ts
+++ b/src/library/ShimmedStabilityAIClient/definition.ts
@@ -25,7 +25,7 @@ import {
   toShortfinRequestBodyPrompt,
 } from './conversions';
 
-const emptyBatchedGenerationRequest = new Shortfin.TextToImage.SDXL.Client.Request.Body.Batched();
+const emptyBatchedGenerationRequestBody = new Shortfin.TextToImage.SDXL.Client.Request.Body.Batched();
 
 const toShortfinBatchedGenerationRequestBody = (
   givenRequests: GenerateFromTextRequest['textToImageRequestBody'][],
@@ -56,7 +56,7 @@ const toShortfinBatchedGenerationRequestBody = (
     }
 
     return runningBatchedRequest;
-  }, cloneOf(emptyBatchedGenerationRequest));
+  }, cloneOf(emptyBatchedGenerationRequestBody));
 };
 
 const Shortfin_TextToImage_SDXL_Client_Response_Body = {

--- a/src/library/ShimmedStabilityAIClient/definition.ts
+++ b/src/library/ShimmedStabilityAIClient/definition.ts
@@ -30,7 +30,7 @@ const emptyBatchedGenerationRequestBody = new Shortfin.TextToImage.SDXL.Client.R
 const toShortfinBatchedGenerationRequestBody = (
   givenRequestBodies: GenerateFromTextRequest['textToImageRequestBody'][],
 ): Shortfin.TextToImage.SDXL.Client.Request.Body.Batched => {
-  return givenRequestBodies.reduce((runningBatchedRequest, eachStabilityAIRequestBody) => {
+  return givenRequestBodies.reduce((runningBatchedRequestBody, eachStabilityAIRequestBody) => {
     if (
       (eachStabilityAIRequestBody.height !== undefined)
       && (eachStabilityAIRequestBody.width !== undefined)
@@ -46,16 +46,16 @@ const toShortfinBatchedGenerationRequestBody = (
         weight: -1,
       });
 
-      (runningBatchedRequest.prompt/*    */).push(positiveTextPrompts/* */);
-      (runningBatchedRequest.neg_prompt/**/).push(negativeTextPrompts/* */);
-      (runningBatchedRequest.height/*    */).push(eachStabilityAIRequestBody.height/*  */);
-      (runningBatchedRequest.width/*     */).push(eachStabilityAIRequestBody.width/*   */);
-      (runningBatchedRequest.steps/*     */).push(eachStabilityAIRequestBody.steps/*   */);
-      (runningBatchedRequest.guidance_scale).push(eachStabilityAIRequestBody.cfgScale/**/);
-      (runningBatchedRequest.seed/*      */).push(eachStabilityAIRequestBody.seed/*    */);
+      (runningBatchedRequestBody.prompt/*    */).push(positiveTextPrompts/* */);
+      (runningBatchedRequestBody.neg_prompt/**/).push(negativeTextPrompts/* */);
+      (runningBatchedRequestBody.height/*    */).push(eachStabilityAIRequestBody.height/*  */);
+      (runningBatchedRequestBody.width/*     */).push(eachStabilityAIRequestBody.width/*   */);
+      (runningBatchedRequestBody.steps/*     */).push(eachStabilityAIRequestBody.steps/*   */);
+      (runningBatchedRequestBody.guidance_scale).push(eachStabilityAIRequestBody.cfgScale/**/);
+      (runningBatchedRequestBody.seed/*      */).push(eachStabilityAIRequestBody.seed/*    */);
     }
 
-    return runningBatchedRequest;
+    return runningBatchedRequestBody;
   }, cloneOf(emptyBatchedGenerationRequestBody));
 };
 

--- a/src/library/ShimmedStabilityAIClient/definition.ts
+++ b/src/library/ShimmedStabilityAIClient/definition.ts
@@ -30,29 +30,29 @@ const emptyBatchedGenerationRequestBody = new Shortfin.TextToImage.SDXL.Client.R
 const toShortfinBatchedGenerationRequestBody = (
   givenRequestBodies: GenerateFromTextRequest['textToImageRequestBody'][],
 ): Shortfin.TextToImage.SDXL.Client.Request.Body.Batched => {
-  return givenRequestBodies.reduce((runningBatchedRequest, eachStabilityAIRequest) => {
+  return givenRequestBodies.reduce((runningBatchedRequest, eachStabilityAIRequestBody) => {
     if (
-      (eachStabilityAIRequest.height !== undefined)
-      && (eachStabilityAIRequest.width !== undefined)
-      && (eachStabilityAIRequest.steps !== undefined)
-      && (eachStabilityAIRequest.cfgScale !== undefined)
-      && (eachStabilityAIRequest.seed !== undefined)
+      (eachStabilityAIRequestBody.height !== undefined)
+      && (eachStabilityAIRequestBody.width !== undefined)
+      && (eachStabilityAIRequestBody.steps !== undefined)
+      && (eachStabilityAIRequestBody.cfgScale !== undefined)
+      && (eachStabilityAIRequestBody.seed !== undefined)
     ) {
-      const positiveTextPrompts = toShortfinRequestBodyPrompt(eachStabilityAIRequest.textPrompts, {
+      const positiveTextPrompts = toShortfinRequestBodyPrompt(eachStabilityAIRequestBody.textPrompts, {
         weight: 1,
       });
 
-      const negativeTextPrompts = toShortfinRequestBodyPrompt(eachStabilityAIRequest.textPrompts, {
+      const negativeTextPrompts = toShortfinRequestBodyPrompt(eachStabilityAIRequestBody.textPrompts, {
         weight: -1,
       });
 
       (runningBatchedRequest.prompt/*    */).push(positiveTextPrompts/* */);
       (runningBatchedRequest.neg_prompt/**/).push(negativeTextPrompts/* */);
-      (runningBatchedRequest.height/*    */).push(eachStabilityAIRequest.height/*  */);
-      (runningBatchedRequest.width/*     */).push(eachStabilityAIRequest.width/*   */);
-      (runningBatchedRequest.steps/*     */).push(eachStabilityAIRequest.steps/*   */);
-      (runningBatchedRequest.guidance_scale).push(eachStabilityAIRequest.cfgScale/**/);
-      (runningBatchedRequest.seed/*      */).push(eachStabilityAIRequest.seed/*    */);
+      (runningBatchedRequest.height/*    */).push(eachStabilityAIRequestBody.height/*  */);
+      (runningBatchedRequest.width/*     */).push(eachStabilityAIRequestBody.width/*   */);
+      (runningBatchedRequest.steps/*     */).push(eachStabilityAIRequestBody.steps/*   */);
+      (runningBatchedRequest.guidance_scale).push(eachStabilityAIRequestBody.cfgScale/**/);
+      (runningBatchedRequest.seed/*      */).push(eachStabilityAIRequestBody.seed/*    */);
     }
 
     return runningBatchedRequest;

--- a/src/library/ShimmedStabilityAIClient/definition.ts
+++ b/src/library/ShimmedStabilityAIClient/definition.ts
@@ -28,9 +28,9 @@ import {
 const emptyBatchedGenerationRequestBody = new Shortfin.TextToImage.SDXL.Client.Request.Body.Batched();
 
 const toShortfinBatchedGenerationRequestBody = (
-  givenRequests: GenerateFromTextRequest['textToImageRequestBody'][],
+  givenRequestBodies: GenerateFromTextRequest['textToImageRequestBody'][],
 ): Shortfin.TextToImage.SDXL.Client.Request.Body.Batched => {
-  return givenRequests.reduce((runningBatchedRequest, eachStabilityAIRequest) => {
+  return givenRequestBodies.reduce((runningBatchedRequest, eachStabilityAIRequest) => {
     if (
       (eachStabilityAIRequest.height !== undefined)
       && (eachStabilityAIRequest.width !== undefined)


### PR DESCRIPTION
- pinning down the semantics helps communicate the role of each unit, making it easier to determine how they can be extracted and modularized
- "request" is "the data that leaves the client and heads over to the server"
- "request _body_" is "the primary payload of request upon which the server will likely base the response", more accurately describes what's being manipulated in this implementation