### PR TITLE
refactor: ensures declarations include level 2 namespaces in "library/Attempt"

### DIFF
--- a/src/features/TextToImage/Server/ServerConnectionError.ts
+++ b/src/features/TextToImage/Server/ServerConnectionError.ts
@@ -1,7 +1,7 @@
 import Attempt from '@/library/Attempt';
 
 class TextToImage_Server_ConnectionError
-  extends Attempt.ActionableError<
+  extends Attempt.Error_Actionable<
   'TextToImage_Server_ConnectionError'
 > {
   public override name = 'TextToImage_Server_ConnectionError' as const;

--- a/src/features/TextToImage/Server/ServerSpecificationError.ts
+++ b/src/features/TextToImage/Server/ServerSpecificationError.ts
@@ -5,7 +5,7 @@ import type {
 } from '@/library/URLComponent';
 
 class TextToImage_Server_SpecificationError
-  extends Attempt.ActionableError<
+  extends Attempt.Error_Actionable<
   'TextToImage_Server_SpecificationError'
 > {
   public override name = 'TextToImage_Server_SpecificationError' as const;

--- a/src/features/TextToImage/client/SDXL/exports.ts
+++ b/src/features/TextToImage/client/SDXL/exports.ts
@@ -67,7 +67,7 @@ const TextToImage_Client_generateOutputFrom = async (
     },
   });
 
