### PR TITLE
ci(dependabot): approves dependencies for patch bumps when approved for minor bumps

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -36,7 +36,7 @@ jobs:
           )
           && (steps.metadata.outputs.update-type == 'version-update:semver-patch')
         run: gh pr review --approve "$PR_URL"
-      - name: 'Approve select dependencies for bump: minor'
+      - name: 'Approve select dependencies for bump: patch, minor'
         if: |
           contains(
             fromJSON('[

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -51,6 +51,7 @@ jobs:
             steps.metadata.outputs.dependency-names
           )
           && (
+            (steps.metadata.outputs.update-type == 'version-update:semver-patch') ||
             (steps.metadata.outputs.update-type == 'version-update:semver-minor')
           )
         run: gh pr review --approve "$PR_URL"

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -50,5 +50,7 @@ jobs:
             ]'),
             steps.metadata.outputs.dependency-names
           )
-          && (steps.metadata.outputs.update-type == 'version-update:semver-minor')
+          && (
+            (steps.metadata.outputs.update-type == 'version-update:semver-minor')
+          )
         run: gh pr review --approve "$PR_URL"


### PR DESCRIPTION
- approvals are supposed to be layered
- intent: approve dependency bumps up _through_ "minor" (includes "patch")
- reality: approve minor dependency bumps only

Incited by #663 not being automatically merged as expected