### PR TITLE
refactor(library/ShimmedStabilityAIClient): avoids mention of "generation" in agnostic components

### DIFF
--- a/src/library/ShimmedStabilityAIClient/definition.ts
+++ b/src/library/ShimmedStabilityAIClient/definition.ts
@@ -25,7 +25,7 @@ import {
   toShortfinRequestBodyPrompt,
 } from './conversions';
 
-const emptyBatchedGenerationRequestBody = new Shortfin.TextToImage.SDXL.Client.Request.Body.Batched();
+const emptyBatchedRequestBody = new Shortfin.TextToImage.SDXL.Client.Request.Body.Batched();
 
 const toShortfinBatchedRequestBody = (
   givenRequestBodies: GenerateFromTextRequest['textToImageRequestBody'][],
@@ -56,7 +56,7 @@ const toShortfinBatchedRequestBody = (
     }
 
     return runningBatchedRequestBody;
-  }, cloneOf(emptyBatchedGenerationRequestBody));
+  }, cloneOf(emptyBatchedRequestBody));
 };
 
 const Shortfin_TextToImage_SDXL_Client_Response_Body = {

--- a/src/library/ShimmedStabilityAIClient/definition.ts
+++ b/src/library/ShimmedStabilityAIClient/definition.ts
@@ -27,7 +27,7 @@ import {
 
 const emptyBatchedGenerationRequestBody = new Shortfin.TextToImage.SDXL.Client.Request.Body.Batched();
 
-const toShortfinBatchedGenerationRequestBody = (
+const toShortfinBatchedRequestBody = (
   givenRequestBodies: GenerateFromTextRequest['textToImageRequestBody'][],
 ): Shortfin.TextToImage.SDXL.Client.Request.Body.Batched => {
   return givenRequestBodies.reduce((runningBatchedRequestBody, eachStabilityAIRequestBody) => {
@@ -82,7 +82,7 @@ class ImageClient
   public async forciblyGenerateFromText(
     givenRequest: GenerateFromTextRequest,
   ): Promise<GenerateFromTextResponse> {
-    const shimmedBatchedRequestBody = toShortfinBatchedGenerationRequestBody([
+    const shimmedBatchedRequestBody = toShortfinBatchedRequestBody([
       givenRequest.textToImageRequestBody,
     ]);
 


### PR DESCRIPTION
- pinning down the semantics helps communicate the role of each unit, making it easier to determine how they can be extracted and modularized
- for this particular implementation (SDXL TextToImage), even though "generation" is accurate, there isn't any other type of request to me made.
- ergo, there's no need to specify