### PR TITLE
refactor(library/ShimmedStabilityAIClient): labels intermediate conversions

### DIFF
--- a/src/library/ShimmedStabilityAIClient/definition.ts
+++ b/src/library/ShimmedStabilityAIClient/definition.ts
@@ -24,11 +24,11 @@ import {
 const toShortfinBatchedRequestBody = (
   givenRequestBodies: GenerateFromTextRequest['textToImageRequestBody'][],
 ): Shortfin.TextToImage.SDXL.Client.Request.Body.Batched => {
-  const emptyBatchedRequestBody = new Shortfin.TextToImage.SDXL.Client.Request.Body.Batched();
-
   const derivedShortfinRequestBodies = givenRequestBodies
     .map(toShortfinRequestBody)
     .filter($0 => $0 !== null);
+
+  const emptyBatchedRequestBody = new Shortfin.TextToImage.SDXL.Client.Request.Body.Batched();
 
   const derivedBatchedRequestBody = derivedShortfinRequestBodies
     .reduce((runningBatchedRequestBody, eachShortfinRequestBody) => {

--- a/src/library/ShimmedStabilityAIClient/definition.ts
+++ b/src/library/ShimmedStabilityAIClient/definition.ts
@@ -26,9 +26,11 @@ const toShortfinBatchedRequestBody = (
 ): Shortfin.TextToImage.SDXL.Client.Request.Body.Batched => {
   const emptyBatchedRequestBody = new Shortfin.TextToImage.SDXL.Client.Request.Body.Batched();
 
-  const derivedBatchedRequestBody = givenRequestBodies
+  const derivedShortfinRequestBodies = givenRequestBodies
     .map(toShortfinRequestBody)
-    .filter($0 => $0 !== null)
+    .filter($0 => $0 !== null);
+
+  const derivedBatchedRequestBody = derivedShortfinRequestBodies
     .reduce((runningBatchedRequestBody, eachShortfinRequestBody) => {
       runningBatchedRequestBody.append(eachShortfinRequestBody);
       return runningBatchedRequestBody;


### PR DESCRIPTION
- helps pin down the mental model for the middle steps, which makes adjacent steps easier to refactor

Facilitates #681