### PR TITLE
types: ensures semantic distinction for generic parameters

### DIFF
--- a/src/library/Attempt/Outcome/Failure/Transformer.ts
+++ b/src/library/Attempt/Outcome/Failure/Transformer.ts
@@ -10,12 +10,12 @@ type CauseTransformer<
 ) => SomeTransformedActionableError;
 
 const causeIdentity = <
-  TransformableActionableError extends ActionableError<string>,
-  TransformedActionableError extends ActionableError<string>,
+  SomeTransformableActionableError extends ActionableError<string>,
+  SomeTransformedActionableError extends ActionableError<string>,
 >(
-  transformableCause: NoInfer<TransformableActionableError>,
-): NoInfer<TransformedActionableError> => {
-  return transformableCause as unknown as TransformedActionableError;
+  transformableCause: NoInfer<SomeTransformableActionableError>,
+): NoInfer<SomeTransformedActionableError> => {
+  return transformableCause as unknown as SomeTransformedActionableError;
 };
 
 interface Attempt_Failure_Transformer<

--- a/src/library/Attempt/Outcome/Failure/Transformer.ts
+++ b/src/library/Attempt/Outcome/Failure/Transformer.ts
@@ -19,12 +19,12 @@ const causeIdentity = <
 };
 
 interface Attempt_Failure_Transformer<
-  TransformableActionableError extends ActionableError<string>,
-  TransformedActionableError extends ActionableError<string>,
+  SomeTransformableActionableError extends ActionableError<string>,
+  SomeTransformedActionableError extends ActionableError<string>,
 > {
   cause: CauseTransformer<
-    TransformableActionableError,
-    TransformedActionableError
+    SomeTransformableActionableError,
+    SomeTransformedActionableError
   >;
 }
 

--- a/src/library/Attempt/Outcome/Failure/Transformer.ts
+++ b/src/library/Attempt/Outcome/Failure/Transformer.ts
@@ -3,11 +3,11 @@ import type {
 } from '../../error';
 
 type CauseTransformer<
-  TransformableActionableError extends ActionableError<string>,
-  TransformedActionableError extends ActionableError<string>,
+  SomeTransformableActionableError extends ActionableError<string>,
+  SomeTransformedActionableError extends ActionableError<string>,
 > = (
-  transformableCause: TransformableActionableError,
-) => TransformedActionableError;
+  transformableCause: SomeTransformableActionableError,
+) => SomeTransformedActionableError;
 
 const causeIdentity = <
   TransformableActionableError extends ActionableError<string>,

--- a/src/library/Attempt/Outcome/Success/Transformer.ts
+++ b/src/library/Attempt/Outcome/Success/Transformer.ts
@@ -6,12 +6,12 @@ type ProductTransformer<
 ) => SomeTransformedProduct;
 
 const productIdentity = <
-  TransformableProduct,
-  TransformedProduct,
+  SomeTransformableProduct,
+  SomeTransformedProduct,
 >(
-  transformableProduct: NoInfer<TransformableProduct>,
-): NoInfer<TransformedProduct> => {
-  return transformableProduct as unknown as TransformedProduct;
+  transformableProduct: NoInfer<SomeTransformableProduct>,
+): NoInfer<SomeTransformedProduct> => {
+  return transformableProduct as unknown as SomeTransformedProduct;
 };
 
 interface Attempt_Success_Transformer<

--- a/src/library/Attempt/Outcome/Success/Transformer.ts
+++ b/src/library/Attempt/Outcome/Success/Transformer.ts
@@ -15,12 +15,12 @@ const productIdentity = <
 };
 
 interface Attempt_Success_Transformer<
-  TransformableProduct,
-  TransformedProduct,
+  SomeTransformableProduct,
+  SomeTransformedProduct,
 > {
   product: ProductTransformer<
-    TransformableProduct,
-    TransformedProduct
+    SomeTransformableProduct,
+    SomeTransformedProduct
   >;
 }
 

--- a/src/library/Attempt/Outcome/Success/Transformer.ts
+++ b/src/library/Attempt/Outcome/Success/Transformer.ts
@@ -1,9 +1,9 @@
 type ProductTransformer<
