### PR TITLE
ci(dependabot): auto-approves non-major bumps to @stylistic/eslint-plugin

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -40,6 +40,7 @@ jobs:
         if: |
           contains(
             fromJSON('[
+              "@stylistic/eslint-plugin",
               "@typescript-eslint/parser",
               "@types/node",
               "eslint",


### PR DESCRIPTION
- changes to `@stylistic/eslint-plugin` that conflict with this codebase will always trigger the CI's linter step to fail
- `@stylistic/eslint-plugin` doesn't actually dictate implementation, just how it's written, so the testing pipeline will always yield the same result before and after the version bump if the linter still passes
- because of this, non-major bumps are safe to automatically approve
- pairing that with auto-merge upon passing required checks, maintainers will seldom have to intervene for this frequently updated dependency 