### PR TITLE
fix: avoids non-actionable error propagation in `Schema` transformations

### DIFF
--- a/src/library/Shortfin/TextToImage/SDXL/Client/Response/Body/definition.ts
+++ b/src/library/Shortfin/TextToImage/SDXL/Client/Response/Body/definition.ts
@@ -15,7 +15,7 @@ const Shortfin_TextToImage_SDXL_Client_Response_Body = {
         message: outcomeOfParsingSubject.cause.message,
       });
 
-      return outcomeOfParsingSubject.forciblyUnwrap(/* TODO: safely adapt errors so it can propagate to encompassing schemas */);
+      return Schema.NEVER;
     }),
     get images() {
       return Schema.tuple([this.image]).rest(this.image);

--- a/src/library/Shortfin/TextToImage/SDXL/Client/Response/Body/definition.ts
+++ b/src/library/Shortfin/TextToImage/SDXL/Client/Response/Body/definition.ts
@@ -4,7 +4,8 @@ import Schema from '@/library/Schema';
 const Shortfin_TextToImage_SDXL_Client_Response_Body = {
   SchemaMember: {
     image: Schema.string().transform((someSubject) => {
-      return Base64CharacterEncodedByteSequence.parsedFrom(someSubject).forciblyUnwrap(/* TODO: safely adapt errors so it can propagate to encompassing schemas */);
+      const outcomeOfParsingSubject = Base64CharacterEncodedByteSequence.parsedFrom(someSubject);
+      return outcomeOfParsingSubject.forciblyUnwrap(/* TODO: safely adapt errors so it can propagate to encompassing schemas */);
     }),
     get images() {
       return Schema.tuple([this.image]).rest(this.image);

--- a/src/library/Shortfin/TextToImage/SDXL/Client/Response/Body/definition.ts
+++ b/src/library/Shortfin/TextToImage/SDXL/Client/Response/Body/definition.ts
@@ -5,6 +5,11 @@ const Shortfin_TextToImage_SDXL_Client_Response_Body = {
   SchemaMember: {
     image: Schema.string().transform((someSubject) => {
       const outcomeOfParsingSubject = Base64CharacterEncodedByteSequence.parsedFrom(someSubject);
+
+      if (
+        outcomeOfParsingSubject.isSuccess
+      ) return outcomeOfParsingSubject.unwrapped;
+
       return outcomeOfParsingSubject.forciblyUnwrap(/* TODO: safely adapt errors so it can propagate to encompassing schemas */);
     }),
     get images() {

--- a/src/library/Shortfin/TextToImage/SDXL/Client/Response/Body/definition.ts
+++ b/src/library/Shortfin/TextToImage/SDXL/Client/Response/Body/definition.ts
@@ -4,7 +4,7 @@ import Schema from '@/library/Schema';
 const Shortfin_TextToImage_SDXL_Client_Response_Body = {
   SchemaMember: {
     image: Schema.string().transform((someSubject) => {
-      return Base64CharacterEncodedByteSequence.parsedFrom(someSubject).forciblyUnwrap(/* Zod can safely propagate errors */);
+      return Base64CharacterEncodedByteSequence.parsedFrom(someSubject).forciblyUnwrap(/* TODO: safely adapt errors so it can propagate to encompassing schemas */);
     }),
     get images() {
       return Schema.tuple([this.image]).rest(this.image);

--- a/src/library/Shortfin/TextToImage/SDXL/Client/Response/Body/definition.ts
+++ b/src/library/Shortfin/TextToImage/SDXL/Client/Response/Body/definition.ts
@@ -3,12 +3,17 @@ import Schema from '@/library/Schema';
 
 const Shortfin_TextToImage_SDXL_Client_Response_Body = {
   SchemaMember: {
-    image: Schema.string().transform((someSubject) => {
+    image: Schema.string().transform((someSubject, currentContext) => {
       const outcomeOfParsingSubject = Base64CharacterEncodedByteSequence.parsedFrom(someSubject);
 
       if (
         outcomeOfParsingSubject.isSuccess
       ) return outcomeOfParsingSubject.unwrapped;
+
+      currentContext.addIssue({
+        code   : 'custom',
+        message: outcomeOfParsingSubject.cause.message,
+      });
 
       return outcomeOfParsingSubject.forciblyUnwrap(/* TODO: safely adapt errors so it can propagate to encompassing schemas */);
     }),


### PR DESCRIPTION
- non-actionable errors are the only errors `throw`n in this project
- one way that happens is force-unwrapping an outcome when it should've been discriminated with control flow
- in [Zod's documentation for using transformations:](https://zod.dev/api?id=transforms)
    > Refinement functions should never throw. Thrown errors are not caught by Zod.
- ergo, there should be no force-unwrappings in Zod transformations