-  TransformableProduct,
-  TransformedProduct,
+  SomeTransformableProduct,
+  SomeTransformedProduct,
 > = (
-  transformableProduct: TransformableProduct,
-) => TransformedProduct;
+  transformableProduct: SomeTransformableProduct,
+) => SomeTransformedProduct;
 
 const productIdentity = <
   TransformableProduct,

--- a/src/library/Attempt/Outcome/Transformer.ts
+++ b/src/library/Attempt/Outcome/Transformer.ts
@@ -11,36 +11,36 @@ import type {
 } from './Success/Transformer';
 
 type Attempt_Outcome_Transformer<
-  TransformableProduct,
-  TransformableActionableError extends ActionableError<string>,
-  TransformedProduct,
-  TransformedActionableError extends ActionableError<string>,
+  SomeTransformableProduct,
+  SomeTransformableActionableError extends ActionableError<string>,
+  SomeTransformedProduct,
+  SomeTransformedActionableError extends ActionableError<string>,
 > =
   | (
     & Required<
       Attempt_Success_Transformer<
-        TransformableProduct,
-        TransformedProduct
+        SomeTransformableProduct,
+        SomeTransformedProduct
       >
     >
     & Partial<
       Attempt_Failure_Transformer<
-        TransformableActionableError,
-        TransformedActionableError
+        SomeTransformableActionableError,
+        SomeTransformedActionableError
       >
     >
   )
   | (
     & Partial<
       Attempt_Success_Transformer<
-        TransformableProduct,
-        TransformedProduct
+        SomeTransformableProduct,
+        SomeTransformedProduct
       >
     >
     & Required<
       Attempt_Failure_Transformer<
-        TransformableActionableError,
-        TransformedActionableError
+        SomeTransformableActionableError,
+        SomeTransformedActionableError
       >
     >
   )

--- a/src/library/Attempt/Outcome/exports.ts
+++ b/src/library/Attempt/Outcome/exports.ts
@@ -37,62 +37,62 @@ type Attempt_Outcome<
 * Helps avoid boilerplate when transforming outcomes.
 */
 function fromRewrapping<
-  TransformableActionableError extends ActionableError<string>,
-  TransformedActionableError extends ActionableError<string> = TransformableActionableError,
+  SomeTransformableActionableError extends ActionableError<string>,
+  SomeTransformedActionableError extends ActionableError<string> = SomeTransformableActionableError,
 >(
-  givenOutcome: Attempt_Failure<TransformableActionableError>,
+  givenOutcome: Attempt_Failure<SomeTransformableActionableError>,
   given?: Attempt_Failure_Transformer<
-    TransformableActionableError,
-    TransformedActionableError
+    SomeTransformableActionableError,
+    SomeTransformedActionableError
   >,
-): Attempt_Failure<TransformedActionableError>;
+): Attempt_Failure<SomeTransformedActionableError>;
 //
 function fromRewrapping<
-  TransformableProduct,
-  TransformedProduct = TransformableProduct,
+  SomeTransformableProduct,
+  SomeTransformedProduct = SomeTransformableProduct,
 >(
-  givenOutcome: Attempt_Success<TransformableProduct>,
+  givenOutcome: Attempt_Success<SomeTransformableProduct>,
   given?: Attempt_Success_Transformer<
-    TransformableProduct,
-    TransformedProduct
+    SomeTransformableProduct,
+    SomeTransformedProduct
   >,
-): Attempt_Success<TransformedProduct>;
+): Attempt_Success<SomeTransformedProduct>;
 //
 function fromRewrapping<
