### PR TITLE
refactor(library/shortfin): simplifies `*.Response.Body.SchemaMember`

### DIFF
--- a/src/library/Shortfin/TextToImage/SDXL/Client/Response/Body/definition.ts
+++ b/src/library/Shortfin/TextToImage/SDXL/Client/Response/Body/definition.ts
@@ -5,8 +5,12 @@ const Shortfin_TextToImage_SDXL_Client_Response_Body = {
     image: Schema.base64CharacterEncodedByteSequence(),
     get images() {
       return Schema
-        .tuple([this.image])
-        .rest(this.image);
+        .tuple([
+          this.image,
+        ])
+        .rest(
+          this.image,
+        );
     },
   },
   get Schema() {

--- a/src/library/Shortfin/TextToImage/SDXL/Client/Response/Body/definition.ts
+++ b/src/library/Shortfin/TextToImage/SDXL/Client/Response/Body/definition.ts
@@ -2,15 +2,13 @@ import Schema from '@/library/Schema';
 
 const Shortfin_TextToImage_SDXL_Client_Response_Body = {
   SchemaMember: {
-    get images() {
-      return Schema
-        .tuple([
-          Schema.base64CharacterEncodedByteSequence(),
-        ])
-        .rest(
-          Schema.base64CharacterEncodedByteSequence(),
-        );
-    },
+    images: Schema
+      .tuple([
+        Schema.base64CharacterEncodedByteSequence(),
+      ])
+      .rest(
+        Schema.base64CharacterEncodedByteSequence(),
+      ),
   },
   get Schema() {
     return Schema.object({

--- a/src/library/Shortfin/TextToImage/SDXL/Client/Response/Body/definition.ts
+++ b/src/library/Shortfin/TextToImage/SDXL/Client/Response/Body/definition.ts
@@ -4,7 +4,9 @@ const Shortfin_TextToImage_SDXL_Client_Response_Body = {
   SchemaMember: {
     image: Schema.base64CharacterEncodedByteSequence(),
     get images() {
-      return Schema.tuple([this.image]).rest(this.image);
+      return Schema
+        .tuple([this.image])
+        .rest(this.image);
     },
   },
   get Schema() {

--- a/src/library/Shortfin/TextToImage/SDXL/Client/Response/Body/definition.ts
+++ b/src/library/Shortfin/TextToImage/SDXL/Client/Response/Body/definition.ts
@@ -2,14 +2,13 @@ import Schema from '@/library/Schema';
 
 const Shortfin_TextToImage_SDXL_Client_Response_Body = {
   SchemaMember: {
-    image: Schema.base64CharacterEncodedByteSequence(),
     get images() {
       return Schema
         .tuple([
-          this.image,
+          Schema.base64CharacterEncodedByteSequence(),
         ])
         .rest(
-          this.image,
+          Schema.base64CharacterEncodedByteSequence(),
         );
     },
   },


### PR DESCRIPTION
- removes need for getters, reducing reliance on `this`

Made possible by #690 