### PR TITLE
refactor: avoids "type" within symbol names

### DIFF
--- a/src/features/TextToImage/config/utilities/DynamicConfig/exports.ts
+++ b/src/features/TextToImage/config/utilities/DynamicConfig/exports.ts
@@ -13,13 +13,13 @@ import DynamicConfig_EndpointResponseError from './EndpointResponseError';
 import DynamicConfig_FetchingError from './FetchingError';
 
 const contentIsJSONIn = (givenResponse: Response): boolean => {
-  const contentType = givenResponse.headers.get('Content-Type');
+  const rawContentDescriptor = givenResponse.headers.get('Content-Type');
 
   if (
-    contentType === null
+    rawContentDescriptor === null
   ) return false;
 
-  return contentType.includes('application/json');
+  return rawContentDescriptor.includes('application/json');
 };
 
 const configEndpoint = URLPath.parsedFrom('/config/text-to-image').forciblyUnwrap();

--- a/src/features/reporting.ts
+++ b/src/features/reporting.ts
@@ -29,10 +29,10 @@ const promptUserToReport = (givenError: Error) => {
   ) return;
 
   const draftOfNewIssue = Repository.draftIssue({
-    title : `[Unexpected Error]: can't <some task> when <some context>`,
-    body  : `### Details\n${formattedErrorDetails}`.replaceAll('\n', '\n> '),
-    labels: ['bug'],
-    type  : 'Bug',
+    title   : `[Unexpected Error]: can't <some task> when <some context>`,
+    body    : `### Details\n${formattedErrorDetails}`.replaceAll('\n', '\n> '),
+    labels  : ['bug'],
+    category: 'Bug',
   });
 
   window.open(draftOfNewIssue);

