### PR TITLE
chore(dev-deps): removes unused @types/lodash.clonedeep

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,6 @@
         "@stylistic/eslint-plugin": "^5.2.3",
         "@tsconfig/node22": "^22.0.2",
         "@types/jsdom": "^21.1.7",
-        "@types/lodash.clonedeep": "^4.5.9",
         "@types/node": "^24.2.1",
         "@typescript-eslint/parser": "^8.39.0",
         "@vitejs/plugin-vue": "^6.0.1",
@@ -2210,23 +2209,6 @@
       "integrity": "sha512-HMwFiRujE5PjrgwHQ25+bsLJgowjGjm5Z8FVSf0N6PwgJrwxH0QxzHYDcKsTfV3wva0vzrpqMTJS2jXPr5BMEQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@types/lodash": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-w/P33JFeySuhN6JLkysYUK2gEmy9kHHFN7E8ro0tkfmlDOgxBDzWEZ/J8cWA+fHqFevpswDTFZnDx+R9lbL6xw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/lodash.clonedeep": {
-      "version": "4.5.9",
-      "resolved": "https://registry.npmjs.org/@types/lodash.clonedeep/-/lodash.clonedeep-4.5.9.tgz",
-      "integrity": "sha512-19429mWC+FyaAhOLzsS8kZUsI+/GmBAQ0HFiCPsKGU+7pBXOQWhyrY6xNNDwUSX8SMZMJvuFVMF9O5dQOlQK9Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/lodash": "*"
-      }
     },
     "node_modules/@types/mdast": {
       "version": "4.0.4",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "@stylistic/eslint-plugin": "^5.2.3",
     "@tsconfig/node22": "^22.0.2",
     "@types/jsdom": "^21.1.7",
-    "@types/lodash.clonedeep": "^4.5.9",
     "@types/node": "^24.2.1",
     "@typescript-eslint/parser": "^8.39.0",
     "@vitejs/plugin-vue": "^6.0.1",


### PR DESCRIPTION
Follows up on #660