### PR TITLE
refactor: establishes "raw" as the canonical opposite for "parsed"

### DIFF
--- a/src/features/TextToImage/config/utilities/DynamicConfig/exports.ts
+++ b/src/features/TextToImage/config/utilities/DynamicConfig/exports.ts
@@ -46,8 +46,8 @@ const fetchConfig = (): Promise<OutcomeOfFetchingConfig> => Attempt.thatEventual
     !contentIsJSONIn(endpointResponse)
   ) return ends.inFailureDueTo(endpointResponseError);
 
-  const unparsedSchema = await endpointResponse.json() as unknown;
-  const fetchedConfig = ConfigSchema.parse(unparsedSchema);
+  const rawSchema = await endpointResponse.json() as unknown;
+  const fetchedConfig = ConfigSchema.parse(rawSchema);
   return ends.inSuccessWith(fetchedConfig);
 });
 

--- a/src/features/TextToImage/config/utilities/StaticConfig/exports.ts
+++ b/src/features/TextToImage/config/utilities/StaticConfig/exports.ts
@@ -25,8 +25,8 @@ const readConfig = (): Promise<OutcomeOfReadingConfig> => Attempt.thatEventually
     !fileResponse.ok
   ) return ends.inFailureDueTo(new StaticConfigReadingError(configFile, fileResponse));
 
-  const unparsedSchema = await fileResponse.json() as unknown;
-  const parsedConfig = ConfigSchema.parse(unparsedSchema);
+  const rawSchema = await fileResponse.json() as unknown;
+  const parsedConfig = ConfigSchema.parse(rawSchema);
   return ends.inSuccessWith(parsedConfig);
 });
 

--- a/src/library/Parser/definition.ts
+++ b/src/library/Parser/definition.ts
@@ -3,11 +3,11 @@ import type Attempt from '@/library/Attempt';
 import ParsingError from './ParsingError';
 
 interface Parser<
-  SomeParsableInput,
+  SomeRawInput,
   SomeParsedOutput,
   SomeParsingError extends ParsingError<string>,
 > {
-  parsedFrom(givenSubject: SomeParsableInput): Attempt.Outcome<SomeParsedOutput, SomeParsingError>;
+  parsedFrom(givenSubject: SomeRawInput): Attempt.Outcome<SomeParsedOutput, SomeParsingError>;
 }
 
 export {

--- a/src/library/ShimmedStabilityAIClient/definition.ts
+++ b/src/library/ShimmedStabilityAIClient/definition.ts
@@ -33,8 +33,8 @@ class ImageClient
       to       : generationEndpoint,
     });
 
-    const newResource = outcomeOfSubmittingResource.forciblyUnwrap(/* matches error propagation of actual StabilityAI Client */);
-    const parsedResource = Shortfin.TextToImage.SDXL.Client.Response.Body.Schema.parse(newResource);
+    const rawResource = outcomeOfSubmittingResource.forciblyUnwrap(/* matches error propagation of actual StabilityAI Client */);
+    const parsedResource = Shortfin.TextToImage.SDXL.Client.Response.Body.Schema.parse(rawResource);
     const [soleGeneratedImage] = parsedResource.images;
 
     const soleGeneratedArtifact: StabilityAI_TextToImage_Pipeline_Output = {


### PR DESCRIPTION
- rejected contenders
  - "new": something can be "old" but still need to be parsed
  - "unparsed": the "un" suggests "undone parsing", but the desired connotation is "not yet parsed"
  - "parsable": it's unknown whether an input is capable of _being_ parsed, only that an attempt has yet to be made
 
Sets precedent for #698