### PR TITLE
refactor(library/ShimmedStabilityAIClient): prefers "derived" to mean "from conversion"

### DIFF
--- a/src/library/ShimmedStabilityAIClient/definition.ts
+++ b/src/library/ShimmedStabilityAIClient/definition.ts
@@ -82,12 +82,12 @@ class ImageClient
   public async forciblyGenerateFromText(
     givenRequest: GenerateFromTextRequest,
   ): Promise<GenerateFromTextResponse> {
-    const shimmedBatchedRequestBody = toShortfinBatchedRequestBody([
+    const derivedBatchedRequestBody = toShortfinBatchedRequestBody([
       givenRequest.textToImageRequestBody,
     ]);
 
     const outcomeOfSubmittingResource = await this.submitResource({
-      bySending: shimmedBatchedRequestBody,
+      bySending: derivedBatchedRequestBody,
       to       : generationEndpoint,
     });
 


### PR DESCRIPTION
- pinning down the semantics helps communicate the role of each unit, making it easier to determine how they can be extracted and modularized
- "shimmed" is a broader term to mean "nudged into place", which is what the "ShimmedStabilityAIClient" does overall with Shortfin
- but for this specific line, the "nudge" is a conversion to "derive" what the batched request body should be