### PR TITLE
refactor: avoids unsafe parsing via `Schema` instances

### DIFF
--- a/src/features/TextToImage/config/types/Config_ParsingError.ts
+++ b/src/features/TextToImage/config/types/Config_ParsingError.ts
@@ -1,0 +1,20 @@
+import {
+  ParsingError,
+} from '@/library/Parser';
+
+class TextToImage_Config_ParsingError
+  extends ParsingError<
+  'TextToImage_Config'
+> {
+  public override name = 'TextToImage_Config_ParsingError' as const;
+
+  public constructor(
+    givenMessage: string,
+  ) {
+    super(`Config could not be parsed. ${givenMessage}`);
+  }
+}
+
+export {
+  TextToImage_Config_ParsingError,
+};

--- a/src/features/TextToImage/config/types/exports.ts
+++ b/src/features/TextToImage/config/types/exports.ts
@@ -1,3 +1,7 @@
 export {
   TextToImage_Config as Config,
 } from './Config';
+
+export {
+  TextToImage_Config_ParsingError as Config_ParsingError,
+} from './Config_ParsingError';

--- a/src/features/TextToImage/config/utilities/DynamicConfig/exports.ts
+++ b/src/features/TextToImage/config/utilities/DynamicConfig/exports.ts
@@ -1,11 +1,16 @@
 import Attempt from '@/library/Attempt';
 
 import {
+  Parse_instanceFrom,
+} from '@/library/Parser';
+
+import {
   URLPath,
 } from '@/library/URLComponent';
 
 import {
   Config,
+  Config_ParsingError,
 } from '../../types';
 
 import DynamicConfig_EndpointResponseError from './EndpointResponseError';
@@ -46,7 +51,12 @@ const fetchConfig = (): Promise<OutcomeOfFetchingConfig> => Attempt.thatEventual
   ) return ends.inFailureDueTo(endpointResponseError);
 
   const rawConfig = await endpointResponse.json() as unknown;
-  const parsedConfig = Config.Schema.parse(rawConfig); // Will raw `throw` upon failure. Implementation must align with established contract.
+
+  const parsedConfig = Parse_instanceFrom(rawConfig, {
+    using      : Config.Schema,
+    failingWith: Config_ParsingError,
+  }).forciblyUnwrap(/* Implementation must align with established contract. */);
+
   return ends.inSuccessWith(parsedConfig);
 });
 

--- a/src/features/TextToImage/config/utilities/StaticConfig/exports.ts
+++ b/src/features/TextToImage/config/utilities/StaticConfig/exports.ts
@@ -1,11 +1,16 @@
 import Attempt from '@/library/Attempt';
 
 import {
+  Parse_instanceFrom,
+} from '@/library/Parser';
+
+import {
   URLPath,
 } from '@/library/URLComponent';
 
 import {
   Config,
+  Config_ParsingError,
 } from '../../types';
 
 import StaticConfigReadingError from './StaticConfigReadingError';
@@ -25,7 +30,12 @@ const readConfig = (): Promise<OutcomeOfReadingConfig> => Attempt.thatEventually
   ) return ends.inFailureDueTo(new StaticConfigReadingError(configFile, fileResponse));
 
   const rawConfig = await fileResponse.json() as unknown;
-  const parsedConfig = Config.Schema.parse(rawConfig); // Will raw `throw` upon failure. Implementation must align with established contract.
+
+  const parsedConfig = Parse_instanceFrom(rawConfig, {
+    using      : Config.Schema,
+    failingWith: Config_ParsingError,
+  }).forciblyUnwrap(/* Implementation must align with established contract. */);
+
   return ends.inSuccessWith(parsedConfig);
 });
 

--- a/src/library/ShimmedStabilityAIClient/definition.ts
+++ b/src/library/ShimmedStabilityAIClient/definition.ts
@@ -8,6 +8,11 @@ import type {
 } from 'stabilityai-client-typescript/models/operations';
 
 import HTTP from '@/library/HTTP';
