### PR TITLE
refactor: avoids unnecessary specificity in "augmented definition" files

### DIFF
--- a/src/library/Shortfin/TextToImage/SDXL/Client/Request/Body/definitionWithAugmentation.ts
+++ b/src/library/Shortfin/TextToImage/SDXL/Client/Request/Body/definitionWithAugmentation.ts
@@ -1,5 +1,3 @@
 import './definitionAugmentation.ts';
 
-export {
-  Shortfin_TextToImage_SDXL_Client_Request_Body,
-} from './definition.ts';
+export * from './definition.ts';

--- a/src/library/Shortfin/TextToImage/SDXL/Client/definitionWithAugmentation.ts
+++ b/src/library/Shortfin/TextToImage/SDXL/Client/definitionWithAugmentation.ts
@@ -1,5 +1,3 @@
 import './definitionAugmentation.ts';
 
-export {
-  Shortfin_TextToImage_SDXL_Client,
-} from './definition.ts';
+export * from './definition.ts';


### PR DESCRIPTION
- "definition" files should only have a single export, so there's no reason to isolate any of the named exports
- using the wildcard exports allows all "definitionWithAugmentation.ts" files to be identical, opening the possibility for templatization