### PR TITLE
refactor: centralizes definition of schema for `Base64CharacterEncodedByteSequence`

### DIFF
--- a/src/library/Schema.ts
+++ b/src/library/Schema.ts
@@ -1,5 +1,0 @@
-import * as Schema from 'zod';
-
-export {
-  Schema as default,
-};

--- a/src/library/Schema/base64CharacterEncodedByteSequence.ts
+++ b/src/library/Schema/base64CharacterEncodedByteSequence.ts
@@ -1,0 +1,26 @@
+import Base64CharacterEncodedByteSequence from '@/library/Base64CharacterEncodedByteSequence';
+
+import {
+  string as Schema_string,
+  NEVER as Schema_NEVER,
+} from './core';
+
+/** An alternative to `Schema.base64()` that avoids using the deprecated `atob` conversion under the hood */
+const Schema_base64CharacterEncodedByteSequence = () => Schema_string().transform((someSubject, currentContext) => {
+  const outcomeOfParsingSubject = Base64CharacterEncodedByteSequence.parsedFrom(someSubject);
+
+  if (
+    outcomeOfParsingSubject.isSuccess
+  ) return outcomeOfParsingSubject.unwrapped;
+
+  currentContext.addIssue({
+    code   : 'custom',
+    message: outcomeOfParsingSubject.cause.message,
+  });
+
+  return Schema_NEVER;
+});
+
+export {
+  Schema_base64CharacterEncodedByteSequence,
+};

--- a/src/library/Schema/core.ts
+++ b/src/library/Schema/core.ts
@@ -1,0 +1,1 @@
+export * from 'zod';

--- a/src/library/Schema/exports.ts
+++ b/src/library/Schema/exports.ts
@@ -1,0 +1,1 @@
+export * from './core';

--- a/src/library/Schema/exports.ts
+++ b/src/library/Schema/exports.ts
@@ -1,1 +1,5 @@
 export * from './core';
+
+export {
+  Schema_base64CharacterEncodedByteSequence as base64CharacterEncodedByteSequence,
+} from './base64CharacterEncodedByteSequence';

--- a/src/library/Schema/index.ts
+++ b/src/library/Schema/index.ts
@@ -1,0 +1,5 @@
+import * as Schema from './exports';
+
+export {
+  Schema as default,
+};

--- a/src/library/Shortfin/TextToImage/SDXL/Client/Response/Body/definition.ts
+++ b/src/library/Shortfin/TextToImage/SDXL/Client/Response/Body/definition.ts
@@ -1,22 +1,8 @@
-import Base64CharacterEncodedByteSequence from '@/library/Base64CharacterEncodedByteSequence';
 import Schema from '@/library/Schema';
 
 const Shortfin_TextToImage_SDXL_Client_Response_Body = {
   SchemaMember: {
-    image: Schema.string().transform((someSubject, currentContext) => {
-      const outcomeOfParsingSubject = Base64CharacterEncodedByteSequence.parsedFrom(someSubject);
-
-      if (
-        outcomeOfParsingSubject.isSuccess
-      ) return outcomeOfParsingSubject.unwrapped;
-
-      currentContext.addIssue({
-        code   : 'custom',
-        message: outcomeOfParsingSubject.cause.message,
-      });
-
-      return Schema.NEVER;
-    }),
+    image: Schema.base64CharacterEncodedByteSequence(),
     get images() {
       return Schema.tuple([this.image]).rest(this.image);
     },


### PR DESCRIPTION
Follows up on #632 