### PR TITLE
refactor(library/Parser): exposes generic error parameters for string parsers

### DIFF
--- a/src/library/Base64CharacterEncodedByteSequence/definition.ts
+++ b/src/library/Base64CharacterEncodedByteSequence/definition.ts
@@ -20,7 +20,8 @@ class Base64CharacterEncodedByteSequence
   extends StringSubset<
   'Base64CharacterEncodedByteSequence'
 > implements StringParsable<
-  typeof Base64CharacterEncodedByteSequence
+  typeof Base64CharacterEncodedByteSequence,
+  /*  */ Base64CharacterEncodedByteSequence_ParsingError
 > {
   public static paddingCharacter = '=';
 

--- a/src/library/NonTrivialString/definition.ts
+++ b/src/library/NonTrivialString/definition.ts
@@ -18,7 +18,8 @@ class NonTrivialString
   extends StringSubset<
   'NonTrivialString'
 > implements StringParsable<
-  typeof NonTrivialString
+  typeof NonTrivialString,
+  /*  */ NonTrivialString_ParsingError
 > {
   public static parsedFrom = (
     givenSubject: string,

--- a/src/library/Parser/string/StaticStringParser.ts
+++ b/src/library/Parser/string/StaticStringParser.ts
@@ -8,7 +8,7 @@ import type {
 
 type StaticStringParser<
   SomeParsedOutput,
-  SomeParsingError extends ParsingError<string> = ParsingError<string>,
+  SomeParsingError extends ParsingError<string>,
 > =
   & Static<
     SomeParsedOutput

--- a/src/library/Parser/string/StaticStringParser.ts
+++ b/src/library/Parser/string/StaticStringParser.ts
@@ -8,13 +8,14 @@ import type {
 
 type StaticStringParser<
   SomeParsedOutput,
+  SomeParsingError extends ParsingError<string> = ParsingError<string>,
 > =
   & Static<
     SomeParsedOutput
   >
   & StringParser<
     SomeParsedOutput,
-    ParsingError<string>
+    SomeParsingError
   >
 ;
 

--- a/src/library/Parser/string/StringParsable.ts
+++ b/src/library/Parser/string/StringParsable.ts
@@ -1,3 +1,5 @@
+import type ParsingError from '../ParsingError';
+
 import type {
   StaticStringParser,
 } from './StaticStringParser';
@@ -8,8 +10,10 @@ import type {
  */
 type StringParsable<
   SomeImplementer extends StaticStringParser<
-    SomeImplementer['prototype']
+    SomeImplementer['prototype'],
+    SomeParsingError
   >,
+  SomeParsingError extends ParsingError<string> = ParsingError<string>,
 > = SomeImplementer['prototype'];
 
 export type {

--- a/src/library/Parser/string/StringParsable.ts
+++ b/src/library/Parser/string/StringParsable.ts
@@ -13,7 +13,7 @@ type StringParsable<
     SomeImplementer['prototype'],
     SomeParsingError
   >,
-  SomeParsingError extends ParsingError<string> = ParsingError<string>,
+  SomeParsingError extends ParsingError<string>,
 > = SomeImplementer['prototype'];
 
 export type {

--- a/src/library/URLComponent/URLOrigin.ts
+++ b/src/library/URLComponent/URLOrigin.ts
@@ -28,7 +28,8 @@ class URLOrigin
   extends StringSubset<
   'URLOrigin'
 > implements StringParsable<
-  typeof URLOrigin
+  typeof URLOrigin,
+  /*  */ URLOrigin_ParsingError
 > {
   public static parsedFrom = (
     givenSubject: string,

--- a/src/library/URLComponent/URLPath.ts
+++ b/src/library/URLComponent/URLPath.ts
@@ -28,7 +28,8 @@ class URLPath
   extends StringSubset<
   'URLPath'
 > implements StringParsable<
-  typeof URLPath
+  typeof URLPath,
+  /*  */ URLPath_ParsingError
 > {
   public static parsedFrom = (
     givenSubject: string,


### PR DESCRIPTION
Enabled by #705. Sets precedent for #698.