### PR TITLE
refactor: ensures declarations include level 3 namespaces in "library/TextToImage"

### DIFF
--- a/src/features/TextToImage/Client/SDXL/exports.ts
+++ b/src/features/TextToImage/Client/SDXL/exports.ts
@@ -30,7 +30,7 @@ const TextToImage_Client_SDXL_initialize = async (): Promise<
   return outcomeOfInitializingClient;
 };
 
-type TextToImage_Client_OutcomeOfGeneratingOutput = Attempt.Outcome<TextToImage_Pipeline_Output,
+type TextToImage_Client_Generation_Outcome = Attempt.Outcome<TextToImage_Pipeline_Output,
   | TextToImage_Server.ConnectionError
   | TextToImage_Server.SpecificationError
 >;
@@ -46,7 +46,7 @@ const TextToImage_Client_SDXL_generateOutputFrom = async (
     | 'seed'
     >;
   },
-): Promise<TextToImage_Client_OutcomeOfGeneratingOutput> => {
+): Promise<TextToImage_Client_Generation_Outcome> => {
   const outcomeOfInitializingClient = await TextToImage_Client_SDXL_initialize();
 
   if (

--- a/src/features/TextToImage/Client/SDXL/exports.ts
+++ b/src/features/TextToImage/Client/SDXL/exports.ts
@@ -17,7 +17,7 @@ import {
 } from './conversions/GenerateFromTextResponse';
 
 const TextToImage_Client_SDXL_initialize = async (): Promise<
-  Attempt.Outcome<ShimmedStabilityAIClient, TextToImage_Server.SpecificationError>
+  Attempt.Outcome<ShimmedStabilityAIClient, TextToImage_Server.Error_Specification>
 > => {
   const outcomeOfRetrievingCurrentServer = await TextToImage_Server.Current_retrieve();
 
@@ -31,8 +31,8 @@ const TextToImage_Client_SDXL_initialize = async (): Promise<
 };
 
 type TextToImage_Client_Generation_Outcome = Attempt.Outcome<TextToImage_Pipeline_Output,
-  | TextToImage_Server.ConnectionError
-  | TextToImage_Server.SpecificationError
+  | TextToImage_Server.Error_Connection
+  | TextToImage_Server.Error_Specification
 >;
 
 const TextToImage_Client_SDXL_generateOutputFrom = async (
@@ -73,7 +73,7 @@ const TextToImage_Client_SDXL_generateOutputFrom = async (
         !(caughtError instanceof HTTP.Endpoint.RequestError)
       ) return null;
 
-      return new TextToImage_Server.ConnectionError(caughtError.endpoint);
+      return new TextToImage_Server.Error_Connection(caughtError.endpoint);
     },
   });
 

--- a/src/features/TextToImage/Client/SDXL/exports.ts
+++ b/src/features/TextToImage/Client/SDXL/exports.ts
@@ -16,7 +16,7 @@ import {
   firstTextToImageOutput,
 } from './conversions/GenerateFromTextResponse';
 
