### PR TITLE
prefeature(library/Parser): adds `Parse_instanceFrom(...)`

### DIFF
--- a/src/library/Parser/Parse_instanceFrom.ts
+++ b/src/library/Parser/Parse_instanceFrom.ts
@@ -1,0 +1,36 @@
+import Attempt from '@/library/Attempt';
+import type Schema from '@/library/Schema';
+
+import type {
+  default as ParsingError,
+} from './ParsingError';
+
+const Parse_instanceFrom = <
+  SomeSchema extends Schema.ZodType,
+  SomeParsingError extends ParsingError<string>,
+>(
+  givenSubject: unknown,
+  {
+    using: givenSchema,
+    failingWith: GivenParsingError,
+  }: {
+    using: SomeSchema;
+    failingWith: new (message: string) => SomeParsingError;
+  },
+): Attempt.Outcome<
+  Schema.infer<SomeSchema>,
+  SomeParsingError
+> => Attempt.that((ends) => {
+  const resultOfParsingSubject = givenSchema.safeParse(givenSubject);
+
+  if (
+    resultOfParsingSubject.success
+  ) return ends.inSuccessWith(resultOfParsingSubject.data);
+
+  const newParsingError = new GivenParsingError(resultOfParsingSubject.error.message);
+  return ends.inFailureDueTo(newParsingError);
+});
+
+export {
+  Parse_instanceFrom,
+};

--- a/src/library/Parser/exports.ts
+++ b/src/library/Parser/exports.ts
@@ -5,3 +5,5 @@ export type * from './Parsable';
 export {
   default as ParsingError,
 } from './ParsingError';
+
+export * from './Parse_instanceFrom';


### PR DESCRIPTION
- adapts `Schema` usage to type-safe error propagation

Pre-req for #707 