-  const outcomeOfSettlingTextToImageResponse = await Attempt.toSettle(promisedTextToImageResponse, {
+  const outcomeOfSettlingTextToImageResponse = await Attempt.Adapted_toSettle(promisedTextToImageResponse, {
     interpretationOf: (caughtError) => {
       if (
         !(caughtError instanceof HTTP.Endpoint.RequestError)

--- a/src/features/TextToImage/config/utilities/DynamicConfig/EndpointResponseError.ts
+++ b/src/features/TextToImage/config/utilities/DynamicConfig/EndpointResponseError.ts
@@ -5,7 +5,7 @@ import type {
 } from '@/library/URLComponent';
 
 class TextToImage_Config_Dynamic_EndpointResponseError
-  extends Attempt.ActionableError<
+  extends Attempt.Error_Actionable<
   'TextToImage_Config_Dynamic_EndpointResponseError'
 > {
   public override name = 'TextToImage_Config_Dynamic_EndpointResponseError' as const;

--- a/src/features/TextToImage/config/utilities/DynamicConfig/FetchingError.ts
+++ b/src/features/TextToImage/config/utilities/DynamicConfig/FetchingError.ts
@@ -5,7 +5,7 @@ import type {
 } from '@/library/URLComponent';
 
 class TextToImage_Config_Dynamic_FetchingError
-  extends Attempt.ActionableError<
+  extends Attempt.Error_Actionable<
   'TextToImage_Config_Dynamic_FetchingError'
 > {
   public override name = 'TextToImage_Config_Dynamic_FetchingError' as const;

--- a/src/features/TextToImage/config/utilities/StaticConfig/StaticConfigReadingError.ts
+++ b/src/features/TextToImage/config/utilities/StaticConfig/StaticConfigReadingError.ts
@@ -5,7 +5,7 @@ import type {
 } from '@/library/URLComponent';
 
 class TextToImage_Config_StaticReadingError
-  extends Attempt.ActionableError<
+  extends Attempt.Error_Actionable<
   'TextToImage_Config_StaticReadingError'
 > {
   public override name = 'TextToImage_Config_StaticReadingError' as const;

--- a/src/library/Attempt/Outcome/Discriminable.ts
+++ b/src/library/Attempt/Outcome/Discriminable.ts
@@ -5,7 +5,7 @@ import type {
 } from '@/library/typeUtilities/Boolean';
 
 import type {
-  Attempt_ActionableError,
+  Attempt_Error_Actionable,
 } from '../error';
 
 type Attempt_Outcome_Discriminant = 'success' | 'failure';
@@ -22,7 +22,7 @@ interface Attempt_DiscriminableOutcome<
   SomePayload extends (
     SomeDiscriminant extends 'success'
       ? unknown
-      : Attempt_ActionableError<string>
+      : Attempt_Error_Actionable<string>
   ),
 > extends Attempt_SyntacticallySugarfreeDiscriminableOutcome<
   SomeDiscriminant
@@ -44,7 +44,7 @@ interface Attempt_DiscriminableOutcome<
     TransformedPayload extends (
       SomeDiscriminant extends 'success'
         ? unknown
-        : Attempt_ActionableError<string>
+        : Attempt_Error_Actionable<string>
     ) = SomePayload,
   >(): Attempt_DiscriminableOutcome<SomeDiscriminant, TransformedPayload>;
 }

--- a/src/library/Attempt/Outcome/Discriminable.ts
+++ b/src/library/Attempt/Outcome/Discriminable.ts
@@ -11,20 +11,20 @@ import type {
 type Attempt_Outcome_Discriminant = 'success' | 'failure';
 
 // cspell:words sugarfree discriminable
-interface Attempt_SyntacticallySugarfreeDiscriminableOutcome<
+interface Attempt_Outcome_SyntacticallySugarfreeDiscriminable<
   SomeDiscriminant extends Attempt_Outcome_Discriminant,
 > {
   readonly discriminant: SomeDiscriminant;
 }
 
-interface Attempt_DiscriminableOutcome<
+interface Attempt_Outcome_Discriminable<
   SomeDiscriminant extends Attempt_Outcome_Discriminant,
   SomePayload extends (
     SomeDiscriminant extends 'success'
       ? unknown
       : Attempt_Error_Actionable<string>
   ),
-> extends Attempt_SyntacticallySugarfreeDiscriminableOutcome<
+> extends Attempt_Outcome_SyntacticallySugarfreeDiscriminable<
   SomeDiscriminant
 > {
   readonly isSuccess: Is<this['discriminant'], 'success'>;
@@ -46,9 +46,9 @@ interface Attempt_DiscriminableOutcome<
         ? unknown
         : Attempt_Error_Actionable<string>
     ) = SomePayload,
-  >(): Attempt_DiscriminableOutcome<SomeDiscriminant, TransformedPayload>;
+  >(): Attempt_Outcome_Discriminable<SomeDiscriminant, TransformedPayload>;
 }
 
 export type {
-  Attempt_DiscriminableOutcome,
+  Attempt_Outcome_Discriminable,
 };

--- a/src/library/Attempt/Outcome/Failure/Transformer.ts
+++ b/src/library/Attempt/Outcome/Failure/Transformer.ts
@@ -1,17 +1,17 @@
 import type {
-  Attempt_ActionableError,
+  Attempt_Error_Actionable,
 } from '../../error';
 
 type Attempt_CauseTransformer<
-  SomeTransformableActionableError extends Attempt_ActionableError<string>,
-  SomeTransformedActionableError extends Attempt_ActionableError<string>,
+  SomeTransformableActionableError extends Attempt_Error_Actionable<string>,
+  SomeTransformedActionableError extends Attempt_Error_Actionable<string>,
 > = (
   transformableCause: SomeTransformableActionableError,
 ) => SomeTransformedActionableError;
 
 const Attempt_causeIdentity = <
-  SomeTransformableActionableError extends Attempt_ActionableError<string>,
-  SomeTransformedActionableError extends Attempt_ActionableError<string>,
+  SomeTransformableActionableError extends Attempt_Error_Actionable<string>,
+  SomeTransformedActionableError extends Attempt_Error_Actionable<string>,
 >(
   transformableCause: NoInfer<SomeTransformableActionableError>,
 ): NoInfer<SomeTransformedActionableError> => {
@@ -19,8 +19,8 @@ const Attempt_causeIdentity = <
 };
 
 interface Attempt_Failure_Transformer<
-  SomeTransformableActionableError extends Attempt_ActionableError<string>,
-  SomeTransformedActionableError extends Attempt_ActionableError<string>,
+  SomeTransformableActionableError extends Attempt_Error_Actionable<string>,
+  SomeTransformedActionableError extends Attempt_Error_Actionable<string>,
 > {
   cause: Attempt_CauseTransformer<
     SomeTransformableActionableError,

--- a/src/library/Attempt/Outcome/Failure/Transformer.ts
+++ b/src/library/Attempt/Outcome/Failure/Transformer.ts
@@ -2,14 +2,14 @@ import type {
   Attempt_Error_Actionable,
 } from '../../error';
 
-type Attempt_CauseTransformer<
+type Attempt_Outcome_CauseTransformer<
   SomeTransformableActionableError extends Attempt_Error_Actionable<string>,
   SomeTransformedActionableError extends Attempt_Error_Actionable<string>,
 > = (
   transformableCause: SomeTransformableActionableError,
 ) => SomeTransformedActionableError;
 
-const Attempt_causeIdentity = <
+const Attempt_Outcome_causeIdentity = <
   SomeTransformableActionableError extends Attempt_Error_Actionable<string>,
   SomeTransformedActionableError extends Attempt_Error_Actionable<string>,
 >(
@@ -18,17 +18,17 @@ const Attempt_causeIdentity = <
   return transformableCause as unknown as SomeTransformedActionableError;
 };
 
-interface Attempt_Failure_Transformer<
+interface Attempt_Outcome_Failure_Transformer<
   SomeTransformableActionableError extends Attempt_Error_Actionable<string>,
   SomeTransformedActionableError extends Attempt_Error_Actionable<string>,
 > {
-  cause: Attempt_CauseTransformer<
+  cause: Attempt_Outcome_CauseTransformer<
     SomeTransformableActionableError,
     SomeTransformedActionableError
   >;
 }
 
 export {
-  type Attempt_Failure_Transformer,
-  Attempt_causeIdentity,
+  type Attempt_Outcome_Failure_Transformer,
+  Attempt_Outcome_causeIdentity,
 };

--- a/src/library/Attempt/Outcome/Failure/exports.ts
+++ b/src/library/Attempt/Outcome/Failure/exports.ts
@@ -5,26 +5,26 @@ import type {
 } from '../../error';
 
 import type {
-  Attempt_DiscriminableOutcome,
+  Attempt_Outcome_Discriminable,
 } from '../Discriminable';
 
 import {
-  type Attempt_Failure_Transformer,
-  Attempt_causeIdentity,
+  type Attempt_Outcome_Failure_Transformer,
+  Attempt_Outcome_causeIdentity,
 } from './Transformer';
 
-interface Attempt_SemanticallySugarfreeFailure<
+interface Attempt_Outcome_SemanticallySugarfreeFailure<
   SomeActionableError extends Attempt_Error_Actionable<string>,
-> extends Attempt_DiscriminableOutcome<
+> extends Attempt_Outcome_Discriminable<
   'failure',
   SomeActionableError
 > {
   readonly cause: SomeActionableError;
 }
 
-interface Attempt_Failure<
+interface Attempt_Outcome_Failure<
   SomeActionableError extends Attempt_Error_Actionable<string>,
-> extends Attempt_SemanticallySugarfreeFailure<
+> extends Attempt_Outcome_SemanticallySugarfreeFailure<
   SomeActionableError
 > {
   /**
@@ -49,18 +49,18 @@ interface Attempt_Failure<
   rewrappedWith<
     TransformedActionableError extends Attempt_Error_Actionable<string> = SomeActionableError,
   >(
-    given?: Attempt_Failure_Transformer<
+    given?: Attempt_Outcome_Failure_Transformer<
       SomeActionableError,
       TransformedActionableError
     >
-  ): Attempt_Failure<TransformedActionableError>;
+  ): Attempt_Outcome_Failure<TransformedActionableError>;
 }
 
-const Attempt_failureDueTo = <
+const Attempt_Outcome_failureDueTo = <
   SomeActionableError extends Attempt_Error_Actionable<string>,
 >(
   givenCause: SomeActionableError,
-): Attempt_Failure<SomeActionableError> => ({
+): Attempt_Outcome_Failure<SomeActionableError> => ({
   discriminant    : 'failure',
   cause           : givenCause,
   isSuccess       : false,
@@ -74,18 +74,18 @@ const Attempt_failureDueTo = <
     {
       cause: transformed,
     } = {
-      cause: Attempt_causeIdentity<SomeActionableError, TransformedActionableError>,
+      cause: Attempt_Outcome_causeIdentity<SomeActionableError, TransformedActionableError>,
     },
   ) => {
     const transformedCause = transformed(givenCause);
-    const transformedFailure = Attempt_failureDueTo(transformedCause);
+    const transformedFailure = Attempt_Outcome_failureDueTo(transformedCause);
     return transformedFailure;
   },
 });
 
 export {
-  type Attempt_Failure,
-  type Attempt_Failure_Transformer,
-  Attempt_failureDueTo,
-  Attempt_causeIdentity,
+  type Attempt_Outcome_Failure,
+  type Attempt_Outcome_Failure_Transformer,
+  Attempt_Outcome_failureDueTo,
+  Attempt_Outcome_causeIdentity,
 };

--- a/src/library/Attempt/Outcome/Failure/exports.ts
+++ b/src/library/Attempt/Outcome/Failure/exports.ts
@@ -1,7 +1,7 @@
 // cspell:words sugarfree discriminable
 
 import type {
-  Attempt_ActionableError,
+  Attempt_Error_Actionable,
 } from '../../error';
 
 import type {
@@ -14,7 +14,7 @@ import {
 } from './Transformer';
 
 interface Attempt_SemanticallySugarfreeFailure<
-  SomeActionableError extends Attempt_ActionableError<string>,
+  SomeActionableError extends Attempt_Error_Actionable<string>,
 > extends Attempt_DiscriminableOutcome<
   'failure',
   SomeActionableError
@@ -23,7 +23,7 @@ interface Attempt_SemanticallySugarfreeFailure<
 }
 
 interface Attempt_Failure<
-  SomeActionableError extends Attempt_ActionableError<string>,
+  SomeActionableError extends Attempt_Error_Actionable<string>,
 > extends Attempt_SemanticallySugarfreeFailure<
   SomeActionableError
 > {
@@ -47,7 +47,7 @@ interface Attempt_Failure<
   readonly causeOfFailure: this['cause'];
 
   rewrappedWith<
-    TransformedActionableError extends Attempt_ActionableError<string> = SomeActionableError,
+    TransformedActionableError extends Attempt_Error_Actionable<string> = SomeActionableError,
   >(
     given?: Attempt_Failure_Transformer<
       SomeActionableError,
@@ -57,7 +57,7 @@ interface Attempt_Failure<
 }
 
 const Attempt_failureDueTo = <
-  SomeActionableError extends Attempt_ActionableError<string>,
+  SomeActionableError extends Attempt_Error_Actionable<string>,
 >(
   givenCause: SomeActionableError,
 ): Attempt_Failure<SomeActionableError> => ({
@@ -69,7 +69,7 @@ const Attempt_failureDueTo = <
   forciblyUnwrap  : () => givenCause.throwAnyway('Unexpected forceful unwrap of a failure'),
   causeOfFailure  : givenCause,
   rewrappedWith   : <
-    TransformedActionableError extends Attempt_ActionableError<string>,
+    TransformedActionableError extends Attempt_Error_Actionable<string>,
   >(
     {
       cause: transformed,

--- a/src/library/Attempt/Outcome/Success/Transformer.ts
+++ b/src/library/Attempt/Outcome/Success/Transformer.ts
@@ -1,11 +1,11 @@
-type Attempt_ProductTransformer<
+type Attempt_Outcome_ProductTransformer<
   SomeTransformableProduct,
   SomeTransformedProduct,
 > = (
   transformableProduct: SomeTransformableProduct,
 ) => SomeTransformedProduct;
 
-const Attempt_productIdentity = <
+const Attempt_Outcome_productIdentity = <
   SomeTransformableProduct,
   SomeTransformedProduct,
 >(
@@ -14,17 +14,17 @@ const Attempt_productIdentity = <
   return transformableProduct as unknown as SomeTransformedProduct;
 };
 
-interface Attempt_Success_Transformer<
+interface Attempt_Outcome_Success_Transformer<
   SomeTransformableProduct,
   SomeTransformedProduct,
 > {
-  product: Attempt_ProductTransformer<
+  product: Attempt_Outcome_ProductTransformer<
     SomeTransformableProduct,
     SomeTransformedProduct
   >;
 }
 
 export {
-  type Attempt_Success_Transformer,
-  Attempt_productIdentity,
+  type Attempt_Outcome_Success_Transformer,
+  Attempt_Outcome_productIdentity,
 };

--- a/src/library/Attempt/Outcome/Success/exports.ts
+++ b/src/library/Attempt/Outcome/Success/exports.ts
@@ -1,26 +1,26 @@
 // cspell:words sugarfree discriminable
 
 import type {
-  Attempt_DiscriminableOutcome,
+  Attempt_Outcome_Discriminable,
 } from '../Discriminable';
 
 import {
-  type Attempt_Success_Transformer,
-  Attempt_productIdentity,
+  type Attempt_Outcome_Success_Transformer,
+  Attempt_Outcome_productIdentity,
 } from './Transformer';
 
-interface Attempt_SemanticallySugarfreeSuccess<
+interface Attempt_Outcome_SemanticallySugarfreeSuccess<
   SomeProduct,
-> extends Attempt_DiscriminableOutcome<
+> extends Attempt_Outcome_Discriminable<
   'success',
   SomeProduct
 > {
   readonly product: SomeProduct;
 }
 
-interface Attempt_Success<
+interface Attempt_Outcome_Success<
   SomeProduct,
-> extends Attempt_SemanticallySugarfreeSuccess<
+> extends Attempt_Outcome_SemanticallySugarfreeSuccess<
   SomeProduct
 > {
   /**
@@ -57,18 +57,18 @@ interface Attempt_Success<
   rewrappedWith<
     TransformedProduct = SomeProduct,
   >(
-    given?: Attempt_Success_Transformer<
+    given?: Attempt_Outcome_Success_Transformer<
       SomeProduct,
       TransformedProduct
     >
-  ): Attempt_Success<TransformedProduct>;
+  ): Attempt_Outcome_Success<TransformedProduct>;
 }
 
-const Attempt_successThatYielded = <
+const Attempt_Outcome_successThatYielded = <
   SomeProduct,
 >(
   givenProduct: SomeProduct,
-): Attempt_Success<SomeProduct> => ({
+): Attempt_Outcome_Success<SomeProduct> => ({
   discriminant    : 'success',
   product         : givenProduct,
   isSuccess       : true,
@@ -82,18 +82,18 @@ const Attempt_successThatYielded = <
     {
       product: transformed,
     } = {
-      product: Attempt_productIdentity<SomeProduct, TransformedProduct>,
+      product: Attempt_Outcome_productIdentity<SomeProduct, TransformedProduct>,
     },
   ) => {
     const transformedProduct = transformed(givenProduct);
-    const transformedSuccess = Attempt_successThatYielded(transformedProduct);
+    const transformedSuccess = Attempt_Outcome_successThatYielded(transformedProduct);
     return transformedSuccess;
   },
 });
 
 export {
-  type Attempt_Success,
-  type Attempt_Success_Transformer,
-  Attempt_successThatYielded,
-  Attempt_productIdentity,
+  type Attempt_Outcome_Success,
+  type Attempt_Outcome_Success_Transformer,
+  Attempt_Outcome_successThatYielded,
+  Attempt_Outcome_productIdentity,
 };

--- a/src/library/Attempt/Outcome/Transformer.ts
+++ b/src/library/Attempt/Outcome/Transformer.ts
@@ -3,11 +3,11 @@ import type {
 } from '../error';
 
 import type {
-  Attempt_Failure_Transformer,
+  Attempt_Outcome_Failure_Transformer,
 } from './Failure/Transformer';
 
 import type {
-  Attempt_Success_Transformer,
+  Attempt_Outcome_Success_Transformer,
 } from './Success/Transformer';
 
 type Attempt_Outcome_Transformer<
@@ -18,13 +18,13 @@ type Attempt_Outcome_Transformer<
 > =
   | (
     & Required<
-      Attempt_Success_Transformer<
+      Attempt_Outcome_Success_Transformer<
         SomeTransformableProduct,
         SomeTransformedProduct
       >
     >
     & Partial<
-      Attempt_Failure_Transformer<
+      Attempt_Outcome_Failure_Transformer<
         SomeTransformableActionableError,
         SomeTransformedActionableError
       >
@@ -32,13 +32,13 @@ type Attempt_Outcome_Transformer<
   )
   | (
     & Partial<
-      Attempt_Success_Transformer<
+      Attempt_Outcome_Success_Transformer<
         SomeTransformableProduct,
         SomeTransformedProduct
       >
     >
     & Required<
-      Attempt_Failure_Transformer<
+      Attempt_Outcome_Failure_Transformer<
         SomeTransformableActionableError,
         SomeTransformedActionableError
       >

--- a/src/library/Attempt/Outcome/Transformer.ts
+++ b/src/library/Attempt/Outcome/Transformer.ts
@@ -1,5 +1,5 @@
 import type {
-  Attempt_ActionableError,
+  Attempt_Error_Actionable,
 } from '../error';
 
 import type {
@@ -12,9 +12,9 @@ import type {
 
 type Attempt_Outcome_Transformer<
   SomeTransformableProduct,
-  SomeTransformableActionableError extends Attempt_ActionableError<string>,
+  SomeTransformableActionableError extends Attempt_Error_Actionable<string>,
   SomeTransformedProduct,
-  SomeTransformedActionableError extends Attempt_ActionableError<string>,
+  SomeTransformedActionableError extends Attempt_Error_Actionable<string>,
 > =
   | (
     & Required<

--- a/src/library/Attempt/Outcome/exports.ts
+++ b/src/library/Attempt/Outcome/exports.ts
@@ -1,5 +1,5 @@
 import type {
-  Attempt_ActionableError,
+  Attempt_Error_Actionable,
 } from '../error';
 
 import {
@@ -22,7 +22,7 @@ import type {
 
 type Attempt_Outcome<
   SomeProduct,
-  SomeActionableError extends Attempt_ActionableError<string>,
+  SomeActionableError extends Attempt_Error_Actionable<string>,
 > =
   | Attempt_Success<SomeProduct>
   | Attempt_Failure<SomeActionableError>
@@ -37,8 +37,8 @@ type Attempt_Outcome<
 * Helps avoid boilerplate when transforming outcomes.
 */
 function Attempt_fromRewrapping<
-  SomeTransformableActionableError extends Attempt_ActionableError<string>,
-  SomeTransformedActionableError extends Attempt_ActionableError<string> = SomeTransformableActionableError,
+  SomeTransformableActionableError extends Attempt_Error_Actionable<string>,
+  SomeTransformedActionableError extends Attempt_Error_Actionable<string> = SomeTransformableActionableError,
 >(
   givenOutcome: Attempt_Failure<SomeTransformableActionableError>,
   given?: Attempt_Failure_Transformer<
@@ -60,9 +60,9 @@ function Attempt_fromRewrapping<
 //
 function Attempt_fromRewrapping<
   SomeTransformableProduct,
-  SomeTransformableActionableError extends Attempt_ActionableError<string>,
+  SomeTransformableActionableError extends Attempt_Error_Actionable<string>,
   SomeTransformedProduct = SomeTransformableProduct,
-  SomeTransformedActionableError extends Attempt_ActionableError<string> = SomeTransformableActionableError,
+  SomeTransformedActionableError extends Attempt_Error_Actionable<string> = SomeTransformableActionableError,
 >(
   givenOutcome: Attempt_Outcome<SomeTransformableProduct, SomeTransformableActionableError>,
   given?: Attempt_Outcome_Transformer<
@@ -75,9 +75,9 @@ function Attempt_fromRewrapping<
 //
 function Attempt_fromRewrapping<
   SomeTransformableProduct,
-  SomeTransformableActionableError extends Attempt_ActionableError<string>,
+  SomeTransformableActionableError extends Attempt_Error_Actionable<string>,
   SomeTransformedProduct = SomeTransformableProduct,
-  SomeTransformedActionableError extends Attempt_ActionableError<string> = SomeTransformableActionableError,
+  SomeTransformedActionableError extends Attempt_Error_Actionable<string> = SomeTransformableActionableError,
 >(
   givenOutcome: Attempt_Outcome<SomeTransformableProduct, SomeTransformableActionableError>,
   {
@@ -109,13 +109,13 @@ const Attempt_Outcome = {
 };
 
 type ProductOf<
-  SomeOutcome extends Attempt_Outcome<unknown, Attempt_ActionableError<string>>,
+  SomeOutcome extends Attempt_Outcome<unknown, Attempt_Error_Actionable<string>>,
 > = SomeOutcome extends Attempt_Success<infer NestedProduct>
   ? NestedProduct
   : never;
 
 type CauseOf<
-  SomeOutcome extends Attempt_Outcome<unknown, Attempt_ActionableError<string>>,
+  SomeOutcome extends Attempt_Outcome<unknown, Attempt_Error_Actionable<string>>,
 > = SomeOutcome extends Attempt_Failure<infer NestedError>
   ? NestedError
   : never;

--- a/src/library/Attempt/Outcome/exports.ts
+++ b/src/library/Attempt/Outcome/exports.ts
@@ -3,17 +3,17 @@ import type {
 } from '../error';
 
 import {
-  type Attempt_Failure,
-  type Attempt_Failure_Transformer,
-  Attempt_failureDueTo,
-  Attempt_causeIdentity,
+  type Attempt_Outcome_Failure,
+  type Attempt_Outcome_Failure_Transformer,
+  Attempt_Outcome_failureDueTo,
+  Attempt_Outcome_causeIdentity,
 } from './Failure';
 
 import {
-  type Attempt_Success,
-  type Attempt_Success_Transformer,
-  Attempt_successThatYielded,
-  Attempt_productIdentity,
+  type Attempt_Outcome_Success,
+  type Attempt_Outcome_Success_Transformer,
+  Attempt_Outcome_successThatYielded,
+  Attempt_Outcome_productIdentity,
 } from './Success';
 
 import type {
@@ -24,8 +24,8 @@ type Attempt_Outcome<
   SomeProduct,
   SomeActionableError extends Attempt_Error_Actionable<string>,
 > =
-  | Attempt_Success<SomeProduct>
-  | Attempt_Failure<SomeActionableError>
+  | Attempt_Outcome_Success<SomeProduct>
+  | Attempt_Outcome_Failure<SomeActionableError>
 ;
 
 /**
@@ -36,29 +36,29 @@ type Attempt_Outcome<
 *
 * Helps avoid boilerplate when transforming outcomes.
 */
-function Attempt_fromRewrapping<
+function Attempt_Outcome_fromRewrapping<
   SomeTransformableActionableError extends Attempt_Error_Actionable<string>,
   SomeTransformedActionableError extends Attempt_Error_Actionable<string> = SomeTransformableActionableError,
 >(
-  givenOutcome: Attempt_Failure<SomeTransformableActionableError>,
-  given?: Attempt_Failure_Transformer<
+  givenOutcome: Attempt_Outcome_Failure<SomeTransformableActionableError>,
+  given?: Attempt_Outcome_Failure_Transformer<
     SomeTransformableActionableError,
     SomeTransformedActionableError
   >,
-): Attempt_Failure<SomeTransformedActionableError>;
+): Attempt_Outcome_Failure<SomeTransformedActionableError>;
 //
-function Attempt_fromRewrapping<
+function Attempt_Outcome_fromRewrapping<
   SomeTransformableProduct,
   SomeTransformedProduct = SomeTransformableProduct,
 >(
-  givenOutcome: Attempt_Success<SomeTransformableProduct>,
-  given?: Attempt_Success_Transformer<
+  givenOutcome: Attempt_Outcome_Success<SomeTransformableProduct>,
+  given?: Attempt_Outcome_Success_Transformer<
     SomeTransformableProduct,
     SomeTransformedProduct
   >,
-): Attempt_Success<SomeTransformedProduct>;
+): Attempt_Outcome_Success<SomeTransformedProduct>;
 //
-function Attempt_fromRewrapping<
+function Attempt_Outcome_fromRewrapping<
   SomeTransformableProduct,
   SomeTransformableActionableError extends Attempt_Error_Actionable<string>,
   SomeTransformedProduct = SomeTransformableProduct,
@@ -73,7 +73,7 @@ function Attempt_fromRewrapping<
   >,
 ): Attempt_Outcome<SomeTransformedProduct, SomeTransformedActionableError>;
 //
-function Attempt_fromRewrapping<
+function Attempt_Outcome_fromRewrapping<
   SomeTransformableProduct,
   SomeTransformableActionableError extends Attempt_Error_Actionable<string>,
   SomeTransformedProduct = SomeTransformableProduct,
@@ -81,16 +81,16 @@ function Attempt_fromRewrapping<
 >(
   givenOutcome: Attempt_Outcome<SomeTransformableProduct, SomeTransformableActionableError>,
   {
-    product: toTransformedProduct = Attempt_productIdentity<SomeTransformableProduct, SomeTransformedProduct>,
-    cause: toTransformedCause = Attempt_causeIdentity<SomeTransformableActionableError, SomeTransformedActionableError>,
+    product: toTransformedProduct = Attempt_Outcome_productIdentity<SomeTransformableProduct, SomeTransformedProduct>,
+    cause: toTransformedCause = Attempt_Outcome_causeIdentity<SomeTransformableActionableError, SomeTransformedActionableError>,
   }: Attempt_Outcome_Transformer<
     SomeTransformableProduct,
     SomeTransformableActionableError,
     SomeTransformedProduct,
     SomeTransformedActionableError
   > = {
-    product: Attempt_productIdentity<SomeTransformableProduct, SomeTransformedProduct>,
-    cause  : Attempt_causeIdentity<SomeTransformableActionableError, SomeTransformedActionableError>,
+    product: Attempt_Outcome_productIdentity<SomeTransformableProduct, SomeTransformedProduct>,
+    cause  : Attempt_Outcome_causeIdentity<SomeTransformableActionableError, SomeTransformedActionableError>,
   },
 ): Attempt_Outcome<SomeTransformedProduct, SomeTransformedActionableError> {
   return givenOutcome.isSuccess
@@ -103,27 +103,27 @@ function Attempt_fromRewrapping<
 }
 
 const Attempt_Outcome = {
-  failureDueTo      : Attempt_failureDueTo,
-  successThatYielded: Attempt_successThatYielded,
-  fromRewrapping    : Attempt_fromRewrapping,
+  failureDueTo      : Attempt_Outcome_failureDueTo,
+  successThatYielded: Attempt_Outcome_successThatYielded,
+  fromRewrapping    : Attempt_Outcome_fromRewrapping,
 };
 
 type ProductOf<
   SomeOutcome extends Attempt_Outcome<unknown, Attempt_Error_Actionable<string>>,
-> = SomeOutcome extends Attempt_Success<infer NestedProduct>
+> = SomeOutcome extends Attempt_Outcome_Success<infer NestedProduct>
   ? NestedProduct
   : never;
 
 type CauseOf<
   SomeOutcome extends Attempt_Outcome<unknown, Attempt_Error_Actionable<string>>,
-> = SomeOutcome extends Attempt_Failure<infer NestedError>
+> = SomeOutcome extends Attempt_Outcome_Failure<infer NestedError>
   ? NestedError
   : never;
 
 export {
   Attempt_Outcome,
-  type Attempt_Success,
-  type Attempt_Failure,
+  type Attempt_Outcome_Success,
+  type Attempt_Outcome_Failure,
   type ProductOf,
   type CauseOf,
 };

--- a/src/library/Attempt/adapter/Config.ts
+++ b/src/library/Attempt/adapter/Config.ts
@@ -4,12 +4,12 @@ import type {
 
 import type Attempt_Error_Interpreter from '../error/Interpreter';
 
-interface Attempt_AdapterConfig<
+interface Attempt_Adapted_Config<
   SomeActionableError extends Attempt_Error_Actionable<string>,
 > {
   interpretationOf: Attempt_Error_Interpreter<SomeActionableError>;
 }
 
 export type {
-  Attempt_AdapterConfig as default,
+  Attempt_Adapted_Config as default,
 };

--- a/src/library/Attempt/adapter/Config.ts
+++ b/src/library/Attempt/adapter/Config.ts
@@ -1,13 +1,13 @@
 import type {
-  Attempt_ActionableError,
+  Attempt_Error_Actionable,
 } from '../error';
 
-import type Attempt_ErrorInterpreter from '../error/Interpreter';
+import type Attempt_Error_Interpreter from '../error/Interpreter';
 
 interface Attempt_AdapterConfig<
-  SomeActionableError extends Attempt_ActionableError<string>,
+  SomeActionableError extends Attempt_Error_Actionable<string>,
 > {
-  interpretationOf: Attempt_ErrorInterpreter<SomeActionableError>;
+  interpretationOf: Attempt_Error_Interpreter<SomeActionableError>;
 }
 
 export type {

--- a/src/library/Attempt/adapter/asynchronous.ts
+++ b/src/library/Attempt/adapter/asynchronous.ts
@@ -3,7 +3,7 @@ import type {
 } from '../Outcome';
 
 import type {
-  Attempt_ActionableError,
+  Attempt_Error_Actionable,
 } from '../error';
 
 import {
@@ -22,7 +22,7 @@ import type Attempt_AdapterConfig from './Config';
 
 const Attempt_toEventually = async <
   SomeProduct,
-  SomeActionableError extends Attempt_ActionableError<string>,
+  SomeActionableError extends Attempt_Error_Actionable<string>,
 >(
   forciblyRetrieveProduct: () => Promise<SomeProduct>,
   given: Attempt_AdapterConfig<SomeActionableError>,
@@ -42,7 +42,7 @@ const Attempt_toEventually = async <
 
 const Attempt_toSettle = async <
   SomeProduct,
-  SomeActionableError extends Attempt_ActionableError<string>,
+  SomeActionableError extends Attempt_Error_Actionable<string>,
 >(
   promisedProduct: Promise<SomeProduct>,
   givenConfig: Attempt_AdapterConfig<SomeActionableError>,

--- a/src/library/Attempt/adapter/asynchronous.ts
+++ b/src/library/Attempt/adapter/asynchronous.ts
@@ -18,14 +18,14 @@ import {
   sanctionedAsync,
 } from '../utilities/sanctionedTryCatch';
 
-import type Attempt_AdapterConfig from './Config';
+import type Attempt_Adapted_Config from './Config';
 
-const Attempt_toEventually = async <
+const Attempt_Adapted_toEventually = async <
   SomeProduct,
   SomeActionableError extends Attempt_Error_Actionable<string>,
 >(
   forciblyRetrieveProduct: () => Promise<SomeProduct>,
-  given: Attempt_AdapterConfig<SomeActionableError>,
+  given: Attempt_Adapted_Config<SomeActionableError>,
 ): Promise<Attempt_Outcome<SomeProduct, SomeActionableError>> => Attempt_thatEventually(ends => sanctionedAsync({
   async try() {
     const retrievedProduct: SomeProduct = await forciblyRetrieveProduct();
@@ -40,18 +40,18 @@ const Attempt_toEventually = async <
   },
 }));
 
-const Attempt_toSettle = async <
+const Attempt_Adapted_toSettle = async <
   SomeProduct,
   SomeActionableError extends Attempt_Error_Actionable<string>,
 >(
   promisedProduct: Promise<SomeProduct>,
-  givenConfig: Attempt_AdapterConfig<SomeActionableError>,
+  givenConfig: Attempt_Adapted_Config<SomeActionableError>,
 ): Promise<Attempt_Outcome<SomeProduct, SomeActionableError>> => {
   const getPromisedProduct = () => promisedProduct;
-  return Attempt_toEventually(getPromisedProduct, givenConfig);
+  return Attempt_Adapted_toEventually(getPromisedProduct, givenConfig);
 };
 
 export {
-  Attempt_toEventually,
-  Attempt_toSettle,
+  Attempt_Adapted_toEventually,
+  Attempt_Adapted_toSettle,
 };

--- a/src/library/Attempt/adapter/exports.ts
+++ b/src/library/Attempt/adapter/exports.ts
@@ -1,12 +1,12 @@
 export {
-  Attempt_to,
+  Attempt_Adapted_to,
 } from './synchronous';
 
 export {
-  Attempt_toEventually,
-  Attempt_toSettle,
+  Attempt_Adapted_toEventually,
+  Attempt_Adapted_toSettle,
 } from './asynchronous';
 
 export type {
-  default as Attempt_AdapterConfig,
+  default as Attempt_Adapted_Config,
 } from './Config';

--- a/src/library/Attempt/adapter/synchronous.ts
+++ b/src/library/Attempt/adapter/synchronous.ts
@@ -18,14 +18,14 @@ import {
   sanctioned,
 } from '../utilities/sanctionedTryCatch';
 
-import type Attempt_AdapterConfig from './Config';
+import type Attempt_Adapted_Config from './Config';
 
-const Attempt_to = <
+const Attempt_Adapted_to = <
   SomeProduct,
   SomeActionableError extends Attempt_Error_Actionable<string>,
 >(
   forciblyGetProduct: () => SomeProduct,
-  given: Attempt_AdapterConfig<SomeActionableError>,
+  given: Attempt_Adapted_Config<SomeActionableError>,
 ): Attempt_Outcome<SomeProduct, SomeActionableError> => Attempt_that(ends => sanctioned({
   try() {
     const gottenProduct = forciblyGetProduct();
@@ -41,5 +41,5 @@ const Attempt_to = <
 }));
 
 export {
-  Attempt_to,
+  Attempt_Adapted_to,
 };

--- a/src/library/Attempt/adapter/synchronous.ts
+++ b/src/library/Attempt/adapter/synchronous.ts
@@ -3,7 +3,7 @@ import type {
 } from '../Outcome';
 
 import type {
-  Attempt_ActionableError,
+  Attempt_Error_Actionable,
 } from '../error';
 
 import {
@@ -22,7 +22,7 @@ import type Attempt_AdapterConfig from './Config';
 
 const Attempt_to = <
   SomeProduct,
-  SomeActionableError extends Attempt_ActionableError<string>,
+  SomeActionableError extends Attempt_Error_Actionable<string>,
 >(
   forciblyGetProduct: () => SomeProduct,
   given: Attempt_AdapterConfig<SomeActionableError>,

--- a/src/library/Attempt/ended.ts
+++ b/src/library/Attempt/ended.ts
@@ -3,7 +3,7 @@ import {
 } from './Outcome';
 
 import {
-  Attempt_NonActionableError,
+  Attempt_Error_NonActionable,
 } from './error';
 
 /**
@@ -20,7 +20,7 @@ const Attempt_ended = {
   /** Call this when the attempt has completed in terms of a prior outcome */
   inTermsOf      : Attempt_Outcome.fromRewrapping,
   /** Call this when it's not possible to complete the attempt */
-  inFlamesBecause: Attempt_NonActionableError.throw.bind(Attempt_NonActionableError),
+  inFlamesBecause: Attempt_Error_NonActionable.throw.bind(Attempt_Error_NonActionable),
 };
 
 export {

--- a/src/library/Attempt/error/ActionableError.ts
+++ b/src/library/Attempt/error/ActionableError.ts
@@ -3,11 +3,11 @@ import type {
 } from '@/library/typeUtilities/Branded';
 
 import {
-  default as Attempt_NonActionableError,
+  default as Attempt_Error_NonActionable,
 } from './NonActionableError';
 
 /** Extend this class to describe errors from which callers ought to recover */
-abstract class Attempt_ActionableError<
+abstract class Attempt_Error_Actionable<
   SomeBrand extends string,
 > extends Error
   implements Branded<
@@ -18,7 +18,7 @@ abstract class Attempt_ActionableError<
   public throwAnyway = (
     givenJustification: string,
   ): never => {
-    return Attempt_NonActionableError.throw(givenJustification, {
+    return Attempt_Error_NonActionable.throw(givenJustification, {
       cause  : this,
       thrower: this.throwAnyway,
     });
@@ -26,5 +26,5 @@ abstract class Attempt_ActionableError<
 }
 
 export {
-  Attempt_ActionableError as default,
+  Attempt_Error_Actionable as default,
 };

--- a/src/library/Attempt/error/Interpreter.ts
+++ b/src/library/Attempt/error/Interpreter.ts
@@ -1,11 +1,11 @@
-import type Attempt_ActionableError from './ActionableError';
+import type Attempt_Error_Actionable from './ActionableError';
 
 import type {
   PotentiallyActionable,
 } from './modifier';
 
 type Attempt_ErrorInterpreter<
-  SomeActionableError extends Attempt_ActionableError<string>,
+  SomeActionableError extends Attempt_Error_Actionable<string>,
 > = (
   caughtError: PotentiallyActionable<Error>
 ) => SomeActionableError | null;

--- a/src/library/Attempt/error/NonActionableError.ts
+++ b/src/library/Attempt/error/NonActionableError.ts
@@ -2,7 +2,7 @@ import type {
   Branded,
 } from '@/library/typeUtilities/Branded';
 
-interface Attempt_NonActionableError_Options
+interface Attempt_Error_NonActionable_Options
   extends ErrorOptions {
   /** A function that's acting as an alternative to raw `throw` */
   thrower?: (...parameters: any[]) => unknown; // eslint-disable-line @typescript-eslint/no-explicit-any
@@ -14,7 +14,7 @@ interface Attempt_NonActionableError_Options
  * Applies to errors that the developer neglected to prevent, or that are
  * impossible to handle.
  */
-class Attempt_NonActionableError
+class Attempt_Error_NonActionable
   extends Error
   implements Branded<
   'NonActionableError'
@@ -23,7 +23,7 @@ class Attempt_NonActionableError
   public readonly brand!: 'NonActionableError';
 
   public constructor(
-    givenMessage: Attempt_NonActionableError['message'],
+    givenMessage: Attempt_Error_NonActionable['message'],
     givenOptions?: ErrorOptions,
   ) {
     super(givenMessage, givenOptions);
@@ -35,8 +35,8 @@ class Attempt_NonActionableError
   }
 
   public static throw(
-    givenMessage: Attempt_NonActionableError['message'],
-    givenOptions?: Attempt_NonActionableError_Options,
+    givenMessage: Attempt_Error_NonActionable['message'],
+    givenOptions?: Attempt_Error_NonActionable_Options,
   ): never {
     const newError = new this(givenMessage, givenOptions);
 
@@ -51,11 +51,11 @@ class Attempt_NonActionableError
   public static rethrow(
     givenError: Error,
     given: {
-      message: Attempt_NonActionableError['message'];
+      message: Attempt_Error_NonActionable['message'];
     },
   ): never {
     if (
-      givenError instanceof Attempt_NonActionableError
+      givenError instanceof Attempt_Error_NonActionable
     ) return givenError.throw();
 
     return this.throw(given.message, {
@@ -75,5 +75,5 @@ class Attempt_NonActionableError
 }
 
 export {
-  Attempt_NonActionableError as default,
+  Attempt_Error_NonActionable as default,
 };

--- a/src/library/Attempt/error/assertions/assertActionable.ts
+++ b/src/library/Attempt/error/assertions/assertActionable.ts
@@ -1,12 +1,12 @@
 import type {
-  default as Attempt_ActionableError,
+  default as Attempt_Error_Actionable,
 } from '../ActionableError';
 
 import type Attempt_ErrorInterpreter from '../Interpreter';
 import NonActionableBuiltInError from '../NonActionableBuiltInError';
 
 import {
-  default as Attempt_NonActionableError,
+  default as Attempt_Error_NonActionable,
 } from '../NonActionableError';
 
 import type {
@@ -18,7 +18,7 @@ import {
 } from './assertPotentiallyActionable';
 
 const assertActionable = <
-  SomeActionableError extends Attempt_ActionableError<string>,
+  SomeActionableError extends Attempt_Error_Actionable<string>,
 >(
   givenError: AppropriatelyThrown<Error>,
   {
@@ -34,7 +34,7 @@ const assertActionable = <
     definitelyActionableError !== null
   ) return definitelyActionableError;
 
-  return Attempt_NonActionableError.rethrow(potentiallyActionableError, {
+  return Attempt_Error_NonActionable.rethrow(potentiallyActionableError, {
     message: NonActionableBuiltInError.describes(givenError)
       ? 'Neglected to prevent built-in error'
       : 'Neglected to interpret or prevent potentially actionable error',

--- a/src/library/Attempt/error/assertions/assertAppropriatelyThrown.ts
+++ b/src/library/Attempt/error/assertions/assertAppropriatelyThrown.ts
@@ -1,5 +1,5 @@
 import {
-  default as Attempt_ActionableError,
+  default as Attempt_Error_Actionable,
 } from '../ActionableError';
 
 import type {
@@ -17,7 +17,7 @@ const assertAppropriatelyThrown = <
   givenError: SomeError,
 ): AppropriatelyThrown<SomeError> => {
   if (
-    givenError instanceof Attempt_ActionableError
+    givenError instanceof Attempt_Error_Actionable
   ) return givenError.throwAnyway('Unexpected raw `throw` of some `ActionableError`. If this was intentional, use `.throwAnyway(...)` on the instance instead.');
 
   return givenError as AppropriatelyThrown<SomeError>;

--- a/src/library/Attempt/error/assertions/assertPotentiallyActionable.ts
+++ b/src/library/Attempt/error/assertions/assertPotentiallyActionable.ts
@@ -1,7 +1,7 @@
-import Attempt_CreationError from '../../factory/AttemptCreationError';
+import Attempt_Error_Creation from '../../factory/AttemptCreationError';
 
 import {
-  default as Attempt_NonActionableError,
+  default as Attempt_Error_NonActionable,
 } from '../NonActionableError';
 
 import type {
@@ -14,11 +14,11 @@ const assertPotentiallyActionable = <
   givenError: SomeError,
 ): PotentiallyActionable<SomeError> => {
   if (
-    !(givenError instanceof Attempt_NonActionableError)
+    !(givenError instanceof Attempt_Error_NonActionable)
   ) return givenError as PotentiallyActionable<SomeError>;
 
   if (
-    !(givenError instanceof Attempt_CreationError)
+    !(givenError instanceof Attempt_Error_Creation)
     && (givenError.charge !== null)
   ) return givenError.charge as PotentiallyActionable<SomeError>;
 

--- a/src/library/Attempt/error/exports.ts
+++ b/src/library/Attempt/error/exports.ts
@@ -1,11 +1,11 @@
 export {
-  default as Attempt_NonActionableError,
+  default as Attempt_Error_NonActionable,
 } from './NonActionableError';
 
 export {
-  default as Attempt_ActionableError,
+  default as Attempt_Error_Actionable,
 } from './ActionableError';
 
 export type {
-  default as Attempt_ErrorInterpreter,
+  default as Attempt_Error_Interpreter,
 } from './Interpreter';

--- a/src/library/Attempt/error/modifier/AppropriatelyThrown.ts
+++ b/src/library/Attempt/error/modifier/AppropriatelyThrown.ts
@@ -1,10 +1,10 @@
-import type Attempt_ActionableError from '../ActionableError';
+import type Attempt_Error_Actionable from '../ActionableError';
 
 type AppropriatelyThrown<
   SomeError extends Error,
 > = Exclude<
   SomeError,
-  Attempt_ActionableError<string>
+  Attempt_Error_Actionable<string>
 >;
 
 export type {

--- a/src/library/Attempt/error/modifier/PotentiallyActionable.ts
+++ b/src/library/Attempt/error/modifier/PotentiallyActionable.ts
@@ -1,8 +1,8 @@
-import type Attempt_NonActionableError from '../NonActionableError';
+import type Attempt_Error_NonActionable from '../NonActionableError';
 
 type PotentiallyActionable<
   SomeError extends Error,
-> = Exclude<SomeError, Attempt_NonActionableError>;
+> = Exclude<SomeError, Attempt_Error_NonActionable>;
 
 export type {
   PotentiallyActionable as default,

--- a/src/library/Attempt/exports.ts
+++ b/src/library/Attempt/exports.ts
@@ -22,9 +22,9 @@ export {
 } from './adapter';
 
 export {
-  Attempt_NonActionableError as NonActionableError,
-  Attempt_ActionableError as ActionableError,
-  type Attempt_ErrorInterpreter as ErrorInterpreter,
+  Attempt_Error_NonActionable as Error_NonActionable,
+  Attempt_Error_Actionable as Error_Actionable,
+  type Attempt_Error_Interpreter as Error_Interpreter,
 } from './error';
 
 export {

--- a/src/library/Attempt/exports.ts
+++ b/src/library/Attempt/exports.ts
@@ -15,10 +15,10 @@ export {
 } from './Outcome';
 
 export {
-  Attempt_to as to,
-  Attempt_toEventually as toEventually,
-  Attempt_toSettle as toSettle,
-  type Attempt_AdapterConfig as AdapterConfig,
+  Attempt_Adapted_to as Adapted_to,
+  Attempt_Adapted_toEventually as Adapted_toEventually,
+  Attempt_Adapted_toSettle as Adapted_toSettle,
+  type Attempt_Adapted_Config as Adapted_Config,
 } from './adapter';
 
 export {

--- a/src/library/Attempt/exports.ts
+++ b/src/library/Attempt/exports.ts
@@ -10,8 +10,8 @@ export {
 
 export {
   Attempt_Outcome as Outcome,
-  type Attempt_Success as Success,
-  type Attempt_Failure as Failure,
+  type Attempt_Outcome_Success as Outcome_Success,
+  type Attempt_Outcome_Failure as Outcome_Failure,
 } from './Outcome';
 
 export {

--- a/src/library/Attempt/exports.ts
+++ b/src/library/Attempt/exports.ts
@@ -30,6 +30,6 @@ export {
 export {
   Attempt_that as that,
   Attempt_thatEventually as thatEventually,
-  type Attempt_EndGetter as EndGetter,
-  type Attempt_EndRetriever as EndRetriever,
+  type Attempt_End_Getter as End_Getter,
+  type Attempt_End_Retriever as End_Retriever,
 } from './factory';

--- a/src/library/Attempt/factory/AttemptCreationError.ts
+++ b/src/library/Attempt/factory/AttemptCreationError.ts
@@ -1,12 +1,12 @@
-import Attempt_NonActionableError from '../error/NonActionableError';
+import Attempt_Error_NonActionable from '../error/NonActionableError';
 
-class Attempt_CreationError
-  extends Attempt_NonActionableError {
+class Attempt_Error_Creation
+  extends Attempt_Error_NonActionable {
   public override name = 'AttemptCreationError' as const;
   public override readonly cause: Error;
 
   private constructor(
-    givenMessage: Attempt_NonActionableError['message'],
+    givenMessage: Attempt_Error_NonActionable['message'],
     givenOptions: {
       cause: Error;
     },
@@ -30,5 +30,5 @@ class Attempt_CreationError
 }
 
 export {
-  Attempt_CreationError as default,
+  Attempt_Error_Creation as default,
 };

--- a/src/library/Attempt/factory/asynchronous.ts
+++ b/src/library/Attempt/factory/asynchronous.ts
@@ -9,23 +9,23 @@ import {
 } from '../ended';
 
 import type {
-  Attempt_ActionableError,
+  Attempt_Error_Actionable,
 } from '../error';
 
 import {
   sanctionedAsync,
 } from '../utilities/sanctionedTryCatch';
 
-import Attempt_CreationError from './AttemptCreationError';
+import Attempt_Error_Creation from './AttemptCreationError';
 
 type Attempt_EndRetriever<
-  SomeInferredOutcome extends Attempt_Outcome<unknown, Attempt_ActionableError<string>>,
+  SomeInferredOutcome extends Attempt_Outcome<unknown, Attempt_Error_Actionable<string>>,
 > = (
   givenHandles: typeof handles
 ) => Promise<SomeInferredOutcome>;
 
 const Attempt_thatEventually = async <
-  SomeInferredOutcome extends Attempt_Outcome<unknown, Attempt_ActionableError<string>>,
+  SomeInferredOutcome extends Attempt_Outcome<unknown, Attempt_Error_Actionable<string>>,
 >(
   endsAccordingTo: Attempt_EndRetriever<SomeInferredOutcome>,
 ) => {
@@ -36,7 +36,7 @@ const Attempt_thatEventually = async <
       return await endsAccordingTo(handles) as EquivalentOutcome;
     },
     catch(someError) {
-      return Attempt_CreationError.rethrow(someError);
+      return Attempt_Error_Creation.rethrow(someError);
     },
   });
 };

--- a/src/library/Attempt/factory/asynchronous.ts
+++ b/src/library/Attempt/factory/asynchronous.ts
@@ -18,7 +18,7 @@ import {
 
 import Attempt_Error_Creation from './AttemptCreationError';
 
-type Attempt_EndRetriever<
+type Attempt_End_Retriever<
   SomeInferredOutcome extends Attempt_Outcome<unknown, Attempt_Error_Actionable<string>>,
 > = (
   givenHandles: typeof handles
@@ -27,7 +27,7 @@ type Attempt_EndRetriever<
 const Attempt_thatEventually = async <
   SomeInferredOutcome extends Attempt_Outcome<unknown, Attempt_Error_Actionable<string>>,
 >(
-  endsAccordingTo: Attempt_EndRetriever<SomeInferredOutcome>,
+  endsAccordingTo: Attempt_End_Retriever<SomeInferredOutcome>,
 ) => {
   type EquivalentOutcome = Attempt_Outcome<ProductOf<SomeInferredOutcome>, CauseOf<SomeInferredOutcome>>;
 
@@ -42,6 +42,6 @@ const Attempt_thatEventually = async <
 };
 
 export {
-  type Attempt_EndRetriever,
+  type Attempt_End_Retriever,
   Attempt_thatEventually,
 };

--- a/src/library/Attempt/factory/synchronous.ts
+++ b/src/library/Attempt/factory/synchronous.ts
@@ -9,23 +9,23 @@ import {
 } from '../ended';
 
 import type {
-  Attempt_ActionableError,
+  Attempt_Error_Actionable,
 } from '../error';
 
 import {
   sanctioned,
 } from '../utilities/sanctionedTryCatch';
 
-import Attempt_CreationError from './AttemptCreationError';
+import Attempt_Error_Creation from './AttemptCreationError';
 
 type Attempt_EndGetter<
-  SomeInferredOutcome extends Attempt_Outcome<unknown, Attempt_ActionableError<string>>,
+  SomeInferredOutcome extends Attempt_Outcome<unknown, Attempt_Error_Actionable<string>>,
 > = (
   givenHandles: typeof handles
 ) => SomeInferredOutcome;
 
 const Attempt_that = <
-  SomeInferredOutcome extends Attempt_Outcome<unknown, Attempt_ActionableError<string>>,
+  SomeInferredOutcome extends Attempt_Outcome<unknown, Attempt_Error_Actionable<string>>,
 >(
   endsAccordingTo: Attempt_EndGetter<SomeInferredOutcome>,
 ) => {
@@ -36,7 +36,7 @@ const Attempt_that = <
       return endsAccordingTo(handles) as EquivalentOutcome;
     },
     catch(someError) {
-      return Attempt_CreationError.rethrow(someError);
+      return Attempt_Error_Creation.rethrow(someError);
     },
   });
 };

--- a/src/library/Attempt/factory/synchronous.ts
+++ b/src/library/Attempt/factory/synchronous.ts
@@ -18,7 +18,7 @@ import {
 
 import Attempt_Error_Creation from './AttemptCreationError';
 
-type Attempt_EndGetter<
+type Attempt_End_Getter<
   SomeInferredOutcome extends Attempt_Outcome<unknown, Attempt_Error_Actionable<string>>,
 > = (
   givenHandles: typeof handles
@@ -27,7 +27,7 @@ type Attempt_EndGetter<
 const Attempt_that = <
   SomeInferredOutcome extends Attempt_Outcome<unknown, Attempt_Error_Actionable<string>>,
 >(
-  endsAccordingTo: Attempt_EndGetter<SomeInferredOutcome>,
+  endsAccordingTo: Attempt_End_Getter<SomeInferredOutcome>,
 ) => {
   type EquivalentOutcome = Attempt_Outcome<ProductOf<SomeInferredOutcome>, CauseOf<SomeInferredOutcome>>;
 
@@ -42,6 +42,6 @@ const Attempt_that = <
 };
 
 export {
-  type Attempt_EndGetter,
+  type Attempt_End_Getter,
   Attempt_that,
 };

--- a/src/library/HTTP/Client.ts
+++ b/src/library/HTTP/Client.ts
@@ -42,7 +42,7 @@ class HTTP_Client {
       body   : JSON.stringify(givenRequestBody),
     });
 
-    const outcomeOfSettlingResponse = await Attempt.toSettle(promisedResponse, {
+    const outcomeOfSettlingResponse = await Attempt.Adapted_toSettle(promisedResponse, {
       interpretationOf: (caughtError) => {
         const clientFailedToReachServer = caughtError.message.includes('Failed to fetch');
 

--- a/src/library/HTTP/Endpoint/RequestError.ts
+++ b/src/library/HTTP/Endpoint/RequestError.ts
@@ -1,7 +1,7 @@
 import Attempt from '@/library/Attempt';
 
 class HTTP_Endpoint_RequestError
-  extends Attempt.ActionableError<
+  extends Attempt.Error_Actionable<
   'HTTP_Endpoint_RequestError'
 > {
   public override name = 'HTTP_Endpoint_RequestError' as const;

--- a/src/library/HTTP/Endpoint/ResponseError.ts
+++ b/src/library/HTTP/Endpoint/ResponseError.ts
@@ -5,7 +5,7 @@ import type {
 } from '../Response';
 
 class HTTP_Endpoint_ResponseError
-  extends Attempt.ActionableError<
+  extends Attempt.Error_Actionable<
   'HTTP_Endpoint_ResponseError'
 > {
   public override name = 'HTTP_Endpoint_ResponseError' as const;

--- a/src/library/Parser/ParsingError.ts
+++ b/src/library/Parser/ParsingError.ts
@@ -2,7 +2,7 @@ import Attempt from '@/library/Attempt';
 
 abstract class ParsingError<
   SomeSubject extends string,
-> extends Attempt.ActionableError<
+> extends Attempt.Error_Actionable<
   `${SomeSubject}_ParsingError`
 > {
   public constructor(

--- a/src/library/Sequence/Base64/ConformanceError.ts
+++ b/src/library/Sequence/Base64/ConformanceError.ts
@@ -2,7 +2,7 @@ import Attempt from '@/library/Attempt';
 import Base64 from '@/library/Base64';
 
 class Sequence_Base64_ConformanceError
-  extends Attempt.ActionableError<
+  extends Attempt.Error_Actionable<
   'Sequence_Base64_ConformanceError'
 > {
   public override name = 'Sequence_Base64_ConformanceError' as const;

--- a/src/library/Sequence/Byte/EncodingCompatibilityError.ts
+++ b/src/library/Sequence/Byte/EncodingCompatibilityError.ts
@@ -2,7 +2,7 @@ import Attempt from '@/library/Attempt';
 import Byte from '@/library/Byte';
 
 class Sequence_Byte_EncodingCompatibilityError
-  extends Attempt.ActionableError<
+  extends Attempt.Error_Actionable<
   'Sequence_Byte_EncodingCompatibilityError'
 > {
   public override name = 'Sequence_Byte_EncodingCompatibilityError' as const;

--- a/src/library/math/operator/constructive/absoluteValueOf.test.ts
+++ b/src/library/math/operator/constructive/absoluteValueOf.test.ts
@@ -43,7 +43,7 @@ describe(absoluteValueOf, () => {
         it('should safely propagate the error', () => {
           expect.assertions(1);
 
-          expect(() => absoluteValueOf(soleInoperableNumber)).toThrow(Attempt.NonActionableError);
+          expect(() => absoluteValueOf(soleInoperableNumber)).toThrow(Attempt.Error_NonActionable);
         });
 
         it('should communicate clearly with developers', () => {

--- a/src/library/math/operator/constructive/greatestCommonDivisor.test.ts
+++ b/src/library/math/operator/constructive/greatestCommonDivisor.test.ts
@@ -102,7 +102,7 @@ describe.each(aliasKeys)(`${GCDAlias.default.name} alias: "%s"`, (eachAliasKey) 
         it.each(combosOfFractionalNumbers)('should safely propagate the error', (...$0) => {
           expect.assertions(1);
 
-          expect(() => eachAliasedGCD(...$0)).toThrow(Attempt.NonActionableError);
+          expect(() => eachAliasedGCD(...$0)).toThrow(Attempt.Error_NonActionable);
         });
 
         const fractionalCombosWithMessage = [

--- a/src/library/math/operator/hyper/rank3/squared.test.ts
+++ b/src/library/math/operator/hyper/rank3/squared.test.ts
@@ -42,7 +42,7 @@ describe(squared, () => {
       it('should safely propagate the error', () => {
         expect.assertions(1);
 
-        expect(() => squared(soleInoperableNumber)).toThrow(Attempt.NonActionableError);
+        expect(() => squared(soleInoperableNumber)).toThrow(Attempt.Error_NonActionable);
       });
 
       it('should communicate clearly with developers', () => {

--- a/src/library/math/operator/predicate/isFinite.test.ts
+++ b/src/library/math/operator/predicate/isFinite.test.ts
@@ -27,7 +27,7 @@ describe(isFinite, () => {
     it('should safely propagate the error', () => {
       expect.assertions(1);
 
-      expect(() => isFinite(theSoleInoperableNumber)).toThrow(Attempt.NonActionableError);
+      expect(() => isFinite(theSoleInoperableNumber)).toThrow(Attempt.Error_NonActionable);
     });
 
     it('should communicate clearly with developers', () => {

--- a/src/library/math/operator/predicate/isNegative.test.ts
+++ b/src/library/math/operator/predicate/isNegative.test.ts
@@ -42,7 +42,7 @@ describe(isNegative, () => {
       it('should safely propagate the error', () => {
         expect.assertions(1);
 
-        expect(() => isNegative(soleInoperableNumber)).toThrow(Attempt.NonActionableError);
+        expect(() => isNegative(soleInoperableNumber)).toThrow(Attempt.Error_NonActionable);
       });
 
       it('should communicate clearly with developers', () => {

--- a/src/library/math/operator/predicate/isWhole.test.ts
+++ b/src/library/math/operator/predicate/isWhole.test.ts
@@ -40,7 +40,7 @@ describe(isWhole, () => {
         it('should safely propagate the error', () => {
           expect.assertions(1);
 
-          expect(() => isWhole(eachInfiniteNumber)).toThrow(Attempt.NonActionableError);
+          expect(() => isWhole(eachInfiniteNumber)).toThrow(Attempt.Error_NonActionable);
         });
 
         it('should communicate clearly with developers', () => {

--- a/src/library/vue/statefulAttempt.ts
+++ b/src/library/vue/statefulAttempt.ts
@@ -9,7 +9,7 @@ import Attempt from '@/library/Attempt';
 
 interface StatefulAttempt<
   SomeProduct,
-  SomeActionableError extends Attempt.ActionableError<string>,
+  SomeActionableError extends Attempt.Error_Actionable<string>,
 > {
   initiate: () => Promise<void>;
   isInProgress: boolean;
@@ -19,7 +19,7 @@ interface StatefulAttempt<
 /** Useful when state of UI is dependent on some async operation and the outcome upon completion */
 const useStatefulAttemptThatEventually = <
   SomeProduct,
-  SomeActionableError extends Attempt.ActionableError<string>,
+  SomeActionableError extends Attempt.Error_Actionable<string>,
 >(
   retrieveOutcome: Attempt.EndRetriever<
     Attempt.Outcome<SomeProduct, SomeActionableError>

--- a/src/library/vue/statefulAttempt.ts
+++ b/src/library/vue/statefulAttempt.ts
@@ -21,7 +21,7 @@ const useStatefulAttemptThatEventually = <
   SomeProduct,
   SomeActionableError extends Attempt.Error_Actionable<string>,
 >(
-  retrieveOutcome: Attempt.EndRetriever<
+  retrieveOutcome: Attempt.End_Retriever<
     Attempt.Outcome<SomeProduct, SomeActionableError>
   >,
 ): StatefulAttempt<SomeProduct, SomeActionableError> => {


### PR DESCRIPTION
- the concepts captured by this error propagation library include:
  - `Attempt.that`
  - `Attempt.abandon`
  - `Attempt.Adapted`
  - `Attempt.End`
  - `Attempt.Outcome`
  - `Attempt.Error` 
- these changes make those concepts obvious from _within_ the library
- it also makes it obvious that some declarations need to be moved so that submodules align with these concepts