### PR TITLE
refactor(library/ShimmedStabilityAIClient): avoids roundabout reuse of reference to compile batched body

### DIFF
--- a/src/library/ShimmedStabilityAIClient/definition.ts
+++ b/src/library/ShimmedStabilityAIClient/definition.ts
@@ -30,13 +30,13 @@ const toShortfinBatchedRequestBody = (
 
   const emptyBatchedRequestBody = new Shortfin.TextToImage.SDXL.Client.Request.Body.Batched();
 
-  const derivedBatchedRequestBody = derivedShortfinRequestBodies
+  const alsoDerivedBatchedRequestBody = derivedShortfinRequestBodies
     .reduce((runningBatchedRequestBody, eachShortfinRequestBody) => {
       runningBatchedRequestBody.append(eachShortfinRequestBody);
       return runningBatchedRequestBody;
     }, emptyBatchedRequestBody);
 
-  return derivedBatchedRequestBody;
+  return alsoDerivedBatchedRequestBody;
 };
 
 const Shortfin_TextToImage_SDXL_Client_Response_Body = {

--- a/src/library/ShimmedStabilityAIClient/definition.ts
+++ b/src/library/ShimmedStabilityAIClient/definition.ts
@@ -31,10 +31,9 @@ const toShortfinBatchedRequestBody = (
   const derivedBatchedRequestBody = new Shortfin.TextToImage.SDXL.Client.Request.Body.Batched();
 
   derivedShortfinRequestBodies
-    .reduce((_, eachShortfinRequestBody) => {
+    .forEach((eachShortfinRequestBody) => {
       derivedBatchedRequestBody.append(eachShortfinRequestBody);
-      return undefined;
-    }, undefined);
+    });
 
   return derivedBatchedRequestBody;
 };

--- a/src/library/ShimmedStabilityAIClient/definition.ts
+++ b/src/library/ShimmedStabilityAIClient/definition.ts
@@ -30,13 +30,13 @@ const toShortfinBatchedRequestBody = (
 
   const derivedBatchedRequestBody = new Shortfin.TextToImage.SDXL.Client.Request.Body.Batched();
 
-  const alsoDerivedBatchedRequestBody = derivedShortfinRequestBodies
+  derivedShortfinRequestBodies
     .reduce((runningBatchedRequestBody, eachShortfinRequestBody) => {
       runningBatchedRequestBody.append(eachShortfinRequestBody);
       return runningBatchedRequestBody;
     }, derivedBatchedRequestBody);
 
-  return alsoDerivedBatchedRequestBody;
+  return derivedBatchedRequestBody;
 };
 
 const Shortfin_TextToImage_SDXL_Client_Response_Body = {

--- a/src/library/ShimmedStabilityAIClient/definition.ts
+++ b/src/library/ShimmedStabilityAIClient/definition.ts
@@ -31,10 +31,10 @@ const toShortfinBatchedRequestBody = (
   const derivedBatchedRequestBody = new Shortfin.TextToImage.SDXL.Client.Request.Body.Batched();
 
   derivedShortfinRequestBodies
-    .reduce((runningBatchedRequestBody, eachShortfinRequestBody) => {
+    .reduce((_, eachShortfinRequestBody) => {
       derivedBatchedRequestBody.append(eachShortfinRequestBody);
-      return runningBatchedRequestBody;
-    }, derivedBatchedRequestBody);
+      return undefined;
+    }, undefined);
 
   return derivedBatchedRequestBody;
 };

--- a/src/library/ShimmedStabilityAIClient/definition.ts
+++ b/src/library/ShimmedStabilityAIClient/definition.ts
@@ -28,13 +28,13 @@ const toShortfinBatchedRequestBody = (
     .map(toShortfinRequestBody)
     .filter($0 => $0 !== null);
 
-  const emptyBatchedRequestBody = new Shortfin.TextToImage.SDXL.Client.Request.Body.Batched();
+  const derivedBatchedRequestBody = new Shortfin.TextToImage.SDXL.Client.Request.Body.Batched();
 
   const alsoDerivedBatchedRequestBody = derivedShortfinRequestBodies
     .reduce((runningBatchedRequestBody, eachShortfinRequestBody) => {
       runningBatchedRequestBody.append(eachShortfinRequestBody);
       return runningBatchedRequestBody;
-    }, emptyBatchedRequestBody);
+    }, derivedBatchedRequestBody);
 
   return alsoDerivedBatchedRequestBody;
 };

--- a/src/library/ShimmedStabilityAIClient/definition.ts
+++ b/src/library/ShimmedStabilityAIClient/definition.ts
@@ -30,10 +30,9 @@ const toShortfinBatchedRequestBody = (
 
   const derivedBatchedRequestBody = new Shortfin.TextToImage.SDXL.Client.Request.Body.Batched();
 
-  derivedShortfinRequestBodies
-    .forEach((eachShortfinRequestBody) => {
-      derivedBatchedRequestBody.append(eachShortfinRequestBody);
-    });
+  derivedShortfinRequestBodies.forEach((eachShortfinRequestBody) => {
+    derivedBatchedRequestBody.append(eachShortfinRequestBody);
+  });
 
   return derivedBatchedRequestBody;
 };

--- a/src/library/ShimmedStabilityAIClient/definition.ts
+++ b/src/library/ShimmedStabilityAIClient/definition.ts
@@ -32,7 +32,7 @@ const toShortfinBatchedRequestBody = (
 
   derivedShortfinRequestBodies
     .reduce((runningBatchedRequestBody, eachShortfinRequestBody) => {
-      runningBatchedRequestBody.append(eachShortfinRequestBody);
+      derivedBatchedRequestBody.append(eachShortfinRequestBody);
       return runningBatchedRequestBody;
     }, derivedBatchedRequestBody);
 


### PR DESCRIPTION
- instead of passing the same reference via `.reduce(...)`, just use `.forEach(...)` to capture the reference

Pre-req for #682