-  TransformableProduct,
-  TransformableActionableError extends ActionableError<string>,
-  TransformedProduct = TransformableProduct,
-  TransformedActionableError extends ActionableError<string> = TransformableActionableError,
+  SomeTransformableProduct,
+  SomeTransformableActionableError extends ActionableError<string>,
+  SomeTransformedProduct = SomeTransformableProduct,
+  SomeTransformedActionableError extends ActionableError<string> = SomeTransformableActionableError,
 >(
-  givenOutcome: Attempt_Outcome<TransformableProduct, TransformableActionableError>,
+  givenOutcome: Attempt_Outcome<SomeTransformableProduct, SomeTransformableActionableError>,
   given?: Attempt_Outcome_Transformer<
-    TransformableProduct,
-    TransformableActionableError,
-    TransformedProduct,
-    TransformedActionableError
+    SomeTransformableProduct,
+    SomeTransformableActionableError,
+    SomeTransformedProduct,
+    SomeTransformedActionableError
   >,
-): Attempt_Outcome<TransformedProduct, TransformedActionableError>;
+): Attempt_Outcome<SomeTransformedProduct, SomeTransformedActionableError>;
 //
 function fromRewrapping<
-  TransformableProduct,
-  TransformableActionableError extends ActionableError<string>,
-  TransformedProduct = TransformableProduct,
-  TransformedActionableError extends ActionableError<string> = TransformableActionableError,
+  SomeTransformableProduct,
+  SomeTransformableActionableError extends ActionableError<string>,
+  SomeTransformedProduct = SomeTransformableProduct,
+  SomeTransformedActionableError extends ActionableError<string> = SomeTransformableActionableError,
 >(
-  givenOutcome: Attempt_Outcome<TransformableProduct, TransformableActionableError>,
+  givenOutcome: Attempt_Outcome<SomeTransformableProduct, SomeTransformableActionableError>,
   {
-    product: toTransformedProduct = productIdentity<TransformableProduct, TransformedProduct>,
-    cause: toTransformedCause = causeIdentity<TransformableActionableError, TransformedActionableError>,
+    product: toTransformedProduct = productIdentity<SomeTransformableProduct, SomeTransformedProduct>,
+    cause: toTransformedCause = causeIdentity<SomeTransformableActionableError, SomeTransformedActionableError>,
   }: Attempt_Outcome_Transformer<
-    TransformableProduct,
-    TransformableActionableError,
-    TransformedProduct,
-    TransformedActionableError
+    SomeTransformableProduct,
+    SomeTransformableActionableError,
+    SomeTransformedProduct,
+    SomeTransformedActionableError
   > = {
-    product: productIdentity<TransformableProduct, TransformedProduct>,
-    cause  : causeIdentity<TransformableActionableError, TransformedActionableError>,
+    product: productIdentity<SomeTransformableProduct, SomeTransformedProduct>,
+    cause  : causeIdentity<SomeTransformableActionableError, SomeTransformedActionableError>,
   },
-): Attempt_Outcome<TransformedProduct, TransformedActionableError> {
+): Attempt_Outcome<SomeTransformedProduct, SomeTransformedActionableError> {
   return givenOutcome.isSuccess
     ? givenOutcome.rewrappedWith({
         product: toTransformedProduct,

--- a/src/library/Attempt/factory/asynchronous.ts
+++ b/src/library/Attempt/factory/asynchronous.ts
@@ -19,10 +19,10 @@ import {
 import AttemptCreationError from './AttemptCreationError';
 
 type Attempt_EndRetriever<
-  InferredOutcome extends Attempt_Outcome<unknown, ActionableError<string>>,
+  SomeInferredOutcome extends Attempt_Outcome<unknown, ActionableError<string>>,
 > = (
   givenHandles: typeof handles
-) => Promise<InferredOutcome>;
+) => Promise<SomeInferredOutcome>;
 
 const Attempt_thatEventually = async <
   InferredOutcome extends Attempt_Outcome<unknown, ActionableError<string>>,

--- a/src/library/Attempt/factory/asynchronous.ts
+++ b/src/library/Attempt/factory/asynchronous.ts
@@ -25,11 +25,11 @@ type Attempt_EndRetriever<
 ) => Promise<SomeInferredOutcome>;
 
 const Attempt_thatEventually = async <
-  InferredOutcome extends Attempt_Outcome<unknown, ActionableError<string>>,
+  SomeInferredOutcome extends Attempt_Outcome<unknown, ActionableError<string>>,
 >(
-  endsAccordingTo: Attempt_EndRetriever<InferredOutcome>,
+  endsAccordingTo: Attempt_EndRetriever<SomeInferredOutcome>,
 ) => {
-  type EquivalentOutcome = Attempt_Outcome<ProductOf<InferredOutcome>, CauseOf<InferredOutcome>>;
+  type EquivalentOutcome = Attempt_Outcome<ProductOf<SomeInferredOutcome>, CauseOf<SomeInferredOutcome>>;
 
   return sanctionedAsync({
     async try() {

--- a/src/library/Attempt/factory/synchronous.ts
+++ b/src/library/Attempt/factory/synchronous.ts
@@ -19,10 +19,10 @@ import {
 import AttemptCreationError from './AttemptCreationError';
 
 type Attempt_EndGetter<
-  InferredOutcome extends Attempt_Outcome<unknown, ActionableError<string>>,
+  SomeInferredOutcome extends Attempt_Outcome<unknown, ActionableError<string>>,
 > = (
   givenHandles: typeof handles
-) => InferredOutcome;
+) => SomeInferredOutcome;
 
 const Attempt_that = <
   InferredOutcome extends Attempt_Outcome<unknown, ActionableError<string>>,

--- a/src/library/Attempt/factory/synchronous.ts
+++ b/src/library/Attempt/factory/synchronous.ts
@@ -25,11 +25,11 @@ type Attempt_EndGetter<
 ) => SomeInferredOutcome;
 
 const Attempt_that = <
-  InferredOutcome extends Attempt_Outcome<unknown, ActionableError<string>>,
+  SomeInferredOutcome extends Attempt_Outcome<unknown, ActionableError<string>>,
 >(
-  endsAccordingTo: Attempt_EndGetter<InferredOutcome>,
+  endsAccordingTo: Attempt_EndGetter<SomeInferredOutcome>,
 ) => {
-  type EquivalentOutcome = Attempt_Outcome<ProductOf<InferredOutcome>, CauseOf<InferredOutcome>>;
+  type EquivalentOutcome = Attempt_Outcome<ProductOf<SomeInferredOutcome>, CauseOf<SomeInferredOutcome>>;
 
   return sanctioned({
     try() {

--- a/src/library/Attempt/utilities/sanctionedTryCatch.ts
+++ b/src/library/Attempt/utilities/sanctionedTryCatch.ts
@@ -11,17 +11,17 @@ import type {
 } from '../error/modifier';
 
 const sanctioned = <
-  TryBlockOutput,
-  CatchBlockOutput,
+  SomeTryBlockOutput,
+  SomeCatchBlockOutput,
 >(
   {
     try: getTryBlockOutput,
     catch: catchBlockOutputFor,
   }: {
-    try: () => TryBlockOutput;
-    catch: ($0: AppropriatelyThrown<Error>) => CatchBlockOutput;
+    try: () => SomeTryBlockOutput;
+    catch: ($0: AppropriatelyThrown<Error>) => SomeCatchBlockOutput;
   },
-): TryBlockOutput | CatchBlockOutput => {
+): SomeTryBlockOutput | SomeCatchBlockOutput => {
   // eslint-disable-next-line no-restricted-syntax -- this is the implementation designed to help avoid use of raw try/catch
   try {
     return getTryBlockOutput();

--- a/src/library/Attempt/utilities/sanctionedTryCatch.ts
+++ b/src/library/Attempt/utilities/sanctionedTryCatch.ts
@@ -34,17 +34,17 @@ const sanctioned = <
 };
 
 const sanctionedAsync = async <
-  OutputOfResolvedPromise,
-  OutputOfRejectedPromise,
+  SomeOutputOfResolvedPromise,
+  SomeOutputOfRejectedPromise,
 >(
   {
     try: retrieveTryBlockOutput,
     catch: catchBlockOutputFor,
   }: {
-    try: () => Promise<OutputOfResolvedPromise>;
-    catch: ($0: AppropriatelyThrown<Error>) => OutputOfRejectedPromise;
+    try: () => Promise<SomeOutputOfResolvedPromise>;
+    catch: ($0: AppropriatelyThrown<Error>) => SomeOutputOfRejectedPromise;
   },
-): Promise<OutputOfResolvedPromise | OutputOfRejectedPromise> => {
+): Promise<SomeOutputOfResolvedPromise | SomeOutputOfRejectedPromise> => {
   const sanction = (whateverThatWasThrown: unknown) => sanctioned({
     try: () => {
       throw whateverThatWasThrown; // eslint-disable-line no-restricted-syntax -- puts the error back through the sanctioned catch

--- a/src/library/Parser/definition.ts
+++ b/src/library/Parser/definition.ts
@@ -3,11 +3,11 @@ import type Attempt from '@/library/Attempt';
 import ParsingError from './ParsingError';
 
 interface Parser<
-  ParsableInput,
-  ParsedOutput,
+  SomeParsableInput,
+  SomeParsedOutput,
   SomeParsingError extends ParsingError<string>,
 > {
-  parsedFrom(givenSubject: ParsableInput): Attempt.Outcome<ParsedOutput, SomeParsingError>;
+  parsedFrom(givenSubject: SomeParsableInput): Attempt.Outcome<SomeParsedOutput, SomeParsingError>;
 }
 
 export {

--- a/src/library/math/operator/constructive/greatestCommonDivisor.test.ts
+++ b/src/library/math/operator/constructive/greatestCommonDivisor.test.ts
@@ -17,14 +17,14 @@ import {
 import * as GCDAlias from './greatestCommonDivisor';
 
 const pairCombos = <
-  LeftElement extends number,
-  RightElement extends number,
-  FillerElement extends number,
+  SomeLeftElement extends number,
+  SomeRightElement extends number,
+  SomeFillerElement extends number,
 >(
   given: {
-    left: LeftElement;
-    right: RightElement;
-    filler: FillerElement;
+    left: SomeLeftElement;
+    right: SomeRightElement;
+    filler: SomeFillerElement;
   },
 ) => [
   [given.left/*  */, given.filler/**/],
@@ -33,12 +33,12 @@ const pairCombos = <
 ] as const;
 
 const symmetricPairCombos = <
-  SymmetricElement extends number,
-  FillerElement extends number,
+  SomeSymmetricElement extends number,
+  SomeFillerElement extends number,
 >(
   given: {
-    of: SymmetricElement;
-    filler: FillerElement;
+    of: SomeSymmetricElement;
+    filler: SomeFillerElement;
   },
 ) => pairCombos({
   left  : given.of,

--- a/src/library/typeUtilities/Boolean.ts
+++ b/src/library/typeUtilities/Boolean.ts
@@ -1,22 +1,22 @@
 type Is<
-  LeftHandOperand,
-  RightHandOperand,
+  SomeLeftHandOperand,
+  SomeRightHandOperand,
 > =
-  LeftHandOperand extends RightHandOperand
-    ? RightHandOperand extends LeftHandOperand
+  SomeLeftHandOperand extends SomeRightHandOperand
+    ? SomeRightHandOperand extends SomeLeftHandOperand
       ? true
       : false
     : false
 ;
 
 type If<
-  Condition extends boolean,
-  WhenTrue,
-  WhenFalse,
+  SomeCondition extends boolean,
+  SomeExpressionWhenTrue,
+  SomeExpressionWhenFalse,
 > =
-  Condition extends true
-    ? WhenTrue
-    : WhenFalse
+  SomeCondition extends true
+    ? SomeExpressionWhenTrue
+    : SomeExpressionWhenFalse
 ;
 
 type Not<

--- a/src/library/utilitiesByType/array.ts
+++ b/src/library/utilitiesByType/array.ts
@@ -4,9 +4,9 @@ const isEmpty = (
   return givenSubject.length === 0;
 };
 
-const hasAtLeastOne = <Element>(
-  givenElements: Element[],
-): givenElements is [Element, ...Element[]] => {
+const hasAtLeastOne = <SomeElement>(
+  givenElements: SomeElement[],
+): givenElements is [SomeElement, ...SomeElement[]] => {
   return !isEmpty(givenElements);
 };
 


### PR DESCRIPTION
- the `Some...` prefix in the names of type parameters makes them more easily distinguishable from types that are custom but concrete, especially when used in the body of a declaration that's more than a few lines

Sets precedent for #698