### PR TITLE
refactor: ensures declarations are prefixed with top-level namespace

### DIFF
--- a/src/components/DiscreteSlider.vue
+++ b/src/components/DiscreteSlider.vue
@@ -17,7 +17,7 @@ import {
 } from 'vuetify/components/VSlider';
 
 import type Range from '@/library/Range';
-import DiscreteRange from '@/library/Range/DiscreteRange.ts';
+import Range_Discrete from '@/library/Range/DiscreteRange.ts';
 
 import {
   shallowlyMerged,
@@ -29,8 +29,8 @@ const currentValue = defineModel<number>({
 
 const given = defineProps<{
   label: string;
-  range: DiscreteRange;
-  tickStep: DiscreteRange['stepSize'];
+  range: Range_Discrete;
+  tickStep: Range_Discrete['stepSize'];
 }>();
 
 const incrementCurrentValueBy = (givenStepCount: number) => {
@@ -93,10 +93,10 @@ const tickLabelsAlong = (
   {
     atEvery: givenStepSize,
   }: {
-    atEvery: DiscreteRange['stepSize'];
+    atEvery: Range_Discrete['stepSize'];
   },
 ): SliderTickLabelsByPosition => {
-  const tickRange = DiscreteRange.spanning({
+  const tickRange = Range_Discrete.spanning({
     from: givenRange.lowerBound,
     to  : givenRange.upperBound,
     by  : givenStepSize,

--- a/src/features/TextToImage/Server/ServerSpecificationError.ts
+++ b/src/features/TextToImage/Server/ServerSpecificationError.ts
@@ -1,7 +1,7 @@
 import Attempt from '@/library/Attempt';
 
 import type {
-  URLPath,
+  URLComponent_Path,
 } from '@/library/URLComponent';
 
 class TextToImage_Server_SpecificationError
@@ -12,8 +12,8 @@ class TextToImage_Server_SpecificationError
 
   public constructor(
     public readonly environmentKey: string,
-    public readonly file: URLPath,
-    public readonly endpoint: URLPath,
+    public readonly file: URLComponent_Path,
+    public readonly endpoint: URLComponent_Path,
   ) {
     super('Failed to determine text-to-image server');
   }

--- a/src/features/TextToImage/Server/exports.ts
+++ b/src/features/TextToImage/Server/exports.ts
@@ -5,17 +5,17 @@ import {
 } from '@/library/WebAPI';
 
 import {
-  DynamicConfig,
-  StaticConfig,
-  emptyConfig,
+  DynamicConfig as TextToImage_DynamicConfig,
+  StaticConfig as TextToImage_StaticConfig,
+  TextToImage_emptyConfig,
 } from '../config';
 
 import TextToImage_Server_SpecificationError from './ServerSpecificationError';
 
-const environmentKeyForOriginOfTextToImageServer = 'VITE__TEXT_TO_IMAGE__API__SERVER__ORIGIN';
+const TextToImage_environmentKeyForOriginOfServer = 'VITE__TEXT_TO_IMAGE__API__SERVER__ORIGIN';
 
-const textToImageServerAccordingToEnvironment = ((): WebAPI_Server | null => {
-  const originAccordingToEnvironment = import.meta.env[environmentKeyForOriginOfTextToImageServer];
+const TextToImage_serverAccordingToEnvironment = ((): WebAPI_Server | null => {
+  const originAccordingToEnvironment = import.meta.env[TextToImage_environmentKeyForOriginOfServer];
 
   if (
     originAccordingToEnvironment === undefined
@@ -26,29 +26,29 @@ const textToImageServerAccordingToEnvironment = ((): WebAPI_Server | null => {
   });
 })();
 
-const retrieveCurrentTextToImageServer = (): Promise<
+const TextToImage_retrieveCurrentServer = (): Promise<
   Attempt.Outcome<WebAPI_Server, TextToImage_Server_SpecificationError>
 > => Attempt.thatEventually(async (ends) => {
   if (
-    textToImageServerAccordingToEnvironment !== null
-  ) return ends.inSuccessWith(textToImageServerAccordingToEnvironment);
+    TextToImage_serverAccordingToEnvironment !== null
+  ) return ends.inSuccessWith(TextToImage_serverAccordingToEnvironment);
 
-  const staticConfig = (await StaticConfig.read()).optionallyUnwrap() ?? emptyConfig;
+  const staticConfig = (await TextToImage_StaticConfig.read()).optionallyUnwrap() ?? TextToImage_emptyConfig;
 
   if (
     staticConfig.server !== null
   ) return ends.inSuccessWith(staticConfig.server);
 
-  const dynamicConfig = (await DynamicConfig.fetch()).optionallyUnwrap() ?? emptyConfig;
+  const dynamicConfig = (await TextToImage_DynamicConfig.fetch()).optionallyUnwrap() ?? TextToImage_emptyConfig;
 
   if (
     dynamicConfig.server !== null
   ) return ends.inSuccessWith(dynamicConfig.server);
 
   const newSpecificationError = new TextToImage_Server_SpecificationError(
-    environmentKeyForOriginOfTextToImageServer,
-    StaticConfig.file,
-    DynamicConfig.endpoint,
+    TextToImage_environmentKeyForOriginOfServer,
+    TextToImage_StaticConfig.file,
+    TextToImage_DynamicConfig.endpoint,
   );
 
   return ends.inFailureDueTo(newSpecificationError);
@@ -59,7 +59,7 @@ export {
 } from './ServerConnectionError';
 
 export {
-  textToImageServerAccordingToEnvironment as accordingToEnvironment,
-  retrieveCurrentTextToImageServer as retrieveCurrent,
+  TextToImage_serverAccordingToEnvironment as accordingToEnvironment,
+  TextToImage_retrieveCurrentServer as retrieveCurrent,
   TextToImage_Server_SpecificationError as SpecificationError,
 };

--- a/src/features/TextToImage/Server/exports.ts
+++ b/src/features/TextToImage/Server/exports.ts
@@ -1,7 +1,7 @@
 import Attempt from '@/library/Attempt';
 
 import {
-  Server,
+  Server as WebAPI_Server,
 } from '@/library/WebAPI';
 
 import {
@@ -14,20 +14,20 @@ import TextToImage_Server_SpecificationError from './ServerSpecificationError';
 
 const environmentKeyForOriginOfTextToImageServer = 'VITE__TEXT_TO_IMAGE__API__SERVER__ORIGIN';
 
-const textToImageServerAccordingToEnvironment = ((): Server | null => {
+const textToImageServerAccordingToEnvironment = ((): WebAPI_Server | null => {
   const originAccordingToEnvironment = import.meta.env[environmentKeyForOriginOfTextToImageServer];
 
   if (
     originAccordingToEnvironment === undefined
   ) return null;
 
-  return Server.from({
+  return WebAPI_Server.from({
     origin: originAccordingToEnvironment,
   });
 })();
 
 const retrieveCurrentTextToImageServer = (): Promise<
-  Attempt.Outcome<Server, TextToImage_Server_SpecificationError>
+  Attempt.Outcome<WebAPI_Server, TextToImage_Server_SpecificationError>
 > => Attempt.thatEventually(async (ends) => {
   if (
     textToImageServerAccordingToEnvironment !== null

--- a/src/features/TextToImage/client/SDXL/conversions/GenerateFromTextResponse.ts
+++ b/src/features/TextToImage/client/SDXL/conversions/GenerateFromTextResponse.ts
@@ -9,8 +9,8 @@ import {
 } from '@/library/utilitiesByType/array';
 
 import type {
-  Input,
-  Output,
+  Input as TextToImage_Input,
+  Output as TextToImage_Output,
 } from '@/features/TextToImage/types';
 
 import {
@@ -22,8 +22,8 @@ import {
 } from './TextPrompt';
 
 const toNullableOutput = (
-  givenImage: Output['image'] | null,
-): Output | null => {
+  givenImage: TextToImage_Output['image'] | null,
+): TextToImage_Output | null => {
   if (
     givenImage === null
   ) return null;
@@ -39,9 +39,9 @@ const textToImageOutputs = (
     inferredFrom: givenInputText,
   }: {
     in: GenerateFromTextResponse;
-    inferredFrom: Input['text'];
+    inferredFrom: TextToImage_Input['text'];
   },
-): (Output | null)[] | null => {
+): (TextToImage_Output | null)[] | null => {
   if (
     !('artifacts' in givenResponse.result)
   ) return Attempt.abandon('Expected response body rather than readable stream');
@@ -67,9 +67,9 @@ const firstTextToImageOutput = (
     inferredFrom: givenInputText,
   }: {
     in: GenerateFromTextResponse;
-    inferredFrom: Input['text'];
+    inferredFrom: TextToImage_Input['text'];
   },
-): Output => {
+): TextToImage_Output => {
   const inferredOutputs = textToImageOutputs({
     in          : givenResponse,
     inferredFrom: givenInputText,

--- a/src/features/TextToImage/client/SDXL/conversions/StabilityAI_Client_Image.ts
+++ b/src/features/TextToImage/client/SDXL/conversions/StabilityAI_Client_Image.ts
@@ -1,7 +1,7 @@
 import type * as StabilityAIClient from 'stabilityai-client-typescript/models/components';
 
 import Base64CharacterEncodedByteSequence from '@/library/Base64CharacterEncodedByteSequence';
-import ImageURI from '@/library/UniformResourceIdentifier/Data/Image';
+import URI_Image from '@/library/UniformResourceIdentifier/Data/Image';
 
 import type {
   Output,
@@ -20,7 +20,7 @@ const toOutputImage = (
   const base64DataOfRawImage = Base64CharacterEncodedByteSequence.parsedFrom(givenImage.base64).forciblyUnwrap(/* Broken web contracts require intervention */);
 
   const derivedImage = {
-    uri        : new ImageURI('png', 'base64', base64DataOfRawImage),
+    uri        : new URI_Image('png', 'base64', base64DataOfRawImage),
     description: given.description,
   };
 

--- a/src/features/TextToImage/client/SDXL/conversions/StabilityAI_Client_Image.ts
+++ b/src/features/TextToImage/client/SDXL/conversions/StabilityAI_Client_Image.ts
@@ -4,7 +4,7 @@ import Base64CharacterEncodedByteSequence from '@/library/Base64CharacterEncoded
 import URI_Image from '@/library/UniformResourceIdentifier/Data/Image';
 
 import type {
-  Output,
+  Output as TextToImage_Output,
 } from '@/features/TextToImage/types';
 
 const toOutputImage = (
@@ -12,7 +12,7 @@ const toOutputImage = (
   given: {
     description: string;
   },
-): Output['image'] | null => {
+): TextToImage_Output['image'] | null => {
   if (
     givenImage.base64 === undefined
   ) return null;

--- a/src/features/TextToImage/client/SDXL/exports.ts
+++ b/src/features/TextToImage/client/SDXL/exports.ts
@@ -7,19 +7,19 @@ import HTTP from '@/library/HTTP';
 import ShimmedStabilityAIClient from '@/library/ShimmedStabilityAIClient';
 
 import type {
-  Output,
+  Output as TextToImage_Output,
 } from '@/features/TextToImage/types';
 
-import * as Server from '../../Server';
+import * as TextToImage_Server from '../../Server';
 
 import {
   firstTextToImageOutput,
 } from './conversions/GenerateFromTextResponse';
 
-const initializeShimmedStabilityAIClient = async (): Promise<
-  Attempt.Outcome<ShimmedStabilityAIClient, Server.SpecificationError>
+const TextToImage_initializeShimmedStabilityAIClient = async (): Promise<
+  Attempt.Outcome<ShimmedStabilityAIClient, TextToImage_Server.SpecificationError>
 > => {
-  const outcomeOfRetrievingCurrentServer = await Server.retrieveCurrent();
+  const outcomeOfRetrievingCurrentServer = await TextToImage_Server.retrieveCurrent();
 
   const outcomeOfInitializingClient = Attempt.Outcome.fromRewrapping(outcomeOfRetrievingCurrentServer, {
     product: textToImageServer => new ShimmedStabilityAIClient({
@@ -30,12 +30,12 @@ const initializeShimmedStabilityAIClient = async (): Promise<
   return outcomeOfInitializingClient;
 };
 
-type OutcomeOfGeneratingTextToImageOutput = Attempt.Outcome<Output,
-  | Server.ConnectionError
-  | Server.SpecificationError
+type TextToImage_OutcomeOfGeneratingOutput = Attempt.Outcome<TextToImage_Output,
+  | TextToImage_Server.ConnectionError
+  | TextToImage_Server.SpecificationError
 >;
 
-const generateOutputFrom = async (
+const TextToImage_generateOutputFrom = async (
   given: {
     textToImageRequestBody: Pick<GenerateFromTextRequest['textToImageRequestBody'],
     | 'textPrompts'
@@ -46,8 +46,8 @@ const generateOutputFrom = async (
     | 'seed'
     >;
   },
-): Promise<OutcomeOfGeneratingTextToImageOutput> => {
-  const outcomeOfInitializingClient = await initializeShimmedStabilityAIClient();
+): Promise<TextToImage_OutcomeOfGeneratingOutput> => {
+  const outcomeOfInitializingClient = await TextToImage_initializeShimmedStabilityAIClient();
 
   if (
     outcomeOfInitializingClient.isFailure
@@ -73,7 +73,7 @@ const generateOutputFrom = async (
         !(caughtError instanceof HTTP.Endpoint.RequestError)
       ) return null;
 
-      return new Server.ConnectionError(caughtError.endpoint);
+      return new TextToImage_Server.ConnectionError(caughtError.endpoint);
     },
   });
 
@@ -87,10 +87,10 @@ const generateOutputFrom = async (
   return outcomeOfSettlingSoleTextToImageOutput;
 };
 
-const SDXLTextToImageClient = {
-  generateOutputFrom,
+const TextToImage_SDXLClient = {
+  generateOutputFrom: TextToImage_generateOutputFrom,
 };
 
 export {
-  SDXLTextToImageClient,
+  TextToImage_SDXLClient,
 };

--- a/src/features/TextToImage/client/SDXL/index.ts
+++ b/src/features/TextToImage/client/SDXL/index.ts
@@ -1,3 +1,3 @@
 export {
-  SDXLTextToImageClient as default,
+  TextToImage_SDXLClient as default,
 } from './exports.ts';

--- a/src/features/TextToImage/components/TextToImageInputSection.vue
+++ b/src/features/TextToImage/components/TextToImageInputSection.vue
@@ -16,10 +16,10 @@ import {
 } from 'vuetify/components/VTextarea';
 
 import type {
-  Input,
+  Input as TextToImage_Input,
 } from '../types';
 
-type StandardizedInputText = Input['text'];
+type StandardizedInputText = TextToImage_Input['text'];
 
 const exposedInputText = defineModel<StandardizedInputText | null>({
   required: true,

--- a/src/features/TextToImage/config/utilities/DynamicConfig/EndpointResponseError.ts
+++ b/src/features/TextToImage/config/utilities/DynamicConfig/EndpointResponseError.ts
@@ -1,7 +1,7 @@
 import Attempt from '@/library/Attempt';
 
 import type {
-  URLPath,
+  URLComponent_Path,
 } from '@/library/URLComponent';
 
 class DynamicConfig_EndpointResponseError
@@ -11,7 +11,7 @@ class DynamicConfig_EndpointResponseError
   public override name = 'DynamicConfig_EndpointResponseError' as const;
 
   public constructor(given: {
-    endpoint: URLPath;
+    endpoint: URLComponent_Path;
     response: Response;
   }) {
     super(`Expected JSON response from "${given.endpoint.toString()}", but received content-type: ${given.response.headers.get('Content-Type') ?? ''}`);

--- a/src/features/TextToImage/config/utilities/DynamicConfig/EndpointResponseError.ts
+++ b/src/features/TextToImage/config/utilities/DynamicConfig/EndpointResponseError.ts
@@ -4,11 +4,11 @@ import type {
   URLComponent_Path,
 } from '@/library/URLComponent';
 
-class DynamicConfig_EndpointResponseError
+class TextToImage_DynamicConfig_EndpointResponseError
   extends Attempt.ActionableError<
-  'DynamicConfig_EndpointResponseError'
+  'TextToImage_DynamicConfig_EndpointResponseError'
 > {
-  public override name = 'DynamicConfig_EndpointResponseError' as const;
+  public override name = 'TextToImage_DynamicConfig_EndpointResponseError' as const;
 
   public constructor(given: {
     endpoint: URLComponent_Path;
@@ -19,5 +19,5 @@ class DynamicConfig_EndpointResponseError
 }
 
 export {
-  DynamicConfig_EndpointResponseError as default,
+  TextToImage_DynamicConfig_EndpointResponseError as default,
 };

--- a/src/features/TextToImage/config/utilities/DynamicConfig/FetchingError.ts
+++ b/src/features/TextToImage/config/utilities/DynamicConfig/FetchingError.ts
@@ -1,7 +1,7 @@
 import Attempt from '@/library/Attempt';
 
 import type {
-  URLPath,
+  URLComponent_Path,
 } from '@/library/URLComponent';
 
 class DynamicConfig_FetchingError
@@ -11,7 +11,7 @@ class DynamicConfig_FetchingError
   public override name = 'DynamicConfig_FetchingError' as const;
 
   public constructor(
-    givenEndpoint: URLPath,
+    givenEndpoint: URLComponent_Path,
   ) {
     super(`Failed to fetch text-to-image config from endpoint: ${givenEndpoint.toString()}`);
   }

--- a/src/features/TextToImage/config/utilities/DynamicConfig/FetchingError.ts
+++ b/src/features/TextToImage/config/utilities/DynamicConfig/FetchingError.ts
@@ -4,11 +4,11 @@ import type {
   URLComponent_Path,
 } from '@/library/URLComponent';
 
-class DynamicConfig_FetchingError
+class TextToImage_DynamicConfig_FetchingError
   extends Attempt.ActionableError<
-  'DynamicConfig_FetchingError'
+  'TextToImage_DynamicConfig_FetchingError'
 > {
-  public override name = 'DynamicConfig_FetchingError' as const;
+  public override name = 'TextToImage_DynamicConfig_FetchingError' as const;
 
   public constructor(
     givenEndpoint: URLComponent_Path,
@@ -18,5 +18,5 @@ class DynamicConfig_FetchingError
 }
 
 export {
-  DynamicConfig_FetchingError as default,
+  TextToImage_DynamicConfig_FetchingError as default,
 };

--- a/src/features/TextToImage/config/utilities/DynamicConfig/exports.ts
+++ b/src/features/TextToImage/config/utilities/DynamicConfig/exports.ts
@@ -5,13 +5,13 @@ import {
 } from '@/library/URLComponent';
 
 import {
-  Config,
+  Config as TextToImage_Config,
 } from '../../types';
 
-import DynamicConfig_EndpointResponseError from './EndpointResponseError';
-import DynamicConfig_FetchingError from './FetchingError';
+import TextToImage_DynamicConfig_EndpointResponseError from './EndpointResponseError';
+import TextToImage_DynamicConfig_FetchingError from './FetchingError';
 
-const contentIsJSONIn = (givenResponse: Response): boolean => {
+const HTTP_contentIsJSONIn = (givenResponse: Response): boolean => {
   const rawContentDescriptor = givenResponse.headers.get('Content-Type');
 
   if (
@@ -21,38 +21,38 @@ const contentIsJSONIn = (givenResponse: Response): boolean => {
   return rawContentDescriptor.includes('application/json');
 };
 
-const configEndpoint = URLComponent_Path.parsedFrom('/config/text-to-image').forciblyUnwrap();
+const TextToImage_configEndpoint = URLComponent_Path.parsedFrom('/config/text-to-image').forciblyUnwrap();
 
-type OutcomeOfFetchingConfig = Attempt.Outcome<Config,
-  | DynamicConfig_FetchingError
-  | DynamicConfig_EndpointResponseError
+type TextToImage_OutcomeOfFetchingConfig = Attempt.Outcome<TextToImage_Config,
+  | TextToImage_DynamicConfig_FetchingError
+  | TextToImage_DynamicConfig_EndpointResponseError
 >;
 
-const fetchConfig = (): Promise<OutcomeOfFetchingConfig> => Attempt.thatEventually(async (ends) => {
-  const endpointResponse = await fetch(configEndpoint.toString());
-  const fetchingError = new DynamicConfig_FetchingError(configEndpoint);
+const TextToImage_fetchConfig = (): Promise<TextToImage_OutcomeOfFetchingConfig> => Attempt.thatEventually(async (ends) => {
+  const endpointResponse = await fetch(TextToImage_configEndpoint.toString());
+  const fetchingError = new TextToImage_DynamicConfig_FetchingError(TextToImage_configEndpoint);
 
   if (
     !endpointResponse.ok
   ) return ends.inFailureDueTo(fetchingError);
 
-  const endpointResponseError = new DynamicConfig_EndpointResponseError({
-    endpoint: configEndpoint,
+  const endpointResponseError = new TextToImage_DynamicConfig_EndpointResponseError({
+    endpoint: TextToImage_configEndpoint,
     response: endpointResponse,
   });
 
   if (
-    !contentIsJSONIn(endpointResponse)
+    !HTTP_contentIsJSONIn(endpointResponse)
   ) return ends.inFailureDueTo(endpointResponseError);
 
   const rawConfig = await endpointResponse.json() as unknown;
-  const parsedConfig = Config.parsedFrom(rawConfig).forciblyUnwrap(/* Implementation must align with established contract. */);
+  const parsedConfig = TextToImage_Config.parsedFrom(rawConfig).forciblyUnwrap(/* Implementation must align with established contract. */);
   return ends.inSuccessWith(parsedConfig);
 });
 
 export {
-  configEndpoint as endpoint,
-  fetchConfig as fetch,
-  DynamicConfig_FetchingError as FetchingError,
-  DynamicConfig_EndpointResponseError as EndpointResponseError,
+  TextToImage_configEndpoint as endpoint,
+  TextToImage_fetchConfig as fetch,
+  TextToImage_DynamicConfig_FetchingError as FetchingError,
+  TextToImage_DynamicConfig_EndpointResponseError as EndpointResponseError,
 };

--- a/src/features/TextToImage/config/utilities/DynamicConfig/exports.ts
+++ b/src/features/TextToImage/config/utilities/DynamicConfig/exports.ts
@@ -1,7 +1,7 @@
 import Attempt from '@/library/Attempt';
 
 import {
-  URLPath,
+  URLComponent_Path,
 } from '@/library/URLComponent';
 
 import {
@@ -21,7 +21,7 @@ const contentIsJSONIn = (givenResponse: Response): boolean => {
   return rawContentDescriptor.includes('application/json');
 };
 
-const configEndpoint = URLPath.parsedFrom('/config/text-to-image').forciblyUnwrap();
+const configEndpoint = URLComponent_Path.parsedFrom('/config/text-to-image').forciblyUnwrap();
 
 type OutcomeOfFetchingConfig = Attempt.Outcome<Config,
   | DynamicConfig_FetchingError

--- a/src/features/TextToImage/config/utilities/StaticConfig/StaticConfigReadingError.ts
+++ b/src/features/TextToImage/config/utilities/StaticConfig/StaticConfigReadingError.ts
@@ -4,11 +4,11 @@ import type {
   URLComponent_Path,
 } from '@/library/URLComponent';
 
-class StaticConfigReadingError
+class TextToImage_StaticConfigReadingError
   extends Attempt.ActionableError<
-  'StaticConfigReadingError'
+  'TextToImage_StaticConfigReadingError'
 > {
-  public override name = 'StaticConfigReadingError' as const;
+  public override name = 'TextToImage_StaticConfigReadingError' as const;
 
   public constructor(
     givenFile: URLComponent_Path,
@@ -19,5 +19,5 @@ class StaticConfigReadingError
 }
 
 export {
-  StaticConfigReadingError as default,
+  TextToImage_StaticConfigReadingError as default,
 };

--- a/src/features/TextToImage/config/utilities/StaticConfig/StaticConfigReadingError.ts
+++ b/src/features/TextToImage/config/utilities/StaticConfig/StaticConfigReadingError.ts
@@ -1,7 +1,7 @@
 import Attempt from '@/library/Attempt';
 
 import type {
-  URLPath,
+  URLComponent_Path,
 } from '@/library/URLComponent';
 
 class StaticConfigReadingError
@@ -11,7 +11,7 @@ class StaticConfigReadingError
   public override name = 'StaticConfigReadingError' as const;
 
   public constructor(
-    givenFile: URLPath,
+    givenFile: URLComponent_Path,
     givenResponse: Response,
   ) {
     super(`Failed to read config at "${givenFile.toString()}". Cause: "${givenResponse.statusText}"`);

--- a/src/features/TextToImage/config/utilities/StaticConfig/exports.ts
+++ b/src/features/TextToImage/config/utilities/StaticConfig/exports.ts
@@ -5,32 +5,32 @@ import {
 } from '@/library/URLComponent';
 
 import {
-  Config,
+  Config as TextToImage_Config,
 } from '../../types';
 
-import StaticConfigReadingError from './StaticConfigReadingError';
+import TextToImage_StaticConfigReadingError from './StaticConfigReadingError';
 
-const configFile = URLComponent_Path.parsedFrom('/config/text-to-image.json').forciblyUnwrap();
+const TextToImage_configFile = URLComponent_Path.parsedFrom('/config/text-to-image.json').forciblyUnwrap();
 
-type OutcomeOfReadingConfig = Attempt.Outcome<
-  Config,
-  StaticConfigReadingError
+type TextToImage_OutcomeOfReadingConfig = Attempt.Outcome<
+  TextToImage_Config,
+  TextToImage_StaticConfigReadingError
 >;
 
-const readConfig = (): Promise<OutcomeOfReadingConfig> => Attempt.thatEventually(async (ends) => {
-  const fileResponse = await fetch(configFile.toString());
+const TextToImage_readConfig = (): Promise<TextToImage_OutcomeOfReadingConfig> => Attempt.thatEventually(async (ends) => {
+  const fileResponse = await fetch(TextToImage_configFile.toString());
 
   if (
     !fileResponse.ok
-  ) return ends.inFailureDueTo(new StaticConfigReadingError(configFile, fileResponse));
+  ) return ends.inFailureDueTo(new TextToImage_StaticConfigReadingError(TextToImage_configFile, fileResponse));
 
   const rawConfig = await fileResponse.json() as unknown;
-  const parsedConfig = Config.parsedFrom(rawConfig).forciblyUnwrap(/* Implementation must align with established contract. */);
+  const parsedConfig = TextToImage_Config.parsedFrom(rawConfig).forciblyUnwrap(/* Implementation must align with established contract. */);
   return ends.inSuccessWith(parsedConfig);
 });
 
 export {
-  configFile as file,
-  readConfig as read,
-  StaticConfigReadingError as ReadingError,
+  TextToImage_configFile as file,
+  TextToImage_readConfig as read,
+  TextToImage_StaticConfigReadingError as ReadingError,
 };

--- a/src/features/TextToImage/config/utilities/StaticConfig/exports.ts
+++ b/src/features/TextToImage/config/utilities/StaticConfig/exports.ts
@@ -1,7 +1,7 @@
 import Attempt from '@/library/Attempt';
 
 import {
-  URLPath,
+  URLComponent_Path,
 } from '@/library/URLComponent';
 
 import {
@@ -10,7 +10,7 @@ import {
 
 import StaticConfigReadingError from './StaticConfigReadingError';
 
-const configFile = URLPath.parsedFrom('/config/text-to-image.json').forciblyUnwrap();
+const configFile = URLComponent_Path.parsedFrom('/config/text-to-image.json').forciblyUnwrap();
 
 type OutcomeOfReadingConfig = Attempt.Outcome<
   Config,

--- a/src/features/TextToImage/config/utilities/emptyConfig.ts
+++ b/src/features/TextToImage/config/utilities/emptyConfig.ts
@@ -1,11 +1,11 @@
 import type {
-  Config,
+  Config as TextToImage_Config,
 } from '../types';
 
-const emptyConfig: Config = {
+const TextToImage_emptyConfig: TextToImage_Config = {
   server: null,
 };
 
 export {
-  emptyConfig,
+  TextToImage_emptyConfig,
 };

--- a/src/features/TextToImage/types/Output/Image.ts
+++ b/src/features/TextToImage/types/Output/Image.ts
@@ -1,7 +1,7 @@
-import type ImageURI from '@/library/UniformResourceIdentifier/Data/Image';
+import type URI_Image from '@/library/UniformResourceIdentifier/Data/Image';
 
 interface TextToImage_Output_Image {
-  uri: ImageURI;
+  uri: URI_Image;
   description: string;
 }
 

--- a/src/library/Attempt/Outcome/Discriminable.ts
+++ b/src/library/Attempt/Outcome/Discriminable.ts
@@ -5,26 +5,26 @@ import type {
 } from '@/library/typeUtilities/Boolean';
 
 import type {
-  ActionableError,
+  Attempt_ActionableError,
 } from '../error';
 
 type Attempt_Outcome_Discriminant = 'success' | 'failure';
 
 // cspell:words sugarfree discriminable
-interface SyntacticallySugarfreeDiscriminableOutcome<
+interface Attempt_SyntacticallySugarfreeDiscriminableOutcome<
   SomeDiscriminant extends Attempt_Outcome_Discriminant,
 > {
   readonly discriminant: SomeDiscriminant;
 }
 
-interface DiscriminableOutcome<
+interface Attempt_DiscriminableOutcome<
   SomeDiscriminant extends Attempt_Outcome_Discriminant,
   SomePayload extends (
     SomeDiscriminant extends 'success'
       ? unknown
-      : ActionableError<string>
+      : Attempt_ActionableError<string>
   ),
-> extends SyntacticallySugarfreeDiscriminableOutcome<
+> extends Attempt_SyntacticallySugarfreeDiscriminableOutcome<
   SomeDiscriminant
 > {
   readonly isSuccess: Is<this['discriminant'], 'success'>;
@@ -44,11 +44,11 @@ interface DiscriminableOutcome<
     TransformedPayload extends (
       SomeDiscriminant extends 'success'
         ? unknown
-        : ActionableError<string>
+        : Attempt_ActionableError<string>
     ) = SomePayload,
-  >(): DiscriminableOutcome<SomeDiscriminant, TransformedPayload>;
+  >(): Attempt_DiscriminableOutcome<SomeDiscriminant, TransformedPayload>;
 }
 
 export type {
-  DiscriminableOutcome,
+  Attempt_DiscriminableOutcome,
 };

--- a/src/library/Attempt/Outcome/Failure/Transformer.ts
+++ b/src/library/Attempt/Outcome/Failure/Transformer.ts
@@ -1,17 +1,17 @@
 import type {
-  ActionableError,
+  Attempt_ActionableError,
 } from '../../error';
 
-type CauseTransformer<
-  SomeTransformableActionableError extends ActionableError<string>,
-  SomeTransformedActionableError extends ActionableError<string>,
+type Attempt_CauseTransformer<
+  SomeTransformableActionableError extends Attempt_ActionableError<string>,
+  SomeTransformedActionableError extends Attempt_ActionableError<string>,
 > = (
   transformableCause: SomeTransformableActionableError,
 ) => SomeTransformedActionableError;
 
-const causeIdentity = <
-  SomeTransformableActionableError extends ActionableError<string>,
-  SomeTransformedActionableError extends ActionableError<string>,
+const Attempt_causeIdentity = <
+  SomeTransformableActionableError extends Attempt_ActionableError<string>,
+  SomeTransformedActionableError extends Attempt_ActionableError<string>,
 >(
   transformableCause: NoInfer<SomeTransformableActionableError>,
 ): NoInfer<SomeTransformedActionableError> => {
@@ -19,10 +19,10 @@ const causeIdentity = <
 };
 
 interface Attempt_Failure_Transformer<
-  SomeTransformableActionableError extends ActionableError<string>,
-  SomeTransformedActionableError extends ActionableError<string>,
+  SomeTransformableActionableError extends Attempt_ActionableError<string>,
+  SomeTransformedActionableError extends Attempt_ActionableError<string>,
 > {
-  cause: CauseTransformer<
+  cause: Attempt_CauseTransformer<
     SomeTransformableActionableError,
     SomeTransformedActionableError
   >;
@@ -30,5 +30,5 @@ interface Attempt_Failure_Transformer<
 
 export {
   type Attempt_Failure_Transformer,
-  causeIdentity,
+  Attempt_causeIdentity,
 };

--- a/src/library/Attempt/Outcome/Failure/exports.ts
+++ b/src/library/Attempt/Outcome/Failure/exports.ts
@@ -1,21 +1,21 @@
 // cspell:words sugarfree discriminable
 
 import type {
-  ActionableError,
+  Attempt_ActionableError,
 } from '../../error';
 
 import type {
-  DiscriminableOutcome,
+  Attempt_DiscriminableOutcome,
 } from '../Discriminable';
 
 import {
   type Attempt_Failure_Transformer,
-  causeIdentity,
+  Attempt_causeIdentity,
 } from './Transformer';
 
-interface SemanticallySugarfreeFailure<
-  SomeActionableError extends ActionableError<string>,
-> extends DiscriminableOutcome<
+interface Attempt_SemanticallySugarfreeFailure<
+  SomeActionableError extends Attempt_ActionableError<string>,
+> extends Attempt_DiscriminableOutcome<
   'failure',
   SomeActionableError
 > {
@@ -23,8 +23,8 @@ interface SemanticallySugarfreeFailure<
 }
 
 interface Attempt_Failure<
-  SomeActionableError extends ActionableError<string>,
-> extends SemanticallySugarfreeFailure<
+  SomeActionableError extends Attempt_ActionableError<string>,
+> extends Attempt_SemanticallySugarfreeFailure<
   SomeActionableError
 > {
   /**
@@ -47,7 +47,7 @@ interface Attempt_Failure<
   readonly causeOfFailure: this['cause'];
 
   rewrappedWith<
-    TransformedActionableError extends ActionableError<string> = SomeActionableError,
+    TransformedActionableError extends Attempt_ActionableError<string> = SomeActionableError,
   >(
     given?: Attempt_Failure_Transformer<
       SomeActionableError,
@@ -56,8 +56,8 @@ interface Attempt_Failure<
   ): Attempt_Failure<TransformedActionableError>;
 }
 
-const failureDueTo = <
-  SomeActionableError extends ActionableError<string>,
+const Attempt_failureDueTo = <
+  SomeActionableError extends Attempt_ActionableError<string>,
 >(
   givenCause: SomeActionableError,
 ): Attempt_Failure<SomeActionableError> => ({
@@ -69,16 +69,16 @@ const failureDueTo = <
   forciblyUnwrap  : () => givenCause.throwAnyway('Unexpected forceful unwrap of a failure'),
   causeOfFailure  : givenCause,
   rewrappedWith   : <
-    TransformedActionableError extends ActionableError<string>,
+    TransformedActionableError extends Attempt_ActionableError<string>,
   >(
     {
       cause: transformed,
     } = {
-      cause: causeIdentity<SomeActionableError, TransformedActionableError>,
+      cause: Attempt_causeIdentity<SomeActionableError, TransformedActionableError>,
     },
   ) => {
     const transformedCause = transformed(givenCause);
-    const transformedFailure = failureDueTo(transformedCause);
+    const transformedFailure = Attempt_failureDueTo(transformedCause);
     return transformedFailure;
   },
 });
@@ -86,6 +86,6 @@ const failureDueTo = <
 export {
   type Attempt_Failure,
   type Attempt_Failure_Transformer,
-  failureDueTo,
-  causeIdentity,
+  Attempt_failureDueTo,
+  Attempt_causeIdentity,
 };

--- a/src/library/Attempt/Outcome/Success/Transformer.ts
+++ b/src/library/Attempt/Outcome/Success/Transformer.ts
@@ -1,11 +1,11 @@
-type ProductTransformer<
+type Attempt_ProductTransformer<
   SomeTransformableProduct,
   SomeTransformedProduct,
 > = (
   transformableProduct: SomeTransformableProduct,
 ) => SomeTransformedProduct;
 
-const productIdentity = <
+const Attempt_productIdentity = <
   SomeTransformableProduct,
   SomeTransformedProduct,
 >(
@@ -18,7 +18,7 @@ interface Attempt_Success_Transformer<
   SomeTransformableProduct,
   SomeTransformedProduct,
 > {
-  product: ProductTransformer<
+  product: Attempt_ProductTransformer<
     SomeTransformableProduct,
     SomeTransformedProduct
   >;
@@ -26,5 +26,5 @@ interface Attempt_Success_Transformer<
 
 export {
   type Attempt_Success_Transformer,
-  productIdentity,
+  Attempt_productIdentity,
 };

--- a/src/library/Attempt/Outcome/Success/exports.ts
+++ b/src/library/Attempt/Outcome/Success/exports.ts
@@ -1,17 +1,17 @@
 // cspell:words sugarfree discriminable
 
 import type {
-  DiscriminableOutcome,
+  Attempt_DiscriminableOutcome,
 } from '../Discriminable';
 
 import {
   type Attempt_Success_Transformer,
-  productIdentity,
+  Attempt_productIdentity,
 } from './Transformer';
 
-interface SemanticallySugarfreeSuccess<
+interface Attempt_SemanticallySugarfreeSuccess<
   SomeProduct,
-> extends DiscriminableOutcome<
+> extends Attempt_DiscriminableOutcome<
   'success',
   SomeProduct
 > {
@@ -20,7 +20,7 @@ interface SemanticallySugarfreeSuccess<
 
 interface Attempt_Success<
   SomeProduct,
-> extends SemanticallySugarfreeSuccess<
+> extends Attempt_SemanticallySugarfreeSuccess<
   SomeProduct
 > {
   /**
@@ -64,7 +64,7 @@ interface Attempt_Success<
   ): Attempt_Success<TransformedProduct>;
 }
 
-const successThatYielded = <
+const Attempt_successThatYielded = <
   SomeProduct,
 >(
   givenProduct: SomeProduct,
@@ -82,11 +82,11 @@ const successThatYielded = <
     {
       product: transformed,
     } = {
-      product: productIdentity<SomeProduct, TransformedProduct>,
+      product: Attempt_productIdentity<SomeProduct, TransformedProduct>,
     },
   ) => {
     const transformedProduct = transformed(givenProduct);
-    const transformedSuccess = successThatYielded(transformedProduct);
+    const transformedSuccess = Attempt_successThatYielded(transformedProduct);
     return transformedSuccess;
   },
 });
@@ -94,6 +94,6 @@ const successThatYielded = <
 export {
   type Attempt_Success,
   type Attempt_Success_Transformer,
-  successThatYielded,
-  productIdentity,
+  Attempt_successThatYielded,
+  Attempt_productIdentity,
 };

--- a/src/library/Attempt/Outcome/Transformer.ts
+++ b/src/library/Attempt/Outcome/Transformer.ts
@@ -1,5 +1,5 @@
 import type {
-  ActionableError,
+  Attempt_ActionableError,
 } from '../error';
 
 import type {
@@ -12,9 +12,9 @@ import type {
 
 type Attempt_Outcome_Transformer<
   SomeTransformableProduct,
-  SomeTransformableActionableError extends ActionableError<string>,
+  SomeTransformableActionableError extends Attempt_ActionableError<string>,
   SomeTransformedProduct,
-  SomeTransformedActionableError extends ActionableError<string>,
+  SomeTransformedActionableError extends Attempt_ActionableError<string>,
 > =
   | (
     & Required<

--- a/src/library/Attempt/Outcome/exports.ts
+++ b/src/library/Attempt/Outcome/exports.ts
@@ -1,19 +1,19 @@
 import type {
-  ActionableError,
+  Attempt_ActionableError,
 } from '../error';
 
 import {
   type Attempt_Failure,
   type Attempt_Failure_Transformer,
-  failureDueTo,
-  causeIdentity,
+  Attempt_failureDueTo,
+  Attempt_causeIdentity,
 } from './Failure';
 
 import {
   type Attempt_Success,
   type Attempt_Success_Transformer,
-  successThatYielded,
-  productIdentity,
+  Attempt_successThatYielded,
+  Attempt_productIdentity,
 } from './Success';
 
 import type {
@@ -22,7 +22,7 @@ import type {
 
 type Attempt_Outcome<
   SomeProduct,
-  SomeActionableError extends ActionableError<string>,
+  SomeActionableError extends Attempt_ActionableError<string>,
 > =
   | Attempt_Success<SomeProduct>
   | Attempt_Failure<SomeActionableError>
@@ -36,9 +36,9 @@ type Attempt_Outcome<
 *
 * Helps avoid boilerplate when transforming outcomes.
 */
-function fromRewrapping<
-  SomeTransformableActionableError extends ActionableError<string>,
-  SomeTransformedActionableError extends ActionableError<string> = SomeTransformableActionableError,
+function Attempt_fromRewrapping<
+  SomeTransformableActionableError extends Attempt_ActionableError<string>,
+  SomeTransformedActionableError extends Attempt_ActionableError<string> = SomeTransformableActionableError,
 >(
   givenOutcome: Attempt_Failure<SomeTransformableActionableError>,
   given?: Attempt_Failure_Transformer<
@@ -47,7 +47,7 @@ function fromRewrapping<
   >,
 ): Attempt_Failure<SomeTransformedActionableError>;
 //
-function fromRewrapping<
+function Attempt_fromRewrapping<
   SomeTransformableProduct,
   SomeTransformedProduct = SomeTransformableProduct,
 >(
@@ -58,11 +58,11 @@ function fromRewrapping<
   >,
 ): Attempt_Success<SomeTransformedProduct>;
 //
-function fromRewrapping<
+function Attempt_fromRewrapping<
   SomeTransformableProduct,
-  SomeTransformableActionableError extends ActionableError<string>,
+  SomeTransformableActionableError extends Attempt_ActionableError<string>,
   SomeTransformedProduct = SomeTransformableProduct,
-  SomeTransformedActionableError extends ActionableError<string> = SomeTransformableActionableError,
+  SomeTransformedActionableError extends Attempt_ActionableError<string> = SomeTransformableActionableError,
 >(
   givenOutcome: Attempt_Outcome<SomeTransformableProduct, SomeTransformableActionableError>,
   given?: Attempt_Outcome_Transformer<
@@ -73,24 +73,24 @@ function fromRewrapping<
   >,
 ): Attempt_Outcome<SomeTransformedProduct, SomeTransformedActionableError>;
 //
-function fromRewrapping<
+function Attempt_fromRewrapping<
   SomeTransformableProduct,
-  SomeTransformableActionableError extends ActionableError<string>,
+  SomeTransformableActionableError extends Attempt_ActionableError<string>,
   SomeTransformedProduct = SomeTransformableProduct,
-  SomeTransformedActionableError extends ActionableError<string> = SomeTransformableActionableError,
+  SomeTransformedActionableError extends Attempt_ActionableError<string> = SomeTransformableActionableError,
 >(
   givenOutcome: Attempt_Outcome<SomeTransformableProduct, SomeTransformableActionableError>,
   {
-    product: toTransformedProduct = productIdentity<SomeTransformableProduct, SomeTransformedProduct>,
-    cause: toTransformedCause = causeIdentity<SomeTransformableActionableError, SomeTransformedActionableError>,
+    product: toTransformedProduct = Attempt_productIdentity<SomeTransformableProduct, SomeTransformedProduct>,
+    cause: toTransformedCause = Attempt_causeIdentity<SomeTransformableActionableError, SomeTransformedActionableError>,
   }: Attempt_Outcome_Transformer<
     SomeTransformableProduct,
     SomeTransformableActionableError,
     SomeTransformedProduct,
     SomeTransformedActionableError
   > = {
-    product: productIdentity<SomeTransformableProduct, SomeTransformedProduct>,
-    cause  : causeIdentity<SomeTransformableActionableError, SomeTransformedActionableError>,
+    product: Attempt_productIdentity<SomeTransformableProduct, SomeTransformedProduct>,
+    cause  : Attempt_causeIdentity<SomeTransformableActionableError, SomeTransformedActionableError>,
   },
 ): Attempt_Outcome<SomeTransformedProduct, SomeTransformedActionableError> {
   return givenOutcome.isSuccess
@@ -103,19 +103,19 @@ function fromRewrapping<
 }
 
 const Attempt_Outcome = {
-  failureDueTo,
-  successThatYielded,
-  fromRewrapping,
+  failureDueTo      : Attempt_failureDueTo,
+  successThatYielded: Attempt_successThatYielded,
+  fromRewrapping    : Attempt_fromRewrapping,
 };
 
 type ProductOf<
-  SomeOutcome extends Attempt_Outcome<unknown, ActionableError<string>>,
+  SomeOutcome extends Attempt_Outcome<unknown, Attempt_ActionableError<string>>,
 > = SomeOutcome extends Attempt_Success<infer NestedProduct>
   ? NestedProduct
   : never;
 
 type CauseOf<
-  SomeOutcome extends Attempt_Outcome<unknown, ActionableError<string>>,
+  SomeOutcome extends Attempt_Outcome<unknown, Attempt_ActionableError<string>>,
 > = SomeOutcome extends Attempt_Failure<infer NestedError>
   ? NestedError
   : never;

--- a/src/library/Attempt/adapter/Config.ts
+++ b/src/library/Attempt/adapter/Config.ts
@@ -1,11 +1,11 @@
 import type {
-  ActionableError,
+  Attempt_ActionableError,
 } from '../error';
 
 import type Attempt_ErrorInterpreter from '../error/Interpreter';
 
 interface Attempt_AdapterConfig<
-  SomeActionableError extends ActionableError<string>,
+  SomeActionableError extends Attempt_ActionableError<string>,
 > {
   interpretationOf: Attempt_ErrorInterpreter<SomeActionableError>;
 }

--- a/src/library/Attempt/adapter/asynchronous.ts
+++ b/src/library/Attempt/adapter/asynchronous.ts
@@ -3,7 +3,7 @@ import type {
 } from '../Outcome';
 
 import type {
-  ActionableError,
+  Attempt_ActionableError,
 } from '../error';
 
 import {
@@ -20,9 +20,9 @@ import {
 
 import type Attempt_AdapterConfig from './Config';
 
-const attemptToEventually = async <
+const Attempt_toEventually = async <
   SomeProduct,
-  SomeActionableError extends ActionableError<string>,
+  SomeActionableError extends Attempt_ActionableError<string>,
 >(
   forciblyRetrieveProduct: () => Promise<SomeProduct>,
   given: Attempt_AdapterConfig<SomeActionableError>,
@@ -40,18 +40,18 @@ const attemptToEventually = async <
   },
 }));
 
-const attemptToSettle = async <
+const Attempt_toSettle = async <
   SomeProduct,
-  SomeActionableError extends ActionableError<string>,
+  SomeActionableError extends Attempt_ActionableError<string>,
 >(
   promisedProduct: Promise<SomeProduct>,
   givenConfig: Attempt_AdapterConfig<SomeActionableError>,
 ): Promise<Attempt_Outcome<SomeProduct, SomeActionableError>> => {
   const getPromisedProduct = () => promisedProduct;
-  return attemptToEventually(getPromisedProduct, givenConfig);
+  return Attempt_toEventually(getPromisedProduct, givenConfig);
 };
 
 export {
-  attemptToEventually,
-  attemptToSettle,
+  Attempt_toEventually,
+  Attempt_toSettle,
 };

--- a/src/library/Attempt/adapter/exports.ts
+++ b/src/library/Attempt/adapter/exports.ts
@@ -1,12 +1,12 @@
 export {
-  attemptTo,
+  Attempt_to,
 } from './synchronous';
 
 export {
-  attemptToEventually,
-  attemptToSettle,
+  Attempt_toEventually,
+  Attempt_toSettle,
 } from './asynchronous';
 
 export type {
-  default as AdapterConfig,
+  default as Attempt_AdapterConfig,
 } from './Config';

--- a/src/library/Attempt/adapter/synchronous.ts
+++ b/src/library/Attempt/adapter/synchronous.ts
@@ -3,7 +3,7 @@ import type {
 } from '../Outcome';
 
 import type {
-  ActionableError,
+  Attempt_ActionableError,
 } from '../error';
 
 import {
@@ -20,9 +20,9 @@ import {
 
 import type Attempt_AdapterConfig from './Config';
 
-const attemptTo = <
+const Attempt_to = <
   SomeProduct,
-  SomeActionableError extends ActionableError<string>,
+  SomeActionableError extends Attempt_ActionableError<string>,
 >(
   forciblyGetProduct: () => SomeProduct,
   given: Attempt_AdapterConfig<SomeActionableError>,
@@ -41,5 +41,5 @@ const attemptTo = <
 }));
 
 export {
-  attemptTo,
+  Attempt_to,
 };

--- a/src/library/Attempt/ended.ts
+++ b/src/library/Attempt/ended.ts
@@ -3,7 +3,7 @@ import {
 } from './Outcome';
 
 import {
-  NonActionableError,
+  Attempt_NonActionableError,
 } from './error';
 
 /**
@@ -20,7 +20,7 @@ const Attempt_ended = {
   /** Call this when the attempt has completed in terms of a prior outcome */
   inTermsOf      : Attempt_Outcome.fromRewrapping,
   /** Call this when it's not possible to complete the attempt */
-  inFlamesBecause: NonActionableError.throw.bind(NonActionableError),
+  inFlamesBecause: Attempt_NonActionableError.throw.bind(Attempt_NonActionableError),
 };
 
 export {

--- a/src/library/Attempt/error/ActionableError.ts
+++ b/src/library/Attempt/error/ActionableError.ts
@@ -3,11 +3,11 @@ import type {
 } from '@/library/typeUtilities/Branded';
 
 import {
-  default as NonActionableError,
+  default as Attempt_NonActionableError,
 } from './NonActionableError';
 
 /** Extend this class to describe errors from which callers ought to recover */
-abstract class ActionableError<
+abstract class Attempt_ActionableError<
   SomeBrand extends string,
 > extends Error
   implements Branded<
@@ -18,7 +18,7 @@ abstract class ActionableError<
   public throwAnyway = (
     givenJustification: string,
   ): never => {
-    return NonActionableError.throw(givenJustification, {
+    return Attempt_NonActionableError.throw(givenJustification, {
       cause  : this,
       thrower: this.throwAnyway,
     });
@@ -26,5 +26,5 @@ abstract class ActionableError<
 }
 
 export {
-  ActionableError as default,
+  Attempt_ActionableError as default,
 };

--- a/src/library/Attempt/error/Interpreter.ts
+++ b/src/library/Attempt/error/Interpreter.ts
@@ -1,11 +1,11 @@
-import type ActionableError from './ActionableError';
+import type Attempt_ActionableError from './ActionableError';
 
 import type {
   PotentiallyActionable,
 } from './modifier';
 
 type Attempt_ErrorInterpreter<
-  SomeActionableError extends ActionableError<string>,
+  SomeActionableError extends Attempt_ActionableError<string>,
 > = (
   caughtError: PotentiallyActionable<Error>
 ) => SomeActionableError | null;

--- a/src/library/Attempt/error/NonActionableError.ts
+++ b/src/library/Attempt/error/NonActionableError.ts
@@ -2,7 +2,7 @@ import type {
   Branded,
 } from '@/library/typeUtilities/Branded';
 
-interface NonActionableError_Options
+interface Attempt_NonActionableError_Options
   extends ErrorOptions {
   /** A function that's acting as an alternative to raw `throw` */
   thrower?: (...parameters: any[]) => unknown; // eslint-disable-line @typescript-eslint/no-explicit-any
@@ -14,7 +14,7 @@ interface NonActionableError_Options
  * Applies to errors that the developer neglected to prevent, or that are
  * impossible to handle.
  */
-class NonActionableError
+class Attempt_NonActionableError
   extends Error
   implements Branded<
   'NonActionableError'
@@ -23,7 +23,7 @@ class NonActionableError
   public readonly brand!: 'NonActionableError';
 
   public constructor(
-    givenMessage: NonActionableError['message'],
+    givenMessage: Attempt_NonActionableError['message'],
     givenOptions?: ErrorOptions,
   ) {
     super(givenMessage, givenOptions);
@@ -35,8 +35,8 @@ class NonActionableError
   }
 
   public static throw(
-    givenMessage: NonActionableError['message'],
-    givenOptions?: NonActionableError_Options,
+    givenMessage: Attempt_NonActionableError['message'],
+    givenOptions?: Attempt_NonActionableError_Options,
   ): never {
     const newError = new this(givenMessage, givenOptions);
 
@@ -51,11 +51,11 @@ class NonActionableError
   public static rethrow(
     givenError: Error,
     given: {
-      message: NonActionableError['message'];
+      message: Attempt_NonActionableError['message'];
     },
   ): never {
     if (
-      givenError instanceof NonActionableError
+      givenError instanceof Attempt_NonActionableError
     ) return givenError.throw();
 
     return this.throw(given.message, {
@@ -75,5 +75,5 @@ class NonActionableError
 }
 
 export {
-  NonActionableError as default,
+  Attempt_NonActionableError as default,
 };

--- a/src/library/Attempt/error/assertions/assertActionable.ts
+++ b/src/library/Attempt/error/assertions/assertActionable.ts
@@ -1,12 +1,12 @@
 import type {
-  default as ActionableError,
+  default as Attempt_ActionableError,
 } from '../ActionableError';
 
 import type Attempt_ErrorInterpreter from '../Interpreter';
 import NonActionableBuiltInError from '../NonActionableBuiltInError';
 
 import {
-  default as NonActionableError,
+  default as Attempt_NonActionableError,
 } from '../NonActionableError';
 
 import type {
@@ -18,7 +18,7 @@ import {
 } from './assertPotentiallyActionable';
 
 const assertActionable = <
-  SomeActionableError extends ActionableError<string>,
+  SomeActionableError extends Attempt_ActionableError<string>,
 >(
   givenError: AppropriatelyThrown<Error>,
   {
@@ -34,7 +34,7 @@ const assertActionable = <
     definitelyActionableError !== null
   ) return definitelyActionableError;
 
-  return NonActionableError.rethrow(potentiallyActionableError, {
+  return Attempt_NonActionableError.rethrow(potentiallyActionableError, {
     message: NonActionableBuiltInError.describes(givenError)
       ? 'Neglected to prevent built-in error'
       : 'Neglected to interpret or prevent potentially actionable error',

--- a/src/library/Attempt/error/assertions/assertAppropriatelyThrown.ts
+++ b/src/library/Attempt/error/assertions/assertAppropriatelyThrown.ts
@@ -1,5 +1,5 @@
 import {
-  default as ActionableError,
+  default as Attempt_ActionableError,
 } from '../ActionableError';
 
 import type {
@@ -17,7 +17,7 @@ const assertAppropriatelyThrown = <
   givenError: SomeError,
 ): AppropriatelyThrown<SomeError> => {
   if (
-    givenError instanceof ActionableError
+    givenError instanceof Attempt_ActionableError
   ) return givenError.throwAnyway('Unexpected raw `throw` of some `ActionableError`. If this was intentional, use `.throwAnyway(...)` on the instance instead.');
 
   return givenError as AppropriatelyThrown<SomeError>;

--- a/src/library/Attempt/error/assertions/assertPotentiallyActionable.ts
+++ b/src/library/Attempt/error/assertions/assertPotentiallyActionable.ts
@@ -1,7 +1,7 @@
-import AttemptCreationError from '../../factory/AttemptCreationError';
+import Attempt_CreationError from '../../factory/AttemptCreationError';
 
 import {
-  default as NonActionableError,
+  default as Attempt_NonActionableError,
 } from '../NonActionableError';
 
 import type {
@@ -14,11 +14,11 @@ const assertPotentiallyActionable = <
   givenError: SomeError,
 ): PotentiallyActionable<SomeError> => {
   if (
-    !(givenError instanceof NonActionableError)
+    !(givenError instanceof Attempt_NonActionableError)
   ) return givenError as PotentiallyActionable<SomeError>;
 
   if (
-    !(givenError instanceof AttemptCreationError)
+    !(givenError instanceof Attempt_CreationError)
     && (givenError.charge !== null)
   ) return givenError.charge as PotentiallyActionable<SomeError>;
 

--- a/src/library/Attempt/error/exports.ts
+++ b/src/library/Attempt/error/exports.ts
@@ -1,11 +1,11 @@
 export {
-  default as NonActionableError,
+  default as Attempt_NonActionableError,
 } from './NonActionableError';
 
 export {
-  default as ActionableError,
+  default as Attempt_ActionableError,
 } from './ActionableError';
 
 export type {
-  default as ErrorInterpreter,
+  default as Attempt_ErrorInterpreter,
 } from './Interpreter';

--- a/src/library/Attempt/error/modifier/AppropriatelyThrown.ts
+++ b/src/library/Attempt/error/modifier/AppropriatelyThrown.ts
@@ -1,10 +1,10 @@
-import type ActionableError from '../ActionableError';
+import type Attempt_ActionableError from '../ActionableError';
 
 type AppropriatelyThrown<
   SomeError extends Error,
 > = Exclude<
   SomeError,
-  ActionableError<string>
+  Attempt_ActionableError<string>
 >;
 
 export type {

--- a/src/library/Attempt/error/modifier/PotentiallyActionable.ts
+++ b/src/library/Attempt/error/modifier/PotentiallyActionable.ts
@@ -1,8 +1,8 @@
-import type NonActionableError from '../NonActionableError';
+import type Attempt_NonActionableError from '../NonActionableError';
 
 type PotentiallyActionable<
   SomeError extends Error,
-> = Exclude<SomeError, NonActionableError>;
+> = Exclude<SomeError, Attempt_NonActionableError>;
 
 export type {
   PotentiallyActionable as default,

--- a/src/library/Attempt/exports.ts
+++ b/src/library/Attempt/exports.ts
@@ -2,10 +2,10 @@ import {
   Attempt_ended,
 } from './ended';
 
-const abandon = Attempt_ended.inFlamesBecause;
+const Attempt_abandon = Attempt_ended.inFlamesBecause;
 
 export {
-  abandon,
+  Attempt_abandon as abandon,
 };
 
 export {
@@ -15,16 +15,16 @@ export {
 } from './Outcome';
 
 export {
-  attemptTo as to,
-  attemptToEventually as toEventually,
-  attemptToSettle as toSettle,
-  type AdapterConfig,
+  Attempt_to as to,
+  Attempt_toEventually as toEventually,
+  Attempt_toSettle as toSettle,
+  type Attempt_AdapterConfig as AdapterConfig,
 } from './adapter';
 
 export {
-  NonActionableError,
-  ActionableError,
-  type ErrorInterpreter,
+  Attempt_NonActionableError as NonActionableError,
+  Attempt_ActionableError as ActionableError,
+  type Attempt_ErrorInterpreter as ErrorInterpreter,
 } from './error';
 
 export {

--- a/src/library/Attempt/factory/AttemptCreationError.ts
+++ b/src/library/Attempt/factory/AttemptCreationError.ts
@@ -1,12 +1,12 @@
-import NonActionableError from '../error/NonActionableError';
+import Attempt_NonActionableError from '../error/NonActionableError';
 
-class AttemptCreationError
-  extends NonActionableError {
+class Attempt_CreationError
+  extends Attempt_NonActionableError {
   public override name = 'AttemptCreationError' as const;
   public override readonly cause: Error;
 
   private constructor(
-    givenMessage: NonActionableError['message'],
+    givenMessage: Attempt_NonActionableError['message'],
     givenOptions: {
       cause: Error;
     },
@@ -30,5 +30,5 @@ class AttemptCreationError
 }
 
 export {
-  AttemptCreationError as default,
+  Attempt_CreationError as default,
 };

--- a/src/library/Attempt/factory/asynchronous.ts
+++ b/src/library/Attempt/factory/asynchronous.ts
@@ -9,23 +9,23 @@ import {
 } from '../ended';
 
 import type {
-  ActionableError,
+  Attempt_ActionableError,
 } from '../error';
 
 import {
   sanctionedAsync,
 } from '../utilities/sanctionedTryCatch';
 
-import AttemptCreationError from './AttemptCreationError';
+import Attempt_CreationError from './AttemptCreationError';
 
 type Attempt_EndRetriever<
-  SomeInferredOutcome extends Attempt_Outcome<unknown, ActionableError<string>>,
+  SomeInferredOutcome extends Attempt_Outcome<unknown, Attempt_ActionableError<string>>,
 > = (
   givenHandles: typeof handles
 ) => Promise<SomeInferredOutcome>;
 
 const Attempt_thatEventually = async <
-  SomeInferredOutcome extends Attempt_Outcome<unknown, ActionableError<string>>,
+  SomeInferredOutcome extends Attempt_Outcome<unknown, Attempt_ActionableError<string>>,
 >(
   endsAccordingTo: Attempt_EndRetriever<SomeInferredOutcome>,
 ) => {
@@ -36,7 +36,7 @@ const Attempt_thatEventually = async <
       return await endsAccordingTo(handles) as EquivalentOutcome;
     },
     catch(someError) {
-      return AttemptCreationError.rethrow(someError);
+      return Attempt_CreationError.rethrow(someError);
     },
   });
 };

--- a/src/library/Attempt/factory/synchronous.ts
+++ b/src/library/Attempt/factory/synchronous.ts
@@ -9,23 +9,23 @@ import {
 } from '../ended';
 
 import type {
-  ActionableError,
+  Attempt_ActionableError,
 } from '../error';
 
 import {
   sanctioned,
 } from '../utilities/sanctionedTryCatch';
 
-import AttemptCreationError from './AttemptCreationError';
+import Attempt_CreationError from './AttemptCreationError';
 
 type Attempt_EndGetter<
-  SomeInferredOutcome extends Attempt_Outcome<unknown, ActionableError<string>>,
+  SomeInferredOutcome extends Attempt_Outcome<unknown, Attempt_ActionableError<string>>,
 > = (
   givenHandles: typeof handles
 ) => SomeInferredOutcome;
 
 const Attempt_that = <
-  SomeInferredOutcome extends Attempt_Outcome<unknown, ActionableError<string>>,
+  SomeInferredOutcome extends Attempt_Outcome<unknown, Attempt_ActionableError<string>>,
 >(
   endsAccordingTo: Attempt_EndGetter<SomeInferredOutcome>,
 ) => {
@@ -36,7 +36,7 @@ const Attempt_that = <
       return endsAccordingTo(handles) as EquivalentOutcome;
     },
     catch(someError) {
-      return AttemptCreationError.rethrow(someError);
+      return Attempt_CreationError.rethrow(someError);
     },
   });
 };

--- a/src/library/Base64CharacterEncodedByteSequence/definition.ts
+++ b/src/library/Base64CharacterEncodedByteSequence/definition.ts
@@ -3,7 +3,7 @@ import Base64 from '@/library/Base64';
 import Byte from '@/library/Byte';
 
 import type {
-  StringParsable,
+  Parsable_String,
 } from '@/library/Parser/string';
 
 import Sequence from '@/library/Sequence';
@@ -20,7 +20,7 @@ import Base64CharacterEncodedByteSequence_ParsingError from './ParsingError.ts';
 class Base64CharacterEncodedByteSequence
   extends StringSubset<
   'Base64CharacterEncodedByteSequence'
-> implements StringParsable<
+> implements Parsable_String<
   typeof Base64CharacterEncodedByteSequence,
   /*  */ Base64CharacterEncodedByteSequence_ParsingError
 > {

--- a/src/library/HTTP/Client.ts
+++ b/src/library/HTTP/Client.ts
@@ -1,8 +1,8 @@
 import Attempt from '@/library/Attempt';
 
 import type {
-  URLOrigin,
-  URLPath,
+  URLComponent_Origin,
+  URLComponent_Path,
 } from '@/library/URLComponent';
 
 import {
@@ -15,11 +15,11 @@ import {
 
 class HTTP_Client {
   public constructor(
-    public readonly origin: URLOrigin,
+    public readonly origin: URLComponent_Origin,
     public readonly headers: HTTP_Request.HeaderMap,
   ) {}
 
-  public originAt(givenPath: URLPath): URL {
+  public originAt(givenPath: URLComponent_Path): URL {
     const serializedURLComponents = this.origin.appendedWith(givenPath);
     return new URL(serializedURLComponents);
   }
@@ -30,7 +30,7 @@ class HTTP_Client {
       to: givenPath,
       using: givenMethod,
     }: {
-      to: URLPath;
+      to: URLComponent_Path;
       using: HTTP_Request.Method;
     },
   ): Promise<HTTP_Endpoint.Outcome> => Attempt.thatEventually(async (ends) => {
@@ -72,7 +72,7 @@ class HTTP_Client {
     {
       from: givenPath,
     }: {
-      from: URLPath;
+      from: URLComponent_Path;
     },
   ): Promise<HTTP_Endpoint.Outcome> {
     return await this.send(null, {
@@ -87,7 +87,7 @@ class HTTP_Client {
       to: givenPath,
     }: {
       bySending: unknown;
-      to: URLPath;
+      to: URLComponent_Path;
     },
   ): Promise<HTTP_Endpoint.Outcome> {
     return await this.send(givenSubmission, {
@@ -102,7 +102,7 @@ class HTTP_Client {
       to: givenPath,
     }: {
       bySending: unknown;
-      to: URLPath;
+      to: URLComponent_Path;
     },
   ): Promise<HTTP_Endpoint.Outcome> {
     return await this.send(givenProperties, {
@@ -117,7 +117,7 @@ class HTTP_Client {
       to: givenPath,
     }: {
       bySending: unknown;
-      to: URLPath;
+      to: URLComponent_Path;
     },
   ): Promise<HTTP_Endpoint.Outcome> {
     return await this.send(givenChanges, {
@@ -127,7 +127,7 @@ class HTTP_Client {
   }
 
   public async deleteResourceAt(
-    givenPath: URLPath,
+    givenPath: URLComponent_Path,
   ): Promise<HTTP_Endpoint.Outcome> {
     return await this.send(null, {
       to   : givenPath,

--- a/src/library/NonTrivialString/definition.ts
+++ b/src/library/NonTrivialString/definition.ts
@@ -1,7 +1,7 @@
 import Attempt from '@/library/Attempt';
 
 import type {
-  StringParsable,
+  Parsable_String,
 } from '@/library/Parser/string';
 
 import StringSubset from '@/library/StringSubset';
@@ -17,7 +17,7 @@ import NonTrivialString_ParsingError from './ParsingError.ts';
 class NonTrivialString
   extends StringSubset<
   'NonTrivialString'
-> implements StringParsable<
+> implements Parsable_String<
   typeof NonTrivialString,
   /*  */ NonTrivialString_ParsingError
 > {

--- a/src/library/Parser/Parsable.ts
+++ b/src/library/Parser/Parsable.ts
@@ -1,7 +1,7 @@
 import type ParsingError from './ParsingError';
 
 import type {
-  StaticParser,
+  Parser_Static,
 } from './StaticParser';
 
 /**
@@ -9,7 +9,7 @@ import type {
  * Implementing this type ensures conformance to a standard parsing interface.
  */
 type Parsable<
-  SomeImplementer extends StaticParser<
+  SomeImplementer extends Parser_Static<
     SomeRawInput,
     SomeImplementer['prototype'],
     SomeParsingError

--- a/src/library/Parser/StaticParser.ts
+++ b/src/library/Parser/StaticParser.ts
@@ -6,7 +6,7 @@ import type {
   Parser,
 } from './definition.ts';
 
-type StaticParser<
+type Parser_Static<
   SomeRawInput,
   SomeParsedOutput,
   SomeParsingError extends ParsingError<string>,
@@ -22,5 +22,5 @@ type StaticParser<
 ;
 
 export type {
-  StaticParser,
+  Parser_Static,
 };

--- a/src/library/Parser/string/StaticStringParser.ts
+++ b/src/library/Parser/string/StaticStringParser.ts
@@ -1,18 +1,18 @@
 import type ParsingError from '../ParsingError';
 
 import type {
-  StaticParser,
+  Parser_Static,
 } from '../StaticParser';
 
-type StaticStringParser<
+type Parser_StaticString<
   SomeParsedOutput,
   SomeParsingError extends ParsingError<string>,
-> = StaticParser<
+> = Parser_Static<
   string,
   SomeParsedOutput,
   SomeParsingError
 >;
 
 export type {
-  StaticStringParser,
+  Parser_StaticString,
 };

--- a/src/library/Parser/string/StringParsable.ts
+++ b/src/library/Parser/string/StringParsable.ts
@@ -5,15 +5,15 @@ import type {
 import type ParsingError from '../ParsingError';
 
 import type {
-  StaticStringParser,
+  Parser_StaticString,
 } from './StaticStringParser';
 
 /**
  * Some classes need a factory that parses strings into an instance.
  * Implement this type to ensure that the class follows the standard interface for this.
  */
-type StringParsable<
-  SomeImplementer extends StaticStringParser<
+type Parsable_String<
+  SomeImplementer extends Parser_StaticString<
     SomeImplementer['prototype'],
     SomeParsingError
   >,
@@ -25,5 +25,5 @@ type StringParsable<
 >;
 
 export type {
-  StringParsable,
+  Parsable_String,
 };

--- a/src/library/Parser/string/exports.ts
+++ b/src/library/Parser/string/exports.ts
@@ -1,3 +1,3 @@
 export type {
-  StringParsable,
+  Parsable_String,
 } from './StringParsable';

--- a/src/library/Range/DiscreteRange.ts
+++ b/src/library/Range/DiscreteRange.ts
@@ -8,7 +8,7 @@ import {
   Range,
 } from './definition.ts';
 
-class DiscreteRange
+class Range_Discrete
   extends Range {
   protected constructor(
     lowerBound: Range['lowerBound'],
@@ -27,11 +27,11 @@ class DiscreteRange
       to: givenUpperBound,
       by: givenStepSize,
     }: {
-      from: DiscreteRange['lowerBound'];
-      to: DiscreteRange['upperBound'];
-      by: DiscreteRange['stepSize'];
+      from: Range_Discrete['lowerBound'];
+      to: Range_Discrete['upperBound'];
+      by: Range_Discrete['stepSize'];
     },
-  ): DiscreteRange {
+  ): Range_Discrete {
     const validRange = super.spanning({
       from: givenLowerBound,
       to  : givenUpperBound,
@@ -94,5 +94,5 @@ class DiscreteRange
 }
 
 export {
-  DiscreteRange as default,
+  Range_Discrete as default,
 };

--- a/src/library/ShimmedStabilityAIClient/definition.ts
+++ b/src/library/ShimmedStabilityAIClient/definition.ts
@@ -1,7 +1,7 @@
 import HTTP from '@/library/HTTP';
 
 import {
-  URLOrigin,
+  URLComponent_Origin,
 } from '@/library/URLComponent';
 
 import {
@@ -13,7 +13,7 @@ class ShimmedStabilityAIClient
   public constructor(given: {
     serverURL: string;
   }) {
-    const serverOrigin = URLOrigin.parsedFrom(given.serverURL).forciblyUnwrap(/* matches error propagation of actual StabilityAI client */);
+    const serverOrigin = URLComponent_Origin.parsedFrom(given.serverURL).forciblyUnwrap(/* matches error propagation of actual StabilityAI client */);
 
     const defaultHeaders = {
       'Content-Type': 'application/json',

--- a/src/library/ShimmedStabilityAIClient/models/SDXLDiffusionStepCount.ts
+++ b/src/library/ShimmedStabilityAIClient/models/SDXLDiffusionStepCount.ts
@@ -1,4 +1,4 @@
-import DiscreteRange from '@/library/Range/DiscreteRange.ts';
+import Range_Discrete from '@/library/Range/DiscreteRange.ts';
 
 /**
  * Sourced from the [StabilityAI OpenAPI spec](https://github.com/nod-ai/StabilityAI-client-typescript/blob/HEAD/openapi.json)
@@ -6,7 +6,7 @@ import DiscreteRange from '@/library/Range/DiscreteRange.ts';
  * Defined at "components.schemas.Steps"
  */
 abstract class SDXLDiffusionStepCount { // eslint-disable-line @typescript-eslint/no-extraneous-class
-  public static range = DiscreteRange.spanning({
+  public static range = Range_Discrete.spanning({
     from: 10,
     to  : 50,
     by  : 1,

--- a/src/library/Shortfin/TextToImage/SDXL/Client/definition.ts
+++ b/src/library/Shortfin/TextToImage/SDXL/Client/definition.ts
@@ -2,7 +2,7 @@ import Attempt from '@/library/Attempt';
 import HTTP from '@/library/HTTP';
 
 import {
-  URLPath,
+  URLComponent_Path,
 } from '@/library/URLComponent';
 
 import type {
@@ -18,7 +18,7 @@ class Shortfin_TextToImage_SDXL_Client
   public generateImageFrom(
     givenBatchedRequestBody: Shortfin_TextToImage_SDXL_Client_Request.Body.Batched,
   ): Promise<Shortfin_TextToImage_SDXL_Client_Request.Outcome> {
-    const generationEndpoint = URLPath.parsedFrom('/generate').forciblyUnwrap();
+    const generationEndpoint = URLComponent_Path.parsedFrom('/generate').forciblyUnwrap();
 
     return Attempt.thatEventually(async (ends) => {
       const outcomeOfSubmittingResource = await this.submitResource({

--- a/src/library/URLComponent/URLOrigin.ts
+++ b/src/library/URLComponent/URLOrigin.ts
@@ -5,7 +5,7 @@ import {
 } from '@/library/Parser';
 
 import type {
-  StringParsable,
+  Parsable_String,
 } from '@/library/Parser/string';
 
 import StringSubset from '@/library/StringSubset';
@@ -27,7 +27,7 @@ class URLOrigin_ParsingError
 class URLOrigin
   extends StringSubset<
   'URLOrigin'
-> implements StringParsable<
+> implements Parsable_String<
   typeof URLOrigin,
   /*  */ URLOrigin_ParsingError
 > {

--- a/src/library/URLComponent/URLOrigin.ts
+++ b/src/library/URLComponent/URLOrigin.ts
@@ -10,11 +10,11 @@ import type {
 
 import StringSubset from '@/library/StringSubset';
 
-class URLOrigin_ParsingError
+class URLComponent_Origin_ParsingError
   extends ParsingError<
-  'URLOrigin'
+  'URLComponent_Origin'
 > {
-  public override name = 'URLOrigin_ParsingError' as const;
+  public override name = 'URLComponent_Origin_ParsingError' as const;
 
   public constructor(given: {
     expectation: string;
@@ -24,19 +24,19 @@ class URLOrigin_ParsingError
   }
 }
 
-class URLOrigin
+class URLComponent_Origin
   extends StringSubset<
-  'URLOrigin'
+  'URLComponent_Origin'
 > implements Parsable_String<
-  typeof URLOrigin,
-  /*  */ URLOrigin_ParsingError
+  typeof URLComponent_Origin,
+  /*  */ URLComponent_Origin_ParsingError
 > {
   public static parsedFrom = (
     givenSubject: string,
-  ): Attempt.Outcome<URLOrigin, URLOrigin_ParsingError> => Attempt.that((ends) => {
+  ): Attempt.Outcome<URLComponent_Origin, URLComponent_Origin_ParsingError> => Attempt.that((ends) => {
     const derived = new URL(givenSubject);
 
-    const newParsingError = new URLOrigin_ParsingError({
+    const newParsingError = new URLComponent_Origin_ParsingError({
       expectation: derived.origin,
       reality    : givenSubject,
     });
@@ -45,12 +45,12 @@ class URLOrigin
       derived.origin !== givenSubject
     ) return ends.inFailureDueTo(newParsingError);
 
-    const parsedURLOrigin = new URLOrigin(derived.origin);
+    const parsedURLOrigin = new URLComponent_Origin(derived.origin);
     return ends.inSuccessWith(parsedURLOrigin);
   });
 }
 
 export {
-  URLOrigin,
-  URLOrigin_ParsingError,
+  URLComponent_Origin,
+  URLComponent_Origin_ParsingError,
 };

--- a/src/library/URLComponent/URLPath.ts
+++ b/src/library/URLComponent/URLPath.ts
@@ -10,11 +10,11 @@ import type {
 
 import StringSubset from '@/library/StringSubset';
 
-class URLPath_ParsingError
+class URLComponent_Path_ParsingError
   extends ParsingError<
-  'URLPath'
+  'URLComponent_Path'
 > {
-  public override name = 'URLPath_ParsingError' as const;
+  public override name = 'URLComponent_Path_ParsingError' as const;
 
   public constructor(given: {
     expectation: string;
@@ -24,19 +24,19 @@ class URLPath_ParsingError
   }
 }
 
-class URLPath
+class URLComponent_Path
   extends StringSubset<
-  'URLPath'
+  'URLComponent_Path'
 > implements Parsable_String<
-  typeof URLPath,
-  /*  */ URLPath_ParsingError
+  typeof URLComponent_Path,
+  /*  */ URLComponent_Path_ParsingError
 > {
   public static parsedFrom = (
     givenSubject: string,
-  ): Attempt.Outcome<URLPath, URLPath_ParsingError> => Attempt.that((ends) => {
+  ): Attempt.Outcome<URLComponent_Path, URLComponent_Path_ParsingError> => Attempt.that((ends) => {
     const exampleURL = new URL(`https://example.com${givenSubject}`);
 
-    const newParsingError = new URLPath_ParsingError({
+    const newParsingError = new URLComponent_Path_ParsingError({
       expectation: exampleURL.pathname,
       reality    : givenSubject,
     });
@@ -45,12 +45,12 @@ class URLPath
       exampleURL.pathname !== givenSubject
     ) return ends.inFailureDueTo(newParsingError);
 
-    const parsedURLPath = new URLPath(exampleURL.pathname);
+    const parsedURLPath = new URLComponent_Path(exampleURL.pathname);
     return ends.inSuccessWith(parsedURLPath);
   });
 }
 
 export {
-  URLPath,
-  URLPath_ParsingError,
+  URLComponent_Path,
+  URLComponent_Path_ParsingError,
 };

--- a/src/library/URLComponent/URLPath.ts
+++ b/src/library/URLComponent/URLPath.ts
@@ -5,7 +5,7 @@ import {
 } from '@/library/Parser';
 
 import type {
-  StringParsable,
+  Parsable_String,
 } from '@/library/Parser/string';
 
 import StringSubset from '@/library/StringSubset';
@@ -27,7 +27,7 @@ class URLPath_ParsingError
 class URLPath
   extends StringSubset<
   'URLPath'
-> implements StringParsable<
+> implements Parsable_String<
   typeof URLPath,
   /*  */ URLPath_ParsingError
 > {

--- a/src/library/UniformResourceIdentifier/Data/EncodingIdentifier/Any.ts
+++ b/src/library/UniformResourceIdentifier/Data/EncodingIdentifier/Any.ts
@@ -1,9 +1,9 @@
 import type {
-  DataURI_EncodingIdentifier_all,
+  URI_Data_EncodingIdentifier_all,
 } from './all';
 
-type DataURI_EncodingIdentifier_Any = (typeof DataURI_EncodingIdentifier_all)[number];
+type URI_Data_EncodingIdentifier_Any = (typeof URI_Data_EncodingIdentifier_all)[number];
 
 export type {
-  DataURI_EncodingIdentifier_Any,
+  URI_Data_EncodingIdentifier_Any,
 };

--- a/src/library/UniformResourceIdentifier/Data/EncodingIdentifier/all.ts
+++ b/src/library/UniformResourceIdentifier/Data/EncodingIdentifier/all.ts
@@ -1,5 +1,5 @@
 /* Defined in accordance with [RFC 2397 Section 2](https://www.rfc-editor.org/rfc/rfc2397#section-2) */
-const DataURI_EncodingIdentifier_all = [
+const URI_Data_EncodingIdentifier_all = [
   'base64',
   /**
    * Means """
@@ -12,5 +12,5 @@ const DataURI_EncodingIdentifier_all = [
 ] as const;
 
 export {
-  DataURI_EncodingIdentifier_all,
+  URI_Data_EncodingIdentifier_all,
 };

--- a/src/library/UniformResourceIdentifier/Data/EncodingIdentifier/exports.ts
+++ b/src/library/UniformResourceIdentifier/Data/EncodingIdentifier/exports.ts
@@ -1,7 +1,7 @@
 export {
-  DataURI_EncodingIdentifier_all as all,
+  URI_Data_EncodingIdentifier_all as all,
 } from './all';
 
 export type {
-  DataURI_EncodingIdentifier_Any as Any,
+  URI_Data_EncodingIdentifier_Any as Any,
 } from './Any';

--- a/src/library/UniformResourceIdentifier/Data/Image/Format/Any.ts
+++ b/src/library/UniformResourceIdentifier/Data/Image/Format/Any.ts
@@ -1,9 +1,9 @@
 import type {
-  ImageURI_Format_all,
+  URI_Image_Format_all,
 } from './all';
 
-type ImageURI_Format_Any = (typeof ImageURI_Format_all)[number];
+type URI_Image_Format_Any = (typeof URI_Image_Format_all)[number];
 
 export type {
-  ImageURI_Format_Any,
+  URI_Image_Format_Any,
 };

--- a/src/library/UniformResourceIdentifier/Data/Image/Format/all.ts
+++ b/src/library/UniformResourceIdentifier/Data/Image/Format/all.ts
@@ -1,5 +1,5 @@
 /** For an exhaustive list, see [the IANA registry](https://www.iana.org/assignments/media-types/media-types.xhtml#image) */
-const ImageURI_Format_all = [
+const URI_Image_Format_all = [
   // https://www.iana.org/assignments/media-types/image/png
   'png',
   // https://www.iana.org/assignments/media-types/image/jpeg
@@ -11,5 +11,5 @@ const ImageURI_Format_all = [
 ] as const;
 
 export {
-  ImageURI_Format_all,
+  URI_Image_Format_all,
 };

--- a/src/library/UniformResourceIdentifier/Data/Image/Format/exports.ts
+++ b/src/library/UniformResourceIdentifier/Data/Image/Format/exports.ts
@@ -1,7 +1,7 @@
 export {
-  ImageURI_Format_all as all,
+  URI_Image_Format_all as all,
 } from './all';
 
 export {
-  type ImageURI_Format_Any as Any,
+  type URI_Image_Format_Any as Any,
 } from './Any';

--- a/src/library/UniformResourceIdentifier/Data/Image/definition.ts
+++ b/src/library/UniformResourceIdentifier/Data/Image/definition.ts
@@ -6,15 +6,15 @@ import type {
 } from '../EncodingIdentifier';
 
 import {
-  DataURI,
+  URI_Data,
 } from '../definition.ts';
 
 import type {
   ImageURI_Format,
 } from './Format';
 
-class ImageURI
-  extends DataURI {
+class URI_Image
+  extends URI_Data {
   public static readonly topLevelDescriptor = 'image';
 
   public constructor(
@@ -29,9 +29,9 @@ class ImageURI
     );
   }
 
-  public override get descriptor(): DataURI['descriptor'] {
+  public override get descriptor(): URI_Data['descriptor'] {
     const computedDescriptor = new ContentDescriptor(
-      ImageURI.topLevelDescriptor,
+      URI_Image.topLevelDescriptor,
       null,
       this.format,
       null,
@@ -43,5 +43,5 @@ class ImageURI
 }
 
 export {
-  ImageURI,
+  URI_Image,
 };

--- a/src/library/UniformResourceIdentifier/Data/Image/exports.ts
+++ b/src/library/UniformResourceIdentifier/Data/Image/exports.ts
@@ -1,3 +1,3 @@
 export {
-  ImageURI,
+  URI_Image,
 } from './definition.ts';

--- a/src/library/UniformResourceIdentifier/Data/Image/index.ts
+++ b/src/library/UniformResourceIdentifier/Data/Image/index.ts
@@ -1,3 +1,3 @@
 export {
-  ImageURI as default,
+  URI_Image as default,
 } from './exports.ts';

--- a/src/library/UniformResourceIdentifier/Data/definition.ts
+++ b/src/library/UniformResourceIdentifier/Data/definition.ts
@@ -12,7 +12,7 @@ import type {
 } from './EncodingIdentifier';
 
 /** See [RFC 2397](https://datatracker.ietf.org/doc/rfc2397) for more info */
-class DataURI
+class URI_Data
   extends UniformResourceIdentifier {
   public static readonly scheme = NonTrivialString.parsedFrom('data').forciblyUnwrap();
 
@@ -22,11 +22,11 @@ class DataURI
     public readonly data: Base64CharacterEncodedByteSequence,
   ) {
     super(
-      DataURI.scheme,
+      URI_Data.scheme,
     );
   }
 
-  public get descriptor(): Exclude<DataURI['overridableDescriptor'], null> {
+  public get descriptor(): Exclude<URI_Data['overridableDescriptor'], null> {
     if (
       this.overridableDescriptor === null
     ) return Attempt.abandon('Descriptor either needs to be initialized or overridden');
@@ -41,13 +41,13 @@ class DataURI
       this.encoding !== 'base64'
     ) return null;
 
-    return DataURI.encodingPrefix.concat(this.encoding);
+    return URI_Data.encodingPrefix.concat(this.encoding);
   }
 
   public static readonly dataPrefix = ',';
 
   public get serializableData(): string {
-    return this.data.prependedWith(DataURI.dataPrefix);
+    return this.data.prependedWith(URI_Data.dataPrefix);
   }
 
   public override get path(): NonTrivialString {
@@ -63,5 +63,5 @@ class DataURI
 }
 
 export {
-  DataURI,
+  URI_Data,
 };

--- a/src/library/WebAPI/Server.ts
+++ b/src/library/WebAPI/Server.ts
@@ -5,7 +5,7 @@ import Schema from '@/library/Schema';
  * - listens for requests
  * - responds to those requests
  */
-class Server {
+class WebAPI_Server {
   public constructor(
     /**
      * The web location of the server, which is the base URL of the API.
@@ -14,8 +14,8 @@ class Server {
     public readonly origin: string,
   ) {}
 
-  public static from(given: Server): Server {
-    const clonedServer = new Server(
+  public static from(given: WebAPI_Server): WebAPI_Server {
+    const clonedServer = new WebAPI_Server(
       given.origin,
     );
 
@@ -26,9 +26,9 @@ class Server {
     .object({
       origin: Schema.string(),
     })
-    .transform($0 => Server.from($0));
+    .transform($0 => WebAPI_Server.from($0));
 }
 
 export {
-  Server as default,
+  WebAPI_Server as default,
 };

--- a/src/library/WebAPI/exports.ts
+++ b/src/library/WebAPI/exports.ts
@@ -1,5 +1,5 @@
-import Server from './Server.ts';
+import WebAPI_Server from './Server.ts';
 
 export {
-  Server,
+  WebAPI_Server as Server,
 };


### PR DESCRIPTION
- one of the challenges with this codebase is keep the concerns between the bespoke logic and the home-rolled utilities (to avoid external dependencies) separate
- the semantic separation helps achieve this by stating the assumed sequence of members used to access a value or type from some top-level namespace
- by stating the top-level namespace for each declaration, it's a little easier to stay oriented no matter which part of the codebase is examined
- it's also easier to tell which declarations are out of place and need to be declared within another namespace
- this convention does not apply to "toolbox" modules that offer suites of pure functions