### PR TITLE
types: avoids `Any` as name for non-constrained generic types

### DIFF
--- a/src/library/Parser/string/StaticStringParser.ts
+++ b/src/library/Parser/string/StaticStringParser.ts
@@ -7,13 +7,13 @@ import type {
 } from './StringParser';
 
 type StaticStringParser<
-  Any,
+  SomeParsedOutput,
 > =
   & Static<
-    Any
+    SomeParsedOutput
   >
   & StringParser<
-    Any,
+    SomeParsedOutput,
     ParsingError<string>
   >
 ;

--- a/src/library/modifiersByType/error/Contextualized.ts
+++ b/src/library/modifiersByType/error/Contextualized.ts
@@ -11,9 +11,9 @@ type Contextualized<
 ;
 
 interface Instantiable<
-  Any,
+  SomeClass,
 > {
-  [Symbol.hasInstance]: (value: unknown) => value is Any;
+  [Symbol.hasInstance]: (value: unknown) => value is SomeClass;
 }
 
 const isContextualized = <

--- a/src/library/typeUtilities/Static.ts
+++ b/src/library/typeUtilities/Static.ts
@@ -1,8 +1,8 @@
 /** The base shape of the _type_ of some class, rather than the class itself */
 interface Static<
-  Any,
+  SomeObject,
 > {
-  prototype: Any;
+  prototype: SomeObject;
 }
 
 export type {

--- a/src/library/vue/reactivity.ts
+++ b/src/library/vue/reactivity.ts
@@ -5,7 +5,7 @@ import {
 } from 'vue';
 
 /** Updates the wrapped instance */
-const updateRef = <Any>(givenSubject: Ref<Any>, givenValue: Any): void => {
+const updateRef = <SomeState>(givenSubject: Ref<SomeState>, givenValue: SomeState): void => {
   givenSubject.value = givenValue;
 };
 


### PR DESCRIPTION
- prefers `Some...` prefix followed by a name that describes intent/role of generic parameter
- defaults to `SomeObject` when there's no other useful context

Sets precedent for #698. Facilitates #699.