### PR TITLE
refactor: avoids shaping module APIs within "exports" files

### DIFF
--- a/src/features/TextToImage/models/SDXL/client/exports.ts
+++ b/src/features/TextToImage/models/SDXL/client/exports.ts
@@ -94,5 +94,5 @@ const SDXLTextToImageClient = {
 };
 
 export {
-  SDXLTextToImageClient as default,
+  SDXLTextToImageClient,
 };

--- a/src/features/TextToImage/models/SDXL/client/index.ts
+++ b/src/features/TextToImage/models/SDXL/client/index.ts
@@ -1,3 +1,3 @@
 export {
-  default as default,
+  SDXLTextToImageClient as default,
 } from './exports.ts';

--- a/src/library/Base64CharacterEncodedByteSequence/exports.ts
+++ b/src/library/Base64CharacterEncodedByteSequence/exports.ts
@@ -1,3 +1,3 @@
 export {
-  Base64CharacterEncodedByteSequence as default,
+  Base64CharacterEncodedByteSequence,
 } from './definition.ts';

--- a/src/library/Base64CharacterEncodedByteSequence/index.ts
+++ b/src/library/Base64CharacterEncodedByteSequence/index.ts
@@ -1,3 +1,3 @@
 export {
-  default as default,
+  Base64CharacterEncodedByteSequence as default,
 } from './exports.ts';

--- a/src/library/ContentDescriptor/exports.ts
+++ b/src/library/ContentDescriptor/exports.ts
@@ -1,5 +1,5 @@
 export {
-  ContentDescriptor as default,
+  ContentDescriptor,
 } from './definition.ts';
 
 export * from './misnomers';

--- a/src/library/ContentDescriptor/index.ts
+++ b/src/library/ContentDescriptor/index.ts
@@ -1,5 +1,5 @@
 export {
-  default as default,
+  ContentDescriptor as default,
   ContentType,
   MediaType,
   MIMEType,

--- a/src/library/NonTrivialString/exports.ts
+++ b/src/library/NonTrivialString/exports.ts
@@ -1,3 +1,3 @@
 export {
-  NonTrivialString as default,
+  NonTrivialString,
 } from './definition.ts';

--- a/src/library/NonTrivialString/index.ts
+++ b/src/library/NonTrivialString/index.ts
@@ -1,3 +1,3 @@
 export {
-  default as default,
+  NonTrivialString as default,
 } from './exports.ts';

--- a/src/library/Range/exports.ts
+++ b/src/library/Range/exports.ts
@@ -1,3 +1,3 @@
 export {
-  Range as default,
+  Range,
 } from './definition.ts';

--- a/src/library/Range/index.ts
+++ b/src/library/Range/index.ts
@@ -1,3 +1,3 @@
 export {
-  default as default,
+  Range as default,
 } from './exports.ts';

--- a/src/library/ShimmedStabilityAIClient/exports.ts
+++ b/src/library/ShimmedStabilityAIClient/exports.ts
@@ -1,3 +1,3 @@
 export {
-  ShimmedStabilityAIClient as default,
+  ShimmedStabilityAIClient,
 } from './definition.ts';

--- a/src/library/ShimmedStabilityAIClient/index.ts
+++ b/src/library/ShimmedStabilityAIClient/index.ts
@@ -1,3 +1,3 @@
 export {
-  default as default,
+  ShimmedStabilityAIClient as default,
 } from './exports.ts';

--- a/src/library/UniformResourceIdentifier/Data/Image/exports.ts
+++ b/src/library/UniformResourceIdentifier/Data/Image/exports.ts
@@ -1,3 +1,3 @@
 export {
-  ImageURI as default,
+  ImageURI,
 } from './definition.ts';

--- a/src/library/UniformResourceIdentifier/Data/Image/index.ts
+++ b/src/library/UniformResourceIdentifier/Data/Image/index.ts
@@ -1,3 +1,3 @@
 export {
-  default as default,
+  ImageURI as default,
 } from './exports.ts';


### PR DESCRIPTION
- "exports" files only determine what _is_ exposed to external modules
- "index" files only determine how exposed submodules are _presented_ to external modules
- the files in these changes mixed these concerns