### PR TITLE
refactor: avoids `default` exports from "definition" modules

### DIFF
--- a/src/library/Base64CharacterEncodedByteSequence/definition.ts
+++ b/src/library/Base64CharacterEncodedByteSequence/definition.ts
@@ -74,6 +74,6 @@ class Base64CharacterEncodedByteSequence
 }
 
 export {
-  Base64CharacterEncodedByteSequence as default,
+  Base64CharacterEncodedByteSequence,
   Base64CharacterEncodedByteSequence_ParsingError,
 };

--- a/src/library/Base64CharacterEncodedByteSequence/exports.ts
+++ b/src/library/Base64CharacterEncodedByteSequence/exports.ts
@@ -1,3 +1,3 @@
 export {
-  default as default,
+  Base64CharacterEncodedByteSequence as default,
 } from './definition.ts';

--- a/src/library/ContentDescriptor/definition.ts
+++ b/src/library/ContentDescriptor/definition.ts
@@ -107,7 +107,7 @@ const MIMEType = ContentDescriptor;
 type MIMEType = ContentDescriptor;
 
 export {
-  ContentDescriptor as default,
+  ContentDescriptor,
   ContentType,
   MediaType,
   MIMEType,

--- a/src/library/ContentDescriptor/exports.ts
+++ b/src/library/ContentDescriptor/exports.ts
@@ -1,3 +1,3 @@
 export {
-  default as default,
+  ContentDescriptor as default,
 } from './definition.ts';

--- a/src/library/NonTrivialString/definition.ts
+++ b/src/library/NonTrivialString/definition.ts
@@ -71,6 +71,6 @@ class NonTrivialString
 }
 
 export {
-  NonTrivialString as default,
+  NonTrivialString,
   NonTrivialString_ParsingError,
 };

--- a/src/library/NonTrivialString/exports.ts
+++ b/src/library/NonTrivialString/exports.ts
@@ -1,3 +1,3 @@
 export {
-  default as default,
+  NonTrivialString as default,
 } from './definition.ts';

--- a/src/library/Parser/StaticParser.ts
+++ b/src/library/Parser/StaticParser.ts
@@ -3,7 +3,7 @@ import type Static from '@/library/typeUtilities/Static';
 import type ParsingError from './ParsingError';
 
 import type {
-  default as Parser,
+  Parser,
 } from './definition.ts';
 
 type StaticParser<

--- a/src/library/Parser/StaticParser.ts
+++ b/src/library/Parser/StaticParser.ts
@@ -1,7 +1,10 @@
 import type Static from '@/library/typeUtilities/Static';
 
 import type ParsingError from './ParsingError';
-import type Parser from './definition.ts';
+
+import type {
+  default as Parser,
+} from './definition.ts';
 
 type StaticParser<
   SomeRawInput,

--- a/src/library/Parser/definition.ts
+++ b/src/library/Parser/definition.ts
@@ -11,6 +11,6 @@ interface Parser<
 }
 
 export {
-  type Parser as default,
+  type Parser,
   ParsingError,
 };

--- a/src/library/Range/DiscreteRange.ts
+++ b/src/library/Range/DiscreteRange.ts
@@ -4,7 +4,9 @@ import {
   isNegative,
 } from '@/library/math';
 
-import Range from './definition.ts';
+import {
+  default as Range,
+} from './definition.ts';
 
 class DiscreteRange
   extends Range {

--- a/src/library/Range/DiscreteRange.ts
+++ b/src/library/Range/DiscreteRange.ts
@@ -5,7 +5,7 @@ import {
 } from '@/library/math';
 
 import {
-  default as Range,
+  Range,
 } from './definition.ts';
 
 class DiscreteRange

--- a/src/library/Range/definition.ts
+++ b/src/library/Range/definition.ts
@@ -79,5 +79,5 @@ class Range {
 }
 
 export {
-  Range as default,
+  Range,
 };

--- a/src/library/Range/exports.ts
+++ b/src/library/Range/exports.ts
@@ -1,3 +1,3 @@
 export {
-  default as default,
+  Range as default,
 } from './definition.ts';

--- a/src/library/ShimmedStabilityAIClient/definition.ts
+++ b/src/library/ShimmedStabilityAIClient/definition.ts
@@ -34,5 +34,5 @@ class ShimmedStabilityAIClient
 }
 
 export {
-  ShimmedStabilityAIClient as default,
+  ShimmedStabilityAIClient,
 };

--- a/src/library/ShimmedStabilityAIClient/exports.ts
+++ b/src/library/ShimmedStabilityAIClient/exports.ts
@@ -1,3 +1,3 @@
 export {
-  default as default,
+  ShimmedStabilityAIClient as default,
 } from './definition.ts';

--- a/src/library/UniformResourceIdentifier/Data/Image/definition.ts
+++ b/src/library/UniformResourceIdentifier/Data/Image/definition.ts
@@ -6,7 +6,7 @@ import type {
 } from '../EncodingIdentifier';
 
 import {
-  default as DataURI,
+  DataURI,
 } from '../definition.ts';
 
 import type {
@@ -43,5 +43,5 @@ class ImageURI
 }
 
 export {
-  ImageURI as default,
+  ImageURI,
 };

--- a/src/library/UniformResourceIdentifier/Data/Image/definition.ts
+++ b/src/library/UniformResourceIdentifier/Data/Image/definition.ts
@@ -5,7 +5,9 @@ import type {
   DataURI_EncodingIdentifier,
 } from '../EncodingIdentifier';
 
-import DataURI from '../definition.ts';
+import {
+  default as DataURI,
+} from '../definition.ts';
 
 import type {
   ImageURI_Format,

--- a/src/library/UniformResourceIdentifier/Data/Image/exports.ts
+++ b/src/library/UniformResourceIdentifier/Data/Image/exports.ts
@@ -1,3 +1,3 @@
 export {
-  default as default,
+  ImageURI as default,
 } from './definition.ts';

--- a/src/library/UniformResourceIdentifier/Data/definition.ts
+++ b/src/library/UniformResourceIdentifier/Data/definition.ts
@@ -4,7 +4,7 @@ import type ContentDescriptor from '@/library/ContentDescriptor';
 import NonTrivialString from '@/library/NonTrivialString';
 
 import {
-  default as UniformResourceIdentifier,
+  UniformResourceIdentifier,
 } from '../definition.ts';
 
 import type {
@@ -63,5 +63,5 @@ class DataURI
 }
 
 export {
-  DataURI as default,
+  DataURI,
 };

--- a/src/library/UniformResourceIdentifier/Data/definition.ts
+++ b/src/library/UniformResourceIdentifier/Data/definition.ts
@@ -3,7 +3,9 @@ import type Base64CharacterEncodedByteSequence from '@/library/Base64CharacterEn
 import type ContentDescriptor from '@/library/ContentDescriptor';
 import NonTrivialString from '@/library/NonTrivialString';
 
-import UniformResourceIdentifier from '../definition.ts';
+import {
+  default as UniformResourceIdentifier,
+} from '../definition.ts';
 
 import type {
   DataURI_EncodingIdentifier,

--- a/src/library/UniformResourceIdentifier/definition.ts
+++ b/src/library/UniformResourceIdentifier/definition.ts
@@ -77,5 +77,5 @@ class UniformResourceIdentifier {
 }
 
 export {
-  UniformResourceIdentifier as default,
+  UniformResourceIdentifier,
 };


### PR DESCRIPTION
- "definition" files only define what the "core" of a module _is_, not how that "core" is _presented_ to external modules, i.e. whether consumers will use the default export or named exports
- presentation should be delegated to "index" files