### PR TITLE
refactor(library/Parser): swaps "class constructor" for "implementer" in generic parameters

### DIFF
--- a/src/library/Parser/string/StringParsable.ts
+++ b/src/library/Parser/string/StringParsable.ts
@@ -7,10 +7,10 @@ import type {
  * Implement this type to ensure that the class follows the standard interface for this.
  */
 type StringParsable<
-  SomeClassConstructor extends StaticStringParser<
-    SomeClassConstructor['prototype']
+  SomeImplementer extends StaticStringParser<
+    SomeImplementer['prototype']
   >,
-> = SomeClassConstructor['prototype'];
+> = SomeImplementer['prototype'];
 
 export type {
   StringParsable,


### PR DESCRIPTION
- technically speaking, all objects have at least one prototype, not just class constructors

Sets precedent for #698