### PR TITLE
refactor(library/ShimmedStabilityAIClient): prefers explicit mapping

### DIFF
--- a/src/library/ShimmedStabilityAIClient/definition.ts
+++ b/src/library/ShimmedStabilityAIClient/definition.ts
@@ -26,15 +26,16 @@ const toShortfinBatchedRequestBody = (
 ): Shortfin.TextToImage.SDXL.Client.Request.Body.Batched => {
   const emptyBatchedRequestBody = new Shortfin.TextToImage.SDXL.Client.Request.Body.Batched();
 
-  const derivedBatchedRequestBody = givenRequestBodies.reduce((runningBatchedRequestBody, eachStabilityAIRequestBody) => {
-    const eachShortfinRequestBody = toShortfinRequestBody(eachStabilityAIRequestBody);
+  const derivedBatchedRequestBody = givenRequestBodies
+    .reduce((runningBatchedRequestBody, eachStabilityAIRequestBody) => {
+      const eachShortfinRequestBody = toShortfinRequestBody(eachStabilityAIRequestBody);
 
-    if (
-      eachShortfinRequestBody !== null
-    ) runningBatchedRequestBody.append(eachShortfinRequestBody);
+      if (
+        eachShortfinRequestBody !== null
+      ) runningBatchedRequestBody.append(eachShortfinRequestBody);
 
-    return runningBatchedRequestBody;
-  }, emptyBatchedRequestBody);
+      return runningBatchedRequestBody;
+    }, emptyBatchedRequestBody);
 
   return derivedBatchedRequestBody;
 };

--- a/src/library/ShimmedStabilityAIClient/definition.ts
+++ b/src/library/ShimmedStabilityAIClient/definition.ts
@@ -27,9 +27,9 @@ const toShortfinBatchedRequestBody = (
   const emptyBatchedRequestBody = new Shortfin.TextToImage.SDXL.Client.Request.Body.Batched();
 
   const derivedBatchedRequestBody = givenRequestBodies
-    .map($0 => $0)
+    .map($0 => toShortfinRequestBody($0))
     .reduce((runningBatchedRequestBody, eachStabilityAIRequestBody) => {
-      const eachShortfinRequestBody = toShortfinRequestBody(eachStabilityAIRequestBody);
+      const eachShortfinRequestBody = eachStabilityAIRequestBody;
 
       if (
         eachShortfinRequestBody !== null

--- a/src/library/ShimmedStabilityAIClient/definition.ts
+++ b/src/library/ShimmedStabilityAIClient/definition.ts
@@ -27,7 +27,7 @@ const toShortfinBatchedRequestBody = (
   const emptyBatchedRequestBody = new Shortfin.TextToImage.SDXL.Client.Request.Body.Batched();
 
   const derivedBatchedRequestBody = givenRequestBodies
-    .map($0 => toShortfinRequestBody($0))
+    .map(toShortfinRequestBody)
     .reduce((runningBatchedRequestBody, eachStabilityAIRequestBody) => {
       const eachShortfinRequestBody = eachStabilityAIRequestBody;
 

--- a/src/library/ShimmedStabilityAIClient/definition.ts
+++ b/src/library/ShimmedStabilityAIClient/definition.ts
@@ -28,9 +28,7 @@ const toShortfinBatchedRequestBody = (
 
   const derivedBatchedRequestBody = givenRequestBodies
     .map(toShortfinRequestBody)
-    .reduce((runningBatchedRequestBody, eachStabilityAIRequestBody) => {
-      const eachShortfinRequestBody = eachStabilityAIRequestBody;
-
+    .reduce((runningBatchedRequestBody, eachShortfinRequestBody) => {
       if (
         eachShortfinRequestBody !== null
       ) runningBatchedRequestBody.append(eachShortfinRequestBody);

--- a/src/library/ShimmedStabilityAIClient/definition.ts
+++ b/src/library/ShimmedStabilityAIClient/definition.ts
@@ -27,6 +27,7 @@ const toShortfinBatchedRequestBody = (
   const emptyBatchedRequestBody = new Shortfin.TextToImage.SDXL.Client.Request.Body.Batched();
 
   const derivedBatchedRequestBody = givenRequestBodies
+    .map($0 => $0)
     .reduce((runningBatchedRequestBody, eachStabilityAIRequestBody) => {
       const eachShortfinRequestBody = toShortfinRequestBody(eachStabilityAIRequestBody);
 


### PR DESCRIPTION
- the arrays are too small (10 elements max) to justify sacrificing readability for negligible performance gains

Facilitates #680