### PR TITLE
fix(library/Shortfin): ensures ` *.Client.Response.Body` is opaque in intellisense

### DIFF
--- a/src/library/Shortfin/TextToImage/SDXL/Client/Response/Body/definition.ts
+++ b/src/library/Shortfin/TextToImage/SDXL/Client/Response/Body/definition.ts
@@ -1,7 +1,8 @@
 import Schema from '@/library/Schema';
 
-const Shortfin_TextToImage_SDXL_Client_Response_Body = {
-  Schema: Schema.object({
+// eslint-disable-next-line @typescript-eslint/no-extraneous-class
+class Shortfin_TextToImage_SDXL_Client_Response_Body {
+  public static Schema = Schema.object({
     images: Schema
       .tuple([
         Schema.base64CharacterEncodedByteSequence(),
@@ -9,8 +10,8 @@ const Shortfin_TextToImage_SDXL_Client_Response_Body = {
       .rest(
         Schema.base64CharacterEncodedByteSequence(),
       ),
-  }),
-};
+  });
+}
 
 export {
   Shortfin_TextToImage_SDXL_Client_Response_Body,

--- a/src/library/Shortfin/TextToImage/SDXL/Client/Response/Body/definition.ts
+++ b/src/library/Shortfin/TextToImage/SDXL/Client/Response/Body/definition.ts
@@ -1,7 +1,14 @@
+import type Base64CharacterEncodedByteSequence from '@/library/Base64CharacterEncodedByteSequence';
 import Schema from '@/library/Schema';
 
-// eslint-disable-next-line @typescript-eslint/no-extraneous-class
 class Shortfin_TextToImage_SDXL_Client_Response_Body {
+  public constructor(
+    public images: [
+      Base64CharacterEncodedByteSequence,
+      ...Base64CharacterEncodedByteSequence[],
+    ],
+  ) {}
+
   public static Schema = Schema
     .object({
       images: Schema
@@ -11,7 +18,10 @@ class Shortfin_TextToImage_SDXL_Client_Response_Body {
         .rest(
           Schema.base64CharacterEncodedByteSequence(),
         ),
-    });
+    })
+    .transform($0 => new Shortfin_TextToImage_SDXL_Client_Response_Body(
+      $0.images,
+    ));
 }
 
 export {

--- a/src/library/Shortfin/TextToImage/SDXL/Client/Response/Body/definition.ts
+++ b/src/library/Shortfin/TextToImage/SDXL/Client/Response/Body/definition.ts
@@ -2,15 +2,16 @@ import Schema from '@/library/Schema';
 
 // eslint-disable-next-line @typescript-eslint/no-extraneous-class
 class Shortfin_TextToImage_SDXL_Client_Response_Body {
-  public static Schema = Schema.object({
-    images: Schema
-      .tuple([
-        Schema.base64CharacterEncodedByteSequence(),
-      ])
-      .rest(
-        Schema.base64CharacterEncodedByteSequence(),
-      ),
-  });
+  public static Schema = Schema
+    .object({
+      images: Schema
+        .tuple([
+          Schema.base64CharacterEncodedByteSequence(),
+        ])
+        .rest(
+          Schema.base64CharacterEncodedByteSequence(),
+        ),
+    });
 }
 
 export {


### PR DESCRIPTION
- before, the type signature would show up as the object literal no matter where it was used in the codebase:
   ```typescript
   {
     images: [Base64CharacterEncodedByteSequence, ...Base64CharacterEncodedByteSequence[]]
   }
   ```
  - this wasn't very semantically valuable
- now, it shows up as a member of the namespace
   ```typescript
   Shortfin.TextToImage.SDXL.Client.Response.Body
   ```