--- a/src/library/ContentDescriptor/definition.ts
+++ b/src/library/ContentDescriptor/definition.ts
@@ -17,7 +17,7 @@ class ContentDescriptor {
   public constructor(
     public topLevelDescriptor: ContentDescriptor_TopLevel.Any,
     public tree: string[] | null,
-    public fileSubtype: string,
+    public bottomLevelDescriptor: string,
     public structureType: ContentDescriptor_StructuredSyntaxNameSuffix.Any | null,
     public parameters: Record<string, string> | null,
   ) {}
@@ -70,7 +70,7 @@ class ContentDescriptor {
     const orderedComponents = [
       this.serializableTopLevelDescriptor,
       this.serializableTree,
-      this.fileSubtype,
+      this.bottomLevelDescriptor,
       this.serializableStructureType,
       this.serializableParameters,
     ] as const;

--- a/src/library/ContentDescriptor/definition.ts
+++ b/src/library/ContentDescriptor/definition.ts
@@ -15,18 +15,18 @@ import type {
 /** See [RFC 2045](https://datatracker.ietf.org/doc/html/rfc2045) for more information */
 class ContentDescriptor {
   public constructor(
-    public fileType: ContentDescriptor_TopLevel.Any,
+    public topLevelDescriptor: ContentDescriptor_TopLevel.Any,
     public tree: string[] | null,
     public fileSubtype: string,
     public structureType: ContentDescriptor_StructuredSyntaxNameSuffix.Any | null,
     public parameters: Record<string, string> | null,
   ) {}
 
-  public static readonly fileTypeSuffix = '/';
+  public static readonly suffixForTopLevelDescriptor = '/';
 
-  public get serializableFileType(): NonTrivialString {
-    const suffixedFileType = this.fileType.concat(ContentDescriptor.fileTypeSuffix);
-    return NonTrivialString.parsedFrom(suffixedFileType).forciblyUnwrap(/* Proven safe by inspecting intellisense of `fileType` */);
+  public get serializableTopLevelDescriptor(): NonTrivialString {
+    const suffixedTopLevelDescriptor = this.topLevelDescriptor.concat(ContentDescriptor.suffixForTopLevelDescriptor);
+    return NonTrivialString.parsedFrom(suffixedTopLevelDescriptor).forciblyUnwrap(/* Proven safe by inspecting intellisense of `topLevelDescriptor` */);
   }
 
   public static readonly treeBranchSuffix = '.';
@@ -68,7 +68,7 @@ class ContentDescriptor {
 
   public get serialized(): NonTrivialString {
     const orderedComponents = [
-      this.serializableFileType,
+      this.serializableTopLevelDescriptor,
       this.serializableTree,
       this.fileSubtype,
       this.serializableStructureType,

--- a/src/library/ContentDescriptor/definition.ts
+++ b/src/library/ContentDescriptor/definition.ts
@@ -18,7 +18,7 @@ class ContentDescriptor {
     public topLevelDescriptor: ContentDescriptor_TopLevel.Any,
     public tree: string[] | null,
     public bottomLevelDescriptor: string,
-    public structureType: ContentDescriptor_StructuredSyntaxNameSuffix.Any | null,
+    public structureDescriptor: ContentDescriptor_StructuredSyntaxNameSuffix.Any | null,
     public parameters: Record<string, string> | null,
   ) {}
 
@@ -41,14 +41,14 @@ class ContentDescriptor {
     return serializedTreeBranches;
   }
 
-  public static readonly structureTypePrefix = '+';
+  public static readonly structureDescriptorPrefix = '+';
 
-  private get serializableStructureType(): string | null {
+  private get serializableStructureDescriptor(): string | null {
     if (
-      this.structureType === null
+      this.structureDescriptor === null
     ) return null;
 
-    return ContentDescriptor.structureTypePrefix.concat(this.structureType);
+    return ContentDescriptor.structureDescriptorPrefix.concat(this.structureDescriptor);
   }
 
   public static readonly parameterPrefix = ';';
@@ -71,7 +71,7 @@ class ContentDescriptor {
       this.serializableTopLevelDescriptor,
       this.serializableTree,
       this.bottomLevelDescriptor,
-      this.serializableStructureType,
+      this.serializableStructureDescriptor,
       this.serializableParameters,
     ] as const;
 

--- a/src/library/Parser/string/StringParsable.ts
+++ b/src/library/Parser/string/StringParsable.ts
@@ -7,10 +7,10 @@ import type {
  * Implement this type to ensure that the class follows the standard interface for this.
  */
 type StringParsable<
-  SomeClassType extends StaticStringParser<
-    SomeClassType['prototype']
+  SomeClassConstructor extends StaticStringParser<
+    SomeClassConstructor['prototype']
   >,
-> = SomeClassType['prototype'];
+> = SomeClassConstructor['prototype'];
 
 export type {
   StringParsable,

--- a/src/library/UniformResourceIdentifier/Data/Image/definition.ts
+++ b/src/library/UniformResourceIdentifier/Data/Image/definition.ts
@@ -13,7 +13,7 @@ import type {
 
 class ImageURI
   extends DataURI {
-  public static readonly fileType = 'image';
+  public static readonly topLevelDescriptor = 'image';
 
   public constructor(
     public readonly format: ImageURI_Format.Any,
@@ -29,7 +29,7 @@ class ImageURI
 
   public override get descriptor(): DataURI['descriptor'] {
     const computedDescriptor = new ContentDescriptor(
-      ImageURI.fileType,
+      ImageURI.topLevelDescriptor,
       null,
       this.format,
       null,

--- a/src/utilities/Repository.ts
+++ b/src/utilities/Repository.ts
@@ -4,7 +4,7 @@ type Repository_Issue_Label =
   | 'documentation'
 ;
 
-type Repository_Issue_Type =
+type Repository_Issue_Category =
   | 'Feature'
   | 'Bug'
   | 'Task'
@@ -14,7 +14,8 @@ interface Repository_Issue {
   title: string;
   body: string;
   labels: Repository_Issue_Label[];
-  type: Repository_Issue_Type;
+  /** a.k.a. "type" */
+  category: Repository_Issue_Category;
 }
 
 const Repository = {
@@ -32,7 +33,7 @@ const Repository = {
     referencedParameters.set('title', given.title);
     referencedParameters.set('body', given.body);
     referencedParameters.set('labels', given.labels.join());
-    referencedParameters.set('type', given.type);
+    referencedParameters.set('type', given.category);
 
     return mutableDraft;
   },


### PR DESCRIPTION
- `type` is a reserved keyword in TypeScript
- conceptually, "type" is taken to mean "the shape of some data"
- sometimes it's used as a synonym for "category" when naming symbols, but the resulting vagueness requires readers to take on extra initiative or cognitive load.
- it's a more sustainable practice to find a more descriptive term rather than falling back to "type"
   - for symbols that represent the "type of a type"/"metatype", the term "constructor" is usually more appropriate
- Consider the question "What type of content was received?"
  - Possible follow up clarifications could be:
    - "An image, a video, some text?"
    - "machine-readable, human-readable?"
    - "complete, partial, absent?"
    - the list goes on
  - the word "type" in the sentence above requires the audience to await or seek out extra context to determine which "dimension" is being referenced in the initial question.
  - this can be avoided by crafting a question that uses a more direct, self-contained concept:
    - "What's the format of the content?"
    - "Who will be able to consume this content?"
    - "How complete is the content?"
    - ...
  - doing so dramatically shrinks the scope of possible contexts

Found while drafting #703