+
+import {
+  Parse_instanceFrom,
+} from '@/library/Parser';
+
 import Shortfin from '@/library/Shortfin';
 
 import {
@@ -34,7 +39,12 @@ class ImageClient
     });
 
     const rawResource = outcomeOfSubmittingResource.forciblyUnwrap(/* matches error propagation of actual StabilityAI Client */);
-    const parsedResource = Shortfin.TextToImage.SDXL.Client.Response.Body.Schema.parse(rawResource); // Will raw `throw` upon failure. Implementation must align with established contract.
+
+    const parsedResource = Parse_instanceFrom(rawResource, {
+      using      : Shortfin.TextToImage.SDXL.Client.Response.Body.Schema,
+      failingWith: Shortfin.TextToImage.SDXL.Client.Response.Body.ParsingError,
+    }).forciblyUnwrap(/* Implementation must align with established contract. */);
+
     const [soleGeneratedImage] = parsedResource.images;
 
     const soleGeneratedArtifact: StabilityAI_TextToImage_Pipeline_Output = {

--- a/src/library/Shortfin/TextToImage/SDXL/Client/Response/Body/ParsingError.ts
+++ b/src/library/Shortfin/TextToImage/SDXL/Client/Response/Body/ParsingError.ts
@@ -1,0 +1,20 @@
+import {
+  ParsingError,
+} from '@/library/Parser';
+
+class Shortfin_TextToImage_SDXL_Client_Response_Body_ParsingError
+  extends ParsingError<
+  'Shortfin_TextToImage_SDXL_Client_Response_Body'
+> {
+  public override name = 'Shortfin_TextToImage_SDXL_Client_Response_Body_ParsingError' as const;
+
+  public constructor(
+    givenMessage: string,
+  ) {
+    super(`Response body could not be parsed. ${givenMessage}`);
+  }
+}
+
+export {
+  Shortfin_TextToImage_SDXL_Client_Response_Body_ParsingError,
+};

--- a/src/library/Shortfin/TextToImage/SDXL/Client/Response/Body/definitionAugmentation.ts
+++ b/src/library/Shortfin/TextToImage/SDXL/Client/Response/Body/definitionAugmentation.ts
@@ -1,0 +1,17 @@
+import {
+  Shortfin_TextToImage_SDXL_Client_Response_Body_ParsingError,
+} from './ParsingError';
+
+import {
+  Shortfin_TextToImage_SDXL_Client_Response_Body,
+} from './definition.ts';
+
+Shortfin_TextToImage_SDXL_Client_Response_Body.ParsingError = Shortfin_TextToImage_SDXL_Client_Response_Body_ParsingError;
+
+declare module './definition.ts' {
+  namespace Shortfin_TextToImage_SDXL_Client_Response_Body {
+    export {
+      Shortfin_TextToImage_SDXL_Client_Response_Body_ParsingError as ParsingError,
+    };
+  }
+}

--- a/src/library/Shortfin/TextToImage/SDXL/Client/Response/Body/definitionWithAugmentation.ts
+++ b/src/library/Shortfin/TextToImage/SDXL/Client/Response/Body/definitionWithAugmentation.ts
@@ -1,0 +1,3 @@
+import './definitionAugmentation.ts';
+
+export * from './definition.ts';

--- a/src/library/Shortfin/TextToImage/SDXL/Client/Response/Body/exports.ts
+++ b/src/library/Shortfin/TextToImage/SDXL/Client/Response/Body/exports.ts
@@ -1,1 +1,1 @@
-export * from './definition.ts';
+export * from './definitionWithAugmentation.ts';


### PR DESCRIPTION
- before, the only thing that warned of unsafe error propagation was some comments next to the call sites for `.parse(...)`
- now, the use of `.forciblyUnwrap(...)` communicates the deliberate choice to perform an unsafe operation

Facilitates #715