### PR TITLE
ci(dependabot): auto-approves non-major bumps to cypress 

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -43,6 +43,7 @@ jobs:
               "@stylistic/eslint-plugin",
               "@typescript-eslint/parser",
               "@types/node",
+              "cypress",
               "eslint",
               "eslint-plugin-vue",
               "typescript-eslint",


### PR DESCRIPTION
- `cypress` is the tooling for end-to-end testing
- it doesn't directly affect implementation, it only measures it
- as of this PR, there's no coverage yet
- prior to _having_ any coverage, the CI will be updated to run the testing suite, which will warn of any breaking changes due to non-major bumps