-const TextToImage_Client_initializeShimmedStabilityAI = async (): Promise<
+const TextToImage_Client_SDXL_initialize = async (): Promise<
   Attempt.Outcome<ShimmedStabilityAIClient, TextToImage_Server.SpecificationError>
 > => {
   const outcomeOfRetrievingCurrentServer = await TextToImage_Server.retrieveCurrent();
@@ -35,7 +35,7 @@ type TextToImage_Client_OutcomeOfGeneratingOutput = Attempt.Outcome<TextToImage_
   | TextToImage_Server.SpecificationError
 >;
 
-const TextToImage_Client_generateOutputFrom = async (
+const TextToImage_Client_SDXL_generateOutputFrom = async (
   given: {
     textToImageRequestBody: Pick<GenerateFromTextRequest['textToImageRequestBody'],
     | 'textPrompts'
@@ -47,7 +47,7 @@ const TextToImage_Client_generateOutputFrom = async (
     >;
   },
 ): Promise<TextToImage_Client_OutcomeOfGeneratingOutput> => {
-  const outcomeOfInitializingClient = await TextToImage_Client_initializeShimmedStabilityAI();
+  const outcomeOfInitializingClient = await TextToImage_Client_SDXL_initialize();
 
   if (
     outcomeOfInitializingClient.isFailure
@@ -88,7 +88,7 @@ const TextToImage_Client_generateOutputFrom = async (
 };
 
 const TextToImage_Client_SDXL = {
-  generateOutputFrom: TextToImage_Client_generateOutputFrom,
+  generateOutputFrom: TextToImage_Client_SDXL_generateOutputFrom,
 };
 
 export {

--- a/src/features/TextToImage/Client/SDXL/exports.ts
+++ b/src/features/TextToImage/Client/SDXL/exports.ts
@@ -19,7 +19,7 @@ import {
 const TextToImage_Client_SDXL_initialize = async (): Promise<
   Attempt.Outcome<ShimmedStabilityAIClient, TextToImage_Server.SpecificationError>
 > => {
-  const outcomeOfRetrievingCurrentServer = await TextToImage_Server.retrieveCurrent();
+  const outcomeOfRetrievingCurrentServer = await TextToImage_Server.Current_retrieve();
 
   const outcomeOfInitializingClient = Attempt.Outcome.fromRewrapping(outcomeOfRetrievingCurrentServer, {
     product: textToImageServer => new ShimmedStabilityAIClient({

--- a/src/features/TextToImage/Config/utilities/DynamicConfig/exports.ts
+++ b/src/features/TextToImage/Config/utilities/DynamicConfig/exports.ts
@@ -12,23 +12,23 @@ import {
 import TextToImage_Config_Dynamic_EndpointResponseError from './EndpointResponseError';
 import TextToImage_Config_Dynamic_FetchingError from './FetchingError';
 
-const TextToImage_Config_endpoint = URLComponent_Path.parsedFrom('/config/text-to-image').forciblyUnwrap();
+const TextToImage_Config_Dynamic_endpoint = URLComponent_Path.parsedFrom('/config/text-to-image').forciblyUnwrap();
 
-type TextToImage_Config_OutcomeOfFetching = Attempt.Outcome<TextToImage_Config,
+type TextToImage_Config_Dynamic_OutcomeOfFetching = Attempt.Outcome<TextToImage_Config,
   | TextToImage_Config_Dynamic_FetchingError
   | TextToImage_Config_Dynamic_EndpointResponseError
 >;
 
-const TextToImage_Config_fetch = (): Promise<TextToImage_Config_OutcomeOfFetching> => Attempt.thatEventually(async (ends) => {
-  const endpointResponse = await fetch(TextToImage_Config_endpoint.toString());
-  const fetchingError = new TextToImage_Config_Dynamic_FetchingError(TextToImage_Config_endpoint);
+const TextToImage_Config_Dynamic_fetch = (): Promise<TextToImage_Config_Dynamic_OutcomeOfFetching> => Attempt.thatEventually(async (ends) => {
+  const endpointResponse = await fetch(TextToImage_Config_Dynamic_endpoint.toString());
+  const fetchingError = new TextToImage_Config_Dynamic_FetchingError(TextToImage_Config_Dynamic_endpoint);
 
   if (
     !endpointResponse.ok
   ) return ends.inFailureDueTo(fetchingError);
 
   const endpointResponseError = new TextToImage_Config_Dynamic_EndpointResponseError({
-    endpoint: TextToImage_Config_endpoint,
+    endpoint: TextToImage_Config_Dynamic_endpoint,
     response: endpointResponse,
   });
 
@@ -42,8 +42,8 @@ const TextToImage_Config_fetch = (): Promise<TextToImage_Config_OutcomeOfFetchin
 });
 
 export {
-  TextToImage_Config_endpoint as endpoint,
-  TextToImage_Config_fetch as fetch,
+  TextToImage_Config_Dynamic_endpoint as endpoint,
+  TextToImage_Config_Dynamic_fetch as fetch,
   TextToImage_Config_Dynamic_FetchingError as FetchingError,
   TextToImage_Config_Dynamic_EndpointResponseError as EndpointResponseError,
 };

--- a/src/features/TextToImage/Config/utilities/StaticConfig/StaticConfigReadingError.ts
+++ b/src/features/TextToImage/Config/utilities/StaticConfig/StaticConfigReadingError.ts
@@ -4,11 +4,11 @@ import type {
   URLComponent_Path,
 } from '@/library/URLComponent';
 
-class TextToImage_Config_StaticReadingError
+class TextToImage_Config_Static_ReadingError
   extends Attempt.Error_Actionable<
-  'TextToImage_Config_StaticReadingError'
+  'TextToImage_Config_Static_ReadingError'
 > {
-  public override name = 'TextToImage_Config_StaticReadingError' as const;
+  public override name = 'TextToImage_Config_Static_ReadingError' as const;
 
   public constructor(
     givenFile: URLComponent_Path,
@@ -19,5 +19,5 @@ class TextToImage_Config_StaticReadingError
 }
 
 export {
-  TextToImage_Config_StaticReadingError as default,
+  TextToImage_Config_Static_ReadingError as default,
 };

--- a/src/features/TextToImage/Config/utilities/StaticConfig/exports.ts
+++ b/src/features/TextToImage/Config/utilities/StaticConfig/exports.ts
@@ -8,21 +8,21 @@ import {
   Config as TextToImage_Config,
 } from '../../types';
 
-import TextToImage_Config_StaticReadingError from './StaticConfigReadingError';
+import TextToImage_Config_Static_ReadingError from './StaticConfigReadingError';
 
-const TextToImage_Config_file = URLComponent_Path.parsedFrom('/config/text-to-image.json').forciblyUnwrap();
+const TextToImage_Config_Static_file = URLComponent_Path.parsedFrom('/config/text-to-image.json').forciblyUnwrap();
 
-type TextToImage_Config_OutcomeOfReading = Attempt.Outcome<
+type TextToImage_Config_Static_OutcomeOfReading = Attempt.Outcome<
   TextToImage_Config,
-  TextToImage_Config_StaticReadingError
+  TextToImage_Config_Static_ReadingError
 >;
 
-const TextToImage_Config_read = (): Promise<TextToImage_Config_OutcomeOfReading> => Attempt.thatEventually(async (ends) => {
-  const fileResponse = await fetch(TextToImage_Config_file.toString());
+const TextToImage_Config_Static_read = (): Promise<TextToImage_Config_Static_OutcomeOfReading> => Attempt.thatEventually(async (ends) => {
+  const fileResponse = await fetch(TextToImage_Config_Static_file.toString());
 
   if (
     !fileResponse.ok
-  ) return ends.inFailureDueTo(new TextToImage_Config_StaticReadingError(TextToImage_Config_file, fileResponse));
+  ) return ends.inFailureDueTo(new TextToImage_Config_Static_ReadingError(TextToImage_Config_Static_file, fileResponse));
 
   const rawConfig = await fileResponse.json() as unknown;
   const parsedConfig = TextToImage_Config.parsedFrom(rawConfig).forciblyUnwrap(/* Implementation must align with established contract. */);
@@ -30,7 +30,7 @@ const TextToImage_Config_read = (): Promise<TextToImage_Config_OutcomeOfReading>
 });
 
 export {
-  TextToImage_Config_file as file,
-  TextToImage_Config_read as read,
-  TextToImage_Config_StaticReadingError as ReadingError,
+  TextToImage_Config_Static_file as file,
+  TextToImage_Config_Static_read as read,
+  TextToImage_Config_Static_ReadingError as ReadingError,
 };

--- a/src/features/TextToImage/Server/ServerConnectionError.ts
+++ b/src/features/TextToImage/Server/ServerConnectionError.ts
@@ -1,10 +1,10 @@
 import Attempt from '@/library/Attempt';
 
-class TextToImage_Server_ConnectionError
+class TextToImage_Server_Error_Connection
   extends Attempt.Error_Actionable<
-  'TextToImage_Server_ConnectionError'
+  'TextToImage_Server_Error_Connection'
 > {
-  public override name = 'TextToImage_Server_ConnectionError' as const;
+  public override name = 'TextToImage_Server_Error_Connection' as const;
 
   public constructor(
     public readonly endpoint: URL,
@@ -14,5 +14,5 @@ class TextToImage_Server_ConnectionError
 }
 
 export {
-  TextToImage_Server_ConnectionError as default,
+  TextToImage_Server_Error_Connection as default,
 };

--- a/src/features/TextToImage/Server/ServerSpecificationError.ts
+++ b/src/features/TextToImage/Server/ServerSpecificationError.ts
@@ -4,11 +4,11 @@ import type {
   URLComponent_Path,
 } from '@/library/URLComponent';
 
-class TextToImage_Server_SpecificationError
+class TextToImage_Server_Error_Specification
   extends Attempt.Error_Actionable<
-  'TextToImage_Server_SpecificationError'
+  'TextToImage_Server_Error_Specification'
 > {
-  public override name = 'TextToImage_Server_SpecificationError' as const;
+  public override name = 'TextToImage_Server_Error_Specification' as const;
 
   public constructor(
     public readonly environmentKey: string,
@@ -20,5 +20,5 @@ class TextToImage_Server_SpecificationError
 }
 
 export {
-  TextToImage_Server_SpecificationError as default,
+  TextToImage_Server_Error_Specification as default,
 };

--- a/src/features/TextToImage/Server/exports.ts
+++ b/src/features/TextToImage/Server/exports.ts
@@ -10,7 +10,7 @@ import {
   TextToImage_Config_empty,
 } from '../Config';
 
-import TextToImage_Server_SpecificationError from './ServerSpecificationError';
+import TextToImage_Server_Error_Specification from './ServerSpecificationError';
 
 const TextToImage_Server_Origin_environmentKey = 'VITE__TEXT_TO_IMAGE__API__SERVER__ORIGIN';
 
@@ -27,7 +27,7 @@ const TextToImage_Server_Current_accordingToEnvironment = ((): WebAPI_Server | n
 })();
 
 const TextToImage_Server_Current_retrieve = (): Promise<
-  Attempt.Outcome<WebAPI_Server, TextToImage_Server_SpecificationError>
+  Attempt.Outcome<WebAPI_Server, TextToImage_Server_Error_Specification>
 > => Attempt.thatEventually(async (ends) => {
   if (
     TextToImage_Server_Current_accordingToEnvironment !== null
@@ -45,7 +45,7 @@ const TextToImage_Server_Current_retrieve = (): Promise<
     dynamicConfig.server !== null
   ) return ends.inSuccessWith(dynamicConfig.server);
 
-  const newSpecificationError = new TextToImage_Server_SpecificationError(
+  const newSpecificationError = new TextToImage_Server_Error_Specification(
     TextToImage_Server_Origin_environmentKey,
     TextToImage_Config_Static.file,
     TextToImage_Config_Dynamic.endpoint,
@@ -55,11 +55,11 @@ const TextToImage_Server_Current_retrieve = (): Promise<
 });
 
 export {
-  default as ConnectionError,
+  default as Error_Connection,
 } from './ServerConnectionError';
 
 export {
   TextToImage_Server_Current_accordingToEnvironment as Current_accordingToEnvironment,
   TextToImage_Server_Current_retrieve as Current_retrieve,
-  TextToImage_Server_SpecificationError as SpecificationError,
+  TextToImage_Server_Error_Specification as Error_Specification,
 };

--- a/src/features/TextToImage/Server/exports.ts
+++ b/src/features/TextToImage/Server/exports.ts
@@ -14,7 +14,7 @@ import TextToImage_Server_SpecificationError from './ServerSpecificationError';
 
 const TextToImage_Server_Origin_environmentKey = 'VITE__TEXT_TO_IMAGE__API__SERVER__ORIGIN';
 
-const TextToImage_Server_accordingToEnvironment = ((): WebAPI_Server | null => {
+const TextToImage_Server_Current_accordingToEnvironment = ((): WebAPI_Server | null => {
   const originAccordingToEnvironment = import.meta.env[TextToImage_Server_Origin_environmentKey];
 
   if (
@@ -26,12 +26,12 @@ const TextToImage_Server_accordingToEnvironment = ((): WebAPI_Server | null => {
   });
 })();
 
-const TextToImage_Server_retrieveCurrent = (): Promise<
+const TextToImage_Server_Current_retrieve = (): Promise<
   Attempt.Outcome<WebAPI_Server, TextToImage_Server_SpecificationError>
 > => Attempt.thatEventually(async (ends) => {
   if (
-    TextToImage_Server_accordingToEnvironment !== null
-  ) return ends.inSuccessWith(TextToImage_Server_accordingToEnvironment);
+    TextToImage_Server_Current_accordingToEnvironment !== null
+  ) return ends.inSuccessWith(TextToImage_Server_Current_accordingToEnvironment);
 
   const staticConfig = (await TextToImage_Config_Static.read()).optionallyUnwrap() ?? TextToImage_Config_empty;
 
@@ -59,7 +59,7 @@ export {
 } from './ServerConnectionError';
 
 export {
-  TextToImage_Server_accordingToEnvironment as accordingToEnvironment,
-  TextToImage_Server_retrieveCurrent as retrieveCurrent,
+  TextToImage_Server_Current_accordingToEnvironment as Current_accordingToEnvironment,
+  TextToImage_Server_Current_retrieve as Current_retrieve,
   TextToImage_Server_SpecificationError as SpecificationError,
 };

--- a/src/features/TextToImage/Server/exports.ts
+++ b/src/features/TextToImage/Server/exports.ts
@@ -12,10 +12,10 @@ import {
 
 import TextToImage_Server_SpecificationError from './ServerSpecificationError';
 
-const TextToImage_Server_environmentKeyForOrigin = 'VITE__TEXT_TO_IMAGE__API__SERVER__ORIGIN';
+const TextToImage_Server_Origin_environmentKey = 'VITE__TEXT_TO_IMAGE__API__SERVER__ORIGIN';
 
 const TextToImage_Server_accordingToEnvironment = ((): WebAPI_Server | null => {
-  const originAccordingToEnvironment = import.meta.env[TextToImage_Server_environmentKeyForOrigin];
+  const originAccordingToEnvironment = import.meta.env[TextToImage_Server_Origin_environmentKey];
 
   if (
     originAccordingToEnvironment === undefined
@@ -46,7 +46,7 @@ const TextToImage_Server_retrieveCurrent = (): Promise<
   ) return ends.inSuccessWith(dynamicConfig.server);
 
   const newSpecificationError = new TextToImage_Server_SpecificationError(
-    TextToImage_Server_environmentKeyForOrigin,
+    TextToImage_Server_Origin_environmentKey,
     TextToImage_Config_Static.file,
     TextToImage_Config_Dynamic.endpoint,
   );

--- a/src/features/TextToImage/components/TextToImageOutputAlert.vue
+++ b/src/features/TextToImage/components/TextToImageOutputAlert.vue
@@ -5,8 +5,8 @@ import TextToImageServerConnectionAlert from './TextToImageServerConnectionAlert
 import TextToImageServerSpecificationAlert from './TextToImageServerSpecificationAlert.vue';
 
 type OutputError =
-  | TextToImage.Server.ConnectionError
-  | TextToImage.Server.SpecificationError
+  | TextToImage.Server.Error_Connection
+  | TextToImage.Server.Error_Specification
 ;
 
 defineProps<{
@@ -16,7 +16,7 @@ defineProps<{
 
 <template>
   <TextToImageServerSpecificationAlert
-    v-if="(error instanceof TextToImage.Server.SpecificationError)"
+    v-if="(error instanceof TextToImage.Server.Error_Specification)"
     :error="error"
   />
   <TextToImageServerConnectionAlert

--- a/src/features/TextToImage/components/TextToImageServerConnectionAlert.vue
+++ b/src/features/TextToImage/components/TextToImageServerConnectionAlert.vue
@@ -6,7 +6,7 @@ import {
 import type * as TextToImage from '@/features/TextToImage';
 
 defineProps<{
-  error: TextToImage.Server.ConnectionError;
+  error: TextToImage.Server.Error_Connection;
 }>();
 </script>
 

--- a/src/features/TextToImage/components/TextToImageServerSpecificationAlert.vue
+++ b/src/features/TextToImage/components/TextToImageServerSpecificationAlert.vue
@@ -6,7 +6,7 @@ import {
 import type * as TextToImage from '@/features/TextToImage';
 
 defineProps<{
-  error: TextToImage.Server.SpecificationError;
+  error: TextToImage.Server.Error_Specification;
 }>();
 </script>
 


### PR DESCRIPTION
- includes:
  - `TextToImage.Client.SDXL`
  - `TextToImage.Client.Generation`
  - `TextToImage.Config.Static`
  - `TextToImage.Config.Dynamic`
  - `TextToImage.Server.Origin`
  - `TextToImage.Server.Current`
  - `TextToImage.Server.Error`
- makes it obvious that some declarations need to be extracted into modules that correspond to their respective level 3 namespace 