### PR TITLE
linter: enforces avoidance of useless renames

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -52,6 +52,9 @@ const extraConfigForESLint: ConfigWithExtends = {
         message : 'Prefer `Attempt.that` callback for error propagation over `throw`.',
       },
     ],
+    'no-useless-rename': [
+      'error', // Reduces diff noise when renaming symbols at module boundaries
+    ],
   },
 };
 

--- a/src/library/utilitiesByType/array.ts
+++ b/src/library/utilitiesByType/array.ts
@@ -12,5 +12,5 @@ const hasAtLeastOne = <SomeElement>(
 
 export {
   isEmpty,
-  hasAtLeastOne as hasAtLeastOne,
+  hasAtLeastOne,
 };


### PR DESCRIPTION
Noisy diffs encountered while working on drafts for #745