### PR TITLE
refactor: ensures declarations include level 2 namespaces in "features/text-to-image"

### DIFF
--- a/src/features/TextToImage/Server/exports.ts
+++ b/src/features/TextToImage/Server/exports.ts
@@ -12,10 +12,10 @@ import {
 
 import TextToImage_Server_SpecificationError from './ServerSpecificationError';
 
-const TextToImage_environmentKeyForOriginOfServer = 'VITE__TEXT_TO_IMAGE__API__SERVER__ORIGIN';
+const TextToImage_Server_environmentKeyForOrigin = 'VITE__TEXT_TO_IMAGE__API__SERVER__ORIGIN';
 
-const TextToImage_serverAccordingToEnvironment = ((): WebAPI_Server | null => {
-  const originAccordingToEnvironment = import.meta.env[TextToImage_environmentKeyForOriginOfServer];
+const TextToImage_Server_accordingToEnvironment = ((): WebAPI_Server | null => {
+  const originAccordingToEnvironment = import.meta.env[TextToImage_Server_environmentKeyForOrigin];
 
   if (
     originAccordingToEnvironment === undefined
@@ -26,12 +26,12 @@ const TextToImage_serverAccordingToEnvironment = ((): WebAPI_Server | null => {
   });
 })();
 
-const TextToImage_retrieveCurrentServer = (): Promise<
+const TextToImage_Server_retrieveCurrent = (): Promise<
   Attempt.Outcome<WebAPI_Server, TextToImage_Server_SpecificationError>
 > => Attempt.thatEventually(async (ends) => {
   if (
-    TextToImage_serverAccordingToEnvironment !== null
-  ) return ends.inSuccessWith(TextToImage_serverAccordingToEnvironment);
+    TextToImage_Server_accordingToEnvironment !== null
+  ) return ends.inSuccessWith(TextToImage_Server_accordingToEnvironment);
 
   const staticConfig = (await TextToImage_Config_Static.read()).optionallyUnwrap() ?? TextToImage_Config_empty;
 
@@ -46,7 +46,7 @@ const TextToImage_retrieveCurrentServer = (): Promise<
   ) return ends.inSuccessWith(dynamicConfig.server);
 
   const newSpecificationError = new TextToImage_Server_SpecificationError(
-    TextToImage_environmentKeyForOriginOfServer,
+    TextToImage_Server_environmentKeyForOrigin,
     TextToImage_Config_Static.file,
     TextToImage_Config_Dynamic.endpoint,
   );
@@ -59,7 +59,7 @@ export {
 } from './ServerConnectionError';
 
 export {
-  TextToImage_serverAccordingToEnvironment as accordingToEnvironment,
-  TextToImage_retrieveCurrentServer as retrieveCurrent,
+  TextToImage_Server_accordingToEnvironment as accordingToEnvironment,
+  TextToImage_Server_retrieveCurrent as retrieveCurrent,
   TextToImage_Server_SpecificationError as SpecificationError,
 };

--- a/src/features/TextToImage/Server/exports.ts
+++ b/src/features/TextToImage/Server/exports.ts
@@ -5,9 +5,9 @@ import {
 } from '@/library/WebAPI';
 
 import {
-  DynamicConfig as TextToImage_DynamicConfig,
-  StaticConfig as TextToImage_StaticConfig,
-  TextToImage_emptyConfig,
+  Config_Dynamic as TextToImage_Config_Dynamic,
+  Config_Static as TextToImage_Config_Static,
+  TextToImage_Config_empty,
 } from '../config';
 
 import TextToImage_Server_SpecificationError from './ServerSpecificationError';
@@ -33,13 +33,13 @@ const TextToImage_retrieveCurrentServer = (): Promise<
     TextToImage_serverAccordingToEnvironment !== null
   ) return ends.inSuccessWith(TextToImage_serverAccordingToEnvironment);
 
-  const staticConfig = (await TextToImage_StaticConfig.read()).optionallyUnwrap() ?? TextToImage_emptyConfig;
+  const staticConfig = (await TextToImage_Config_Static.read()).optionallyUnwrap() ?? TextToImage_Config_empty;
 
   if (
     staticConfig.server !== null
   ) return ends.inSuccessWith(staticConfig.server);
 
-  const dynamicConfig = (await TextToImage_DynamicConfig.fetch()).optionallyUnwrap() ?? TextToImage_emptyConfig;
+  const dynamicConfig = (await TextToImage_Config_Dynamic.fetch()).optionallyUnwrap() ?? TextToImage_Config_empty;
 
   if (
     dynamicConfig.server !== null
@@ -47,8 +47,8 @@ const TextToImage_retrieveCurrentServer = (): Promise<
 
   const newSpecificationError = new TextToImage_Server_SpecificationError(
     TextToImage_environmentKeyForOriginOfServer,
-    TextToImage_StaticConfig.file,
-    TextToImage_DynamicConfig.endpoint,
+    TextToImage_Config_Static.file,
+    TextToImage_Config_Dynamic.endpoint,
   );
 
   return ends.inFailureDueTo(newSpecificationError);

--- a/src/features/TextToImage/client/SDXL/conversions/GenerateFromTextResponse.ts
+++ b/src/features/TextToImage/client/SDXL/conversions/GenerateFromTextResponse.ts
@@ -9,8 +9,8 @@ import {
 } from '@/library/utilitiesByType/array';
 
 import type {
-  Input as TextToImage_Input,
-  Output as TextToImage_Output,
+  Input as TextToImage_Pipeline_Input,
+  Output as TextToImage_Pipeline_Output,
 } from '@/features/TextToImage/types';
 
 import {
@@ -22,8 +22,8 @@ import {
 } from './TextPrompt';
 
 const toNullableOutput = (
-  givenImage: TextToImage_Output['image'] | null,
-): TextToImage_Output | null => {
+  givenImage: TextToImage_Pipeline_Output['image'] | null,
+): TextToImage_Pipeline_Output | null => {
   if (
     givenImage === null
   ) return null;
@@ -39,9 +39,9 @@ const textToImageOutputs = (
     inferredFrom: givenInputText,
   }: {
     in: GenerateFromTextResponse;
-    inferredFrom: TextToImage_Input['text'];
+    inferredFrom: TextToImage_Pipeline_Input['text'];
   },
-): (TextToImage_Output | null)[] | null => {
+): (TextToImage_Pipeline_Output | null)[] | null => {
   if (
     !('artifacts' in givenResponse.result)
   ) return Attempt.abandon('Expected response body rather than readable stream');
@@ -67,9 +67,9 @@ const firstTextToImageOutput = (
     inferredFrom: givenInputText,
   }: {
     in: GenerateFromTextResponse;
-    inferredFrom: TextToImage_Input['text'];
+    inferredFrom: TextToImage_Pipeline_Input['text'];
   },
-): TextToImage_Output => {
+): TextToImage_Pipeline_Output => {
   const inferredOutputs = textToImageOutputs({
     in          : givenResponse,
     inferredFrom: givenInputText,

--- a/src/features/TextToImage/client/SDXL/conversions/StabilityAI_Client_Image.ts
+++ b/src/features/TextToImage/client/SDXL/conversions/StabilityAI_Client_Image.ts
@@ -4,7 +4,7 @@ import Base64CharacterEncodedByteSequence from '@/library/Base64CharacterEncoded
 import URI_Image from '@/library/UniformResourceIdentifier/Data/Image';
 
 import type {
-  Output as TextToImage_Output,
+  Output as TextToImage_Pipeline_Output,
 } from '@/features/TextToImage/types';
 
 const toOutputImage = (
@@ -12,7 +12,7 @@ const toOutputImage = (
   given: {
     description: string;
   },
-): TextToImage_Output['image'] | null => {
+): TextToImage_Pipeline_Output['image'] | null => {
   if (
     givenImage.base64 === undefined
   ) return null;

--- a/src/features/TextToImage/client/SDXL/exports.ts
+++ b/src/features/TextToImage/client/SDXL/exports.ts
@@ -16,7 +16,7 @@ import {
   firstTextToImageOutput,
 } from './conversions/GenerateFromTextResponse';
 
-const TextToImage_initializeShimmedStabilityAIClient = async (): Promise<
+const TextToImage_Client_initializeShimmedStabilityAI = async (): Promise<
   Attempt.Outcome<ShimmedStabilityAIClient, TextToImage_Server.SpecificationError>
 > => {
   const outcomeOfRetrievingCurrentServer = await TextToImage_Server.retrieveCurrent();
@@ -30,12 +30,12 @@ const TextToImage_initializeShimmedStabilityAIClient = async (): Promise<
   return outcomeOfInitializingClient;
 };
 
-type TextToImage_OutcomeOfGeneratingOutput = Attempt.Outcome<TextToImage_Pipeline_Output,
+type TextToImage_Client_OutcomeOfGeneratingOutput = Attempt.Outcome<TextToImage_Pipeline_Output,
   | TextToImage_Server.ConnectionError
   | TextToImage_Server.SpecificationError
 >;
 
-const TextToImage_generateOutputFrom = async (
+const TextToImage_Client_generateOutputFrom = async (
   given: {
     textToImageRequestBody: Pick<GenerateFromTextRequest['textToImageRequestBody'],
     | 'textPrompts'
@@ -46,8 +46,8 @@ const TextToImage_generateOutputFrom = async (
     | 'seed'
     >;
   },
-): Promise<TextToImage_OutcomeOfGeneratingOutput> => {
-  const outcomeOfInitializingClient = await TextToImage_initializeShimmedStabilityAIClient();
+): Promise<TextToImage_Client_OutcomeOfGeneratingOutput> => {
+  const outcomeOfInitializingClient = await TextToImage_Client_initializeShimmedStabilityAI();
 
   if (
     outcomeOfInitializingClient.isFailure
@@ -87,10 +87,10 @@ const TextToImage_generateOutputFrom = async (
   return outcomeOfSettlingSoleTextToImageOutput;
 };
 
-const TextToImage_SDXLClient = {
-  generateOutputFrom: TextToImage_generateOutputFrom,
+const TextToImage_Client_SDXL = {
+  generateOutputFrom: TextToImage_Client_generateOutputFrom,
 };
 
 export {
-  TextToImage_SDXLClient,
+  TextToImage_Client_SDXL,
 };

--- a/src/features/TextToImage/client/SDXL/exports.ts
+++ b/src/features/TextToImage/client/SDXL/exports.ts
@@ -7,7 +7,7 @@ import HTTP from '@/library/HTTP';
 import ShimmedStabilityAIClient from '@/library/ShimmedStabilityAIClient';
 
 import type {
-  Output as TextToImage_Output,
+  Output as TextToImage_Pipeline_Output,
 } from '@/features/TextToImage/types';
 
 import * as TextToImage_Server from '../../Server';
@@ -30,7 +30,7 @@ const TextToImage_initializeShimmedStabilityAIClient = async (): Promise<
   return outcomeOfInitializingClient;
 };
 
-type TextToImage_OutcomeOfGeneratingOutput = Attempt.Outcome<TextToImage_Output,
+type TextToImage_OutcomeOfGeneratingOutput = Attempt.Outcome<TextToImage_Pipeline_Output,
   | TextToImage_Server.ConnectionError
   | TextToImage_Server.SpecificationError
 >;

--- a/src/features/TextToImage/client/SDXL/index.ts
+++ b/src/features/TextToImage/client/SDXL/index.ts
@@ -1,3 +1,3 @@
 export {
-  TextToImage_SDXLClient as default,
+  TextToImage_Client_SDXL as default,
 } from './exports.ts';

--- a/src/features/TextToImage/components/TextToImageInputSection.vue
+++ b/src/features/TextToImage/components/TextToImageInputSection.vue
@@ -16,10 +16,10 @@ import {
 } from 'vuetify/components/VTextarea';
 
 import type {
-  Input as TextToImage_Input,
+  Input as TextToImage_Pipeline_Input,
 } from '../types';
 
-type StandardizedInputText = TextToImage_Input['text'];
+type StandardizedInputText = TextToImage_Pipeline_Input['text'];
 
 const exposedInputText = defineModel<StandardizedInputText | null>({
   required: true,

--- a/src/features/TextToImage/config/exports.ts
+++ b/src/features/TextToImage/config/exports.ts
@@ -1,3 +1,3 @@
-export * as DynamicConfig from './utilities/DynamicConfig';
-export * as StaticConfig from './utilities/StaticConfig';
+export * as Config_Dynamic from './utilities/DynamicConfig';
+export * as Config_Static from './utilities/StaticConfig';
 export * from './utilities/emptyConfig';

--- a/src/features/TextToImage/config/utilities/DynamicConfig/EndpointResponseError.ts
+++ b/src/features/TextToImage/config/utilities/DynamicConfig/EndpointResponseError.ts
@@ -4,11 +4,11 @@ import type {
   URLComponent_Path,
 } from '@/library/URLComponent';
 
-class TextToImage_DynamicConfig_EndpointResponseError
+class TextToImage_Config_Dynamic_EndpointResponseError
   extends Attempt.ActionableError<
-  'TextToImage_DynamicConfig_EndpointResponseError'
+  'TextToImage_Config_Dynamic_EndpointResponseError'
 > {
-  public override name = 'TextToImage_DynamicConfig_EndpointResponseError' as const;
+  public override name = 'TextToImage_Config_Dynamic_EndpointResponseError' as const;
 
   public constructor(given: {
     endpoint: URLComponent_Path;
@@ -19,5 +19,5 @@ class TextToImage_DynamicConfig_EndpointResponseError
 }
 
 export {
-  TextToImage_DynamicConfig_EndpointResponseError as default,
+  TextToImage_Config_Dynamic_EndpointResponseError as default,
 };

--- a/src/features/TextToImage/config/utilities/DynamicConfig/FetchingError.ts
+++ b/src/features/TextToImage/config/utilities/DynamicConfig/FetchingError.ts
@@ -4,11 +4,11 @@ import type {
   URLComponent_Path,
 } from '@/library/URLComponent';
 
-class TextToImage_DynamicConfig_FetchingError
+class TextToImage_Config_Dynamic_FetchingError
   extends Attempt.ActionableError<
-  'TextToImage_DynamicConfig_FetchingError'
+  'TextToImage_Config_Dynamic_FetchingError'
 > {
-  public override name = 'TextToImage_DynamicConfig_FetchingError' as const;
+  public override name = 'TextToImage_Config_Dynamic_FetchingError' as const;
 
   public constructor(
     givenEndpoint: URLComponent_Path,
@@ -18,5 +18,5 @@ class TextToImage_DynamicConfig_FetchingError
 }
 
 export {
-  TextToImage_DynamicConfig_FetchingError as default,
+  TextToImage_Config_Dynamic_FetchingError as default,
 };

--- a/src/features/TextToImage/config/utilities/DynamicConfig/exports.ts
+++ b/src/features/TextToImage/config/utilities/DynamicConfig/exports.ts
@@ -11,7 +11,7 @@ import {
 import TextToImage_DynamicConfig_EndpointResponseError from './EndpointResponseError';
 import TextToImage_DynamicConfig_FetchingError from './FetchingError';
 
-const HTTP_contentIsJSONIn = (givenResponse: Response): boolean => {
+const HTTP_Client_contentIsJSONIn = (givenResponse: Response): boolean => {
   const rawContentDescriptor = givenResponse.headers.get('Content-Type');
 
   if (
@@ -42,7 +42,7 @@ const TextToImage_fetchConfig = (): Promise<TextToImage_OutcomeOfFetchingConfig>
   });
 
   if (
-    !HTTP_contentIsJSONIn(endpointResponse)
+    !HTTP_Client_contentIsJSONIn(endpointResponse)
   ) return ends.inFailureDueTo(endpointResponseError);
 
   const rawConfig = await endpointResponse.json() as unknown;

--- a/src/features/TextToImage/config/utilities/DynamicConfig/exports.ts
+++ b/src/features/TextToImage/config/utilities/DynamicConfig/exports.ts
@@ -8,8 +8,8 @@ import {
   Config as TextToImage_Config,
 } from '../../types';
 
-import TextToImage_DynamicConfig_EndpointResponseError from './EndpointResponseError';
-import TextToImage_DynamicConfig_FetchingError from './FetchingError';
+import TextToImage_Config_Dynamic_EndpointResponseError from './EndpointResponseError';
+import TextToImage_Config_Dynamic_FetchingError from './FetchingError';
 
 const HTTP_Client_contentIsJSONIn = (givenResponse: Response): boolean => {
   const rawContentDescriptor = givenResponse.headers.get('Content-Type');
@@ -21,23 +21,23 @@ const HTTP_Client_contentIsJSONIn = (givenResponse: Response): boolean => {
   return rawContentDescriptor.includes('application/json');
 };
 
-const TextToImage_configEndpoint = URLComponent_Path.parsedFrom('/config/text-to-image').forciblyUnwrap();
+const TextToImage_Config_endpoint = URLComponent_Path.parsedFrom('/config/text-to-image').forciblyUnwrap();
 
-type TextToImage_OutcomeOfFetchingConfig = Attempt.Outcome<TextToImage_Config,
-  | TextToImage_DynamicConfig_FetchingError
-  | TextToImage_DynamicConfig_EndpointResponseError
+type TextToImage_Config_OutcomeOfFetching = Attempt.Outcome<TextToImage_Config,
+  | TextToImage_Config_Dynamic_FetchingError
+  | TextToImage_Config_Dynamic_EndpointResponseError
 >;
 
-const TextToImage_fetchConfig = (): Promise<TextToImage_OutcomeOfFetchingConfig> => Attempt.thatEventually(async (ends) => {
-  const endpointResponse = await fetch(TextToImage_configEndpoint.toString());
-  const fetchingError = new TextToImage_DynamicConfig_FetchingError(TextToImage_configEndpoint);
+const TextToImage_Config_fetch = (): Promise<TextToImage_Config_OutcomeOfFetching> => Attempt.thatEventually(async (ends) => {
+  const endpointResponse = await fetch(TextToImage_Config_endpoint.toString());
+  const fetchingError = new TextToImage_Config_Dynamic_FetchingError(TextToImage_Config_endpoint);
 
   if (
     !endpointResponse.ok
   ) return ends.inFailureDueTo(fetchingError);
 
-  const endpointResponseError = new TextToImage_DynamicConfig_EndpointResponseError({
-    endpoint: TextToImage_configEndpoint,
+  const endpointResponseError = new TextToImage_Config_Dynamic_EndpointResponseError({
+    endpoint: TextToImage_Config_endpoint,
     response: endpointResponse,
   });
 
@@ -51,8 +51,8 @@ const TextToImage_fetchConfig = (): Promise<TextToImage_OutcomeOfFetchingConfig>
 });
 
 export {
-  TextToImage_configEndpoint as endpoint,
-  TextToImage_fetchConfig as fetch,
-  TextToImage_DynamicConfig_FetchingError as FetchingError,
-  TextToImage_DynamicConfig_EndpointResponseError as EndpointResponseError,
+  TextToImage_Config_endpoint as endpoint,
+  TextToImage_Config_fetch as fetch,
+  TextToImage_Config_Dynamic_FetchingError as FetchingError,
+  TextToImage_Config_Dynamic_EndpointResponseError as EndpointResponseError,
 };

--- a/src/features/TextToImage/config/utilities/StaticConfig/StaticConfigReadingError.ts
+++ b/src/features/TextToImage/config/utilities/StaticConfig/StaticConfigReadingError.ts
@@ -4,11 +4,11 @@ import type {
   URLComponent_Path,
 } from '@/library/URLComponent';
 
-class TextToImage_StaticConfigReadingError
+class TextToImage_Config_StaticReadingError
   extends Attempt.ActionableError<
-  'TextToImage_StaticConfigReadingError'
+  'TextToImage_Config_StaticReadingError'
 > {
-  public override name = 'TextToImage_StaticConfigReadingError' as const;
+  public override name = 'TextToImage_Config_StaticReadingError' as const;
 
   public constructor(
     givenFile: URLComponent_Path,
@@ -19,5 +19,5 @@ class TextToImage_StaticConfigReadingError
 }
 
 export {
-  TextToImage_StaticConfigReadingError as default,
+  TextToImage_Config_StaticReadingError as default,
 };

--- a/src/features/TextToImage/config/utilities/StaticConfig/exports.ts
+++ b/src/features/TextToImage/config/utilities/StaticConfig/exports.ts
@@ -8,21 +8,21 @@ import {
   Config as TextToImage_Config,
 } from '../../types';
 
-import TextToImage_StaticConfigReadingError from './StaticConfigReadingError';
+import TextToImage_Config_StaticReadingError from './StaticConfigReadingError';
 
-const TextToImage_configFile = URLComponent_Path.parsedFrom('/config/text-to-image.json').forciblyUnwrap();
+const TextToImage_Config_file = URLComponent_Path.parsedFrom('/config/text-to-image.json').forciblyUnwrap();
 
-type TextToImage_OutcomeOfReadingConfig = Attempt.Outcome<
+type TextToImage_Config_OutcomeOfReading = Attempt.Outcome<
   TextToImage_Config,
-  TextToImage_StaticConfigReadingError
+  TextToImage_Config_StaticReadingError
 >;
 
-const TextToImage_readConfig = (): Promise<TextToImage_OutcomeOfReadingConfig> => Attempt.thatEventually(async (ends) => {
-  const fileResponse = await fetch(TextToImage_configFile.toString());
+const TextToImage_Config_read = (): Promise<TextToImage_Config_OutcomeOfReading> => Attempt.thatEventually(async (ends) => {
+  const fileResponse = await fetch(TextToImage_Config_file.toString());
 
   if (
     !fileResponse.ok
-  ) return ends.inFailureDueTo(new TextToImage_StaticConfigReadingError(TextToImage_configFile, fileResponse));
+  ) return ends.inFailureDueTo(new TextToImage_Config_StaticReadingError(TextToImage_Config_file, fileResponse));
 
   const rawConfig = await fileResponse.json() as unknown;
   const parsedConfig = TextToImage_Config.parsedFrom(rawConfig).forciblyUnwrap(/* Implementation must align with established contract. */);
@@ -30,7 +30,7 @@ const TextToImage_readConfig = (): Promise<TextToImage_OutcomeOfReadingConfig> =
 });
 
 export {
-  TextToImage_configFile as file,
-  TextToImage_readConfig as read,
-  TextToImage_StaticConfigReadingError as ReadingError,
+  TextToImage_Config_file as file,
+  TextToImage_Config_read as read,
+  TextToImage_Config_StaticReadingError as ReadingError,
 };

--- a/src/features/TextToImage/config/utilities/emptyConfig.ts
+++ b/src/features/TextToImage/config/utilities/emptyConfig.ts
@@ -2,10 +2,10 @@ import type {
   Config as TextToImage_Config,
 } from '../types';
 
-const TextToImage_emptyConfig: TextToImage_Config = {
+const TextToImage_Config_empty: TextToImage_Config = {
   server: null,
 };
 
 export {
-  TextToImage_emptyConfig,
+  TextToImage_Config_empty,
 };

--- a/src/features/TextToImage/types/Input.ts
+++ b/src/features/TextToImage/types/Input.ts
@@ -3,10 +3,10 @@ import type {
 } from 'stabilityai-client-typescript/models/components';
 
 /** The information that's eventually ingested by some text-to-image model */
-interface TextToImage_Input {
+interface TextToImage_Pipeline_Input {
   text: TextToImageRequestBody['textPrompts'];
 }
 
 export type {
-  TextToImage_Input,
+  TextToImage_Pipeline_Input,
 };

--- a/src/features/TextToImage/types/Output/Image.ts
+++ b/src/features/TextToImage/types/Output/Image.ts
@@ -1,10 +1,10 @@
 import type URI_Image from '@/library/UniformResourceIdentifier/Data/Image';
 
-interface TextToImage_Output_Image {
+interface TextToImage_Pipeline_Output_Image {
   uri: URI_Image;
   description: string;
 }
 
 export type {
-  TextToImage_Output_Image as default,
+  TextToImage_Pipeline_Output_Image as default,
 };

--- a/src/features/TextToImage/types/Output/definition.ts
+++ b/src/features/TextToImage/types/Output/definition.ts
@@ -1,10 +1,10 @@
-import type TextToImage_Output_Image from './Image';
+import type TextToImage_Pipeline_Output_Image from './Image';
 
 /** The resulting information after a text-to-image model has ingested some input with some configuration */
-interface TextToImage_Output {
-  image: TextToImage_Output_Image;
+interface TextToImage_Pipeline_Output {
+  image: TextToImage_Pipeline_Output_Image;
 }
 
 export type {
-  TextToImage_Output,
+  TextToImage_Pipeline_Output,
 };

--- a/src/features/TextToImage/types/exports.ts
+++ b/src/features/TextToImage/types/exports.ts
@@ -1,6 +1,6 @@
 export type {
-  TextToImage_Input as Input,
+  TextToImage_Pipeline_Input as Input,
 } from './Input';
 export type {
-  TextToImage_Output as Output,
+  TextToImage_Pipeline_Output as Output,
 } from './Output';


### PR DESCRIPTION
- the concepts captured by this feature library include:
  - `TextToImage.Client`
  - `TextToImage.Server`
  - `TextToImage.Config`
  - `TextToImage.Pipeline` 
- these changes make those concepts obvious from _within_ the library
- it also makes it obvious that the `HTTP_Client...` declaration is in the wrong library and needs to be moved