### PR TITLE
prefeature(library/Range): exposes `Range.BoundContainment`

### DIFF
--- a/src/library/Range/definitionAugmentation.ts
+++ b/src/library/Range/definitionAugmentation.ts
@@ -1,0 +1,11 @@
+import type {
+  Range_BoundContainment,
+} from './BoundContainment';
+
+declare module './definition.ts' {
+  namespace Range {
+    export type {
+      Range_BoundContainment as BoundContainment,
+    };
+  }
+}

--- a/src/library/Range/definitionWithAugmentation.ts
+++ b/src/library/Range/definitionWithAugmentation.ts
@@ -1,1 +1,3 @@
+import './definitionAugmentation.ts';
+
 export * from './definition.ts';

--- a/src/library/Range/definitionWithAugmentation.ts
+++ b/src/library/Range/definitionWithAugmentation.ts
@@ -1,0 +1,1 @@
+export * from './definition.ts';

--- a/src/library/Range/exports.ts
+++ b/src/library/Range/exports.ts
@@ -1,3 +1,3 @@
 export {
   Range,
-} from './definition.ts';
+} from './definitionWithAugmentation.ts';


### PR DESCRIPTION
Follows up on #741 