### PR TITLE
refactor(library/Parser): restricts exports from all-type "definition" to type-only

### DIFF
--- a/src/library/Parser/definition.ts
+++ b/src/library/Parser/definition.ts
@@ -1,6 +1,6 @@
 import type Attempt from '@/library/Attempt';
 
-import ParsingError from './ParsingError';
+import type ParsingError from './ParsingError';
 
 interface Parser<
   SomeRawInput,
@@ -10,7 +10,7 @@ interface Parser<
   parsedFrom(givenSubject: SomeRawInput): Attempt.Outcome<SomeParsedOutput, SomeParsingError>;
 }
 
-export {
-  type Parser,
+export type {
+  Parser,
   ParsingError,
 };


### PR DESCRIPTION
- this particular re-export is not used at run-time by any consumer outside the module
- this restriction helps prevent circular exports

Facilitates #743