### PR TITLE
fix(library/Sequence): ensures intermediary namespaces

### DIFF
--- a/src/library/Sequence/Base64/index.ts
+++ b/src/library/Sequence/Base64/index.ts
@@ -1,1 +1,1 @@
-export * from './exports.ts';
+export * as Sequence_Base64 from './exports.ts';

--- a/src/library/Sequence/Byte/index.ts
+++ b/src/library/Sequence/Byte/index.ts
@@ -1,1 +1,1 @@
-export * from './exports.ts';
+export * as Sequence_Byte from './exports.ts';

--- a/src/library/Sequence/exports.ts
+++ b/src/library/Sequence/exports.ts
@@ -2,4 +2,6 @@ export {
   Sequence_Byte as Byte,
 } from './Byte';
 
-export * as Base64 from './Base64';
+export {
+  Sequence_Base64 as Base64,
+} from './Base64';

--- a/src/library/Sequence/exports.ts
+++ b/src/library/Sequence/exports.ts
@@ -1,3 +1,5 @@
-export * as Byte from './Byte';
+export {
+  Sequence_Byte as Byte,
+} from './Byte';
 
 export * as Base64 from './Base64';


### PR DESCRIPTION
Follows up on antipatterns introduced in #753, #754