### PR TITLE
refactor: ensures namespaces are visible to intellisense

### DIFF
--- a/src/library/Attempt/index.ts
+++ b/src/library/Attempt/index.ts
@@ -1,1 +1,5 @@
-export * as default from './exports.ts';
+import * as Attempt from './exports.ts';
+
+export {
+  Attempt as default,
+};

--- a/src/library/Base64/index.ts
+++ b/src/library/Base64/index.ts
@@ -1,1 +1,5 @@
-export * as default from './exports.ts';
+import * as Base64 from './exports.ts';
+
+export {
+  Base64 as default,
+};

--- a/src/library/Byte/index.ts
+++ b/src/library/Byte/index.ts
@@ -1,1 +1,5 @@
-export * as default from './exports.ts';
+import * as Byte from './exports.ts';
+
+export {
+  Byte as default,
+};

--- a/src/library/HTTP/index.ts
+++ b/src/library/HTTP/index.ts
@@ -1,1 +1,5 @@
-export * as default from './exports.ts';
+import * as HTTP from './exports.ts';
+
+export {
+  HTTP as default,
+};

--- a/src/library/Schema.ts
+++ b/src/library/Schema.ts
@@ -1,5 +1,5 @@
-import * as z from 'zod';
+import * as Schema from 'zod';
 
 export {
-  z as default,
+  Schema as default,
 };


### PR DESCRIPTION
- when the index files lack a namespace import, intellisense can't help with automatic imports

Reverts [this commit](https://github.com/nod-ai/shark-ui/pull/607/commits/734d7e8fc8be0904af70471dbcd770c88b527adb) within #607