### PR TITLE
refactor(library/Shortfin): simplifies `*.Response.Body.Schema`

### DIFF
--- a/src/library/Shortfin/TextToImage/SDXL/Client/Response/Body/definition.ts
+++ b/src/library/Shortfin/TextToImage/SDXL/Client/Response/Body/definition.ts
@@ -1,17 +1,15 @@
 import Schema from '@/library/Schema';
 
 const Shortfin_TextToImage_SDXL_Client_Response_Body = {
-  get Schema() {
-    return Schema.object({
-      images: Schema
-        .tuple([
-          Schema.base64CharacterEncodedByteSequence(),
-        ])
-        .rest(
-          Schema.base64CharacterEncodedByteSequence(),
-        ),
-    });
-  },
+  Schema: Schema.object({
+    images: Schema
+      .tuple([
+        Schema.base64CharacterEncodedByteSequence(),
+      ])
+      .rest(
+        Schema.base64CharacterEncodedByteSequence(),
+      ),
+  }),
 };
 
 export {

--- a/src/library/Shortfin/TextToImage/SDXL/Client/Response/Body/definition.ts
+++ b/src/library/Shortfin/TextToImage/SDXL/Client/Response/Body/definition.ts
@@ -1,6 +1,11 @@
 import Schema from '@/library/Schema';
 
 const Shortfin_TextToImage_SDXL_Client_Response_Body = {
+  get Schema() {
+    return Schema.object({
+      images: this.SchemaMember.images,
+    });
+  },
   SchemaMember: {
     images: Schema
       .tuple([
@@ -9,11 +14,6 @@ const Shortfin_TextToImage_SDXL_Client_Response_Body = {
       .rest(
         Schema.base64CharacterEncodedByteSequence(),
       ),
-  },
-  get Schema() {
-    return Schema.object({
-      images: this.SchemaMember.images,
-    });
   },
 };
 

--- a/src/library/Shortfin/TextToImage/SDXL/Client/Response/Body/definition.ts
+++ b/src/library/Shortfin/TextToImage/SDXL/Client/Response/Body/definition.ts
@@ -3,17 +3,14 @@ import Schema from '@/library/Schema';
 const Shortfin_TextToImage_SDXL_Client_Response_Body = {
   get Schema() {
     return Schema.object({
-      images: this.SchemaMember.images,
+      images: Schema
+        .tuple([
+          Schema.base64CharacterEncodedByteSequence(),
+        ])
+        .rest(
+          Schema.base64CharacterEncodedByteSequence(),
+        ),
     });
-  },
-  SchemaMember: {
-    images: Schema
-      .tuple([
-        Schema.base64CharacterEncodedByteSequence(),
-      ])
-      .rest(
-        Schema.base64CharacterEncodedByteSequence(),
-      ),
   },
 };
 


### PR DESCRIPTION
- reduces runtime cost by removing need for getter

Made possible by #691