### PR TITLE
refactor(library/ShimmedStabilityAIClient): prefers explicit filtering

### DIFF
--- a/src/library/ShimmedStabilityAIClient/definition.ts
+++ b/src/library/ShimmedStabilityAIClient/definition.ts
@@ -28,7 +28,7 @@ const toShortfinBatchedRequestBody = (
 
   const derivedBatchedRequestBody = givenRequestBodies
     .map(toShortfinRequestBody)
-    .filter(() => true)
+    .filter($0 => $0 !== null)
     .reduce((runningBatchedRequestBody, eachShortfinRequestBody) => {
       if (
         eachShortfinRequestBody !== null

--- a/src/library/ShimmedStabilityAIClient/definition.ts
+++ b/src/library/ShimmedStabilityAIClient/definition.ts
@@ -28,6 +28,7 @@ const toShortfinBatchedRequestBody = (
 
   const derivedBatchedRequestBody = givenRequestBodies
     .map(toShortfinRequestBody)
+    .filter(() => true)
     .reduce((runningBatchedRequestBody, eachShortfinRequestBody) => {
       if (
         eachShortfinRequestBody !== null

--- a/src/library/ShimmedStabilityAIClient/definition.ts
+++ b/src/library/ShimmedStabilityAIClient/definition.ts
@@ -30,10 +30,7 @@ const toShortfinBatchedRequestBody = (
     .map(toShortfinRequestBody)
     .filter($0 => $0 !== null)
     .reduce((runningBatchedRequestBody, eachShortfinRequestBody) => {
-      if (
-        eachShortfinRequestBody !== null
-      ) runningBatchedRequestBody.append(eachShortfinRequestBody);
-
+      runningBatchedRequestBody.append(eachShortfinRequestBody);
       return runningBatchedRequestBody;
     }, emptyBatchedRequestBody);
 


### PR DESCRIPTION
- the arrays are too small (10 elements max) to justify sacrificing readability for negligible performance gains

Facilitates #680