### PR TITLE
refactor(library/URI): ensures declarations are prefixed with top-level namespace

### DIFF
--- a/src/library/UniformResourceIdentifier/Data/EncodingIdentifier/index.ts
+++ b/src/library/UniformResourceIdentifier/Data/EncodingIdentifier/index.ts
@@ -1,1 +1,1 @@
-export * as DataURI_EncodingIdentifier from './exports.ts';
+export * as URI_Data_EncodingIdentifier from './exports.ts';

--- a/src/library/UniformResourceIdentifier/Data/Image/definition.ts
+++ b/src/library/UniformResourceIdentifier/Data/Image/definition.ts
@@ -2,7 +2,7 @@ import type Base64CharacterEncodedByteSequence from '@/library/Base64CharacterEn
 import ContentDescriptor from '@/library/ContentDescriptor';
 
 import type {
-  DataURI_EncodingIdentifier,
+  URI_Data_EncodingIdentifier,
 } from '../EncodingIdentifier';
 
 import {
@@ -19,7 +19,7 @@ class URI_Image
 
   public constructor(
     public readonly format: ImageURI_Format.Any,
-    givenEncoding: DataURI_EncodingIdentifier.Any,
+    givenEncoding: URI_Data_EncodingIdentifier.Any,
     givenData: Base64CharacterEncodedByteSequence,
   ) {
     super(

--- a/src/library/UniformResourceIdentifier/Data/definition.ts
+++ b/src/library/UniformResourceIdentifier/Data/definition.ts
@@ -8,7 +8,7 @@ import {
 } from '../definition.ts';
 
 import type {
-  DataURI_EncodingIdentifier,
+  URI_Data_EncodingIdentifier,
 } from './EncodingIdentifier';
 
 /** See [RFC 2397](https://datatracker.ietf.org/doc/rfc2397) for more info */
@@ -18,7 +18,7 @@ class URI_Data
 
   public constructor(
     private readonly overridableDescriptor: ContentDescriptor | null,
-    public readonly encoding: DataURI_EncodingIdentifier.Any,
+    public readonly encoding: URI_Data_EncodingIdentifier.Any,
     public readonly data: Base64CharacterEncodedByteSequence,
   ) {
     super(


### PR DESCRIPTION
Overlooked in #763 