### PR TITLE
refactor: ensures declarations include level 3 namespaces in "library/HTTP"

### DIFF
--- a/src/features/TextToImage/Client/SDXL/exports.ts
+++ b/src/features/TextToImage/Client/SDXL/exports.ts
@@ -70,7 +70,7 @@ const TextToImage_Client_SDXL_generateOutputFrom = async (
   const outcomeOfSettlingTextToImageResponse = await Attempt.Adapted_toSettle(promisedTextToImageResponse, {
     interpretationOf: (caughtError) => {
       if (
-        !(caughtError instanceof HTTP.Endpoint.RequestError)
+        !(caughtError instanceof HTTP.Endpoint.Error_Request)
       ) return null;
 
       return new TextToImage_Server.Error_Connection(caughtError.endpoint);

--- a/src/library/HTTP/Client.ts
+++ b/src/library/HTTP/Client.ts
@@ -62,7 +62,7 @@ class HTTP_Client {
           !clientFailedToReachServer
         ) return null;
 
-        return new HTTP_Endpoint.RequestError(endpointURL);
+        return new HTTP_Endpoint.Error_Request(endpointURL);
       },
     });
 
@@ -74,7 +74,7 @@ class HTTP_Client {
 
     if (
       !response.ok
-    ) return ends.inFailureDueTo(new HTTP_Endpoint.ResponseError(response.statusText, response.status));
+    ) return ends.inFailureDueTo(new HTTP_Endpoint.Error_Response(response.statusText, response.status));
 
     const responseBody: unknown = await response.json();
     return ends.inSuccessWith(responseBody);

--- a/src/library/HTTP/Endpoint/Outcome.ts
+++ b/src/library/HTTP/Endpoint/Outcome.ts
@@ -1,16 +1,16 @@
 import type Attempt from '@/library/Attempt';
 
 import type {
-  HTTP_Endpoint_RequestError,
+  HTTP_Endpoint_Error_Request,
 } from './RequestError';
 
 import type {
-  HTTP_Endpoint_ResponseError,
+  HTTP_Endpoint_Error_Response,
 } from './ResponseError';
 
 type HTTP_Endpoint_Outcome = Attempt.Outcome<
   unknown,
-  HTTP_Endpoint_RequestError | HTTP_Endpoint_ResponseError
+  HTTP_Endpoint_Error_Request | HTTP_Endpoint_Error_Response
 >;
 
 export type {

--- a/src/library/HTTP/Endpoint/RequestError.ts
+++ b/src/library/HTTP/Endpoint/RequestError.ts
@@ -1,10 +1,10 @@
 import Attempt from '@/library/Attempt';
 
-class HTTP_Endpoint_RequestError
+class HTTP_Endpoint_Error_Request
   extends Attempt.Error_Actionable<
-  'HTTP_Endpoint_RequestError'
+  'HTTP_Endpoint_Error_Request'
 > {
-  public override name = 'HTTP_Endpoint_RequestError' as const;
+  public override name = 'HTTP_Endpoint_Error_Request' as const;
 
   public constructor(
     public readonly endpoint: URL,
@@ -14,5 +14,5 @@ class HTTP_Endpoint_RequestError
 }
 
 export {
-  HTTP_Endpoint_RequestError,
+  HTTP_Endpoint_Error_Request,
 };

--- a/src/library/HTTP/Endpoint/ResponseError.ts
+++ b/src/library/HTTP/Endpoint/ResponseError.ts
@@ -4,11 +4,11 @@ import type {
   HTTP_Response,
 } from '../Response';
 
-class HTTP_Endpoint_ResponseError
+class HTTP_Endpoint_Error_Response
   extends Attempt.Error_Actionable<
-  'HTTP_Endpoint_ResponseError'
+  'HTTP_Endpoint_Error_Response'
 > {
-  public override name = 'HTTP_Endpoint_ResponseError' as const;
+  public override name = 'HTTP_Endpoint_Error_Response' as const;
 
   public constructor(
     givenMessage: string,
@@ -19,5 +19,5 @@ class HTTP_Endpoint_ResponseError
 }
 
 export {
-  HTTP_Endpoint_ResponseError,
+  HTTP_Endpoint_Error_Response,
 };

--- a/src/library/HTTP/Endpoint/exports.ts
+++ b/src/library/HTTP/Endpoint/exports.ts
@@ -1,9 +1,9 @@
 export {
-  HTTP_Endpoint_RequestError as RequestError,
+  HTTP_Endpoint_Error_Request as Error_Request,
 } from './RequestError';
 
 export {
-  HTTP_Endpoint_ResponseError as ResponseError,
+  HTTP_Endpoint_Error_Response as Error_Response,
 } from './ResponseError';
 
 export type {

--- a/src/library/Shortfin/TextToImage/SDXL/Client/Request/Outcome.ts
+++ b/src/library/Shortfin/TextToImage/SDXL/Client/Request/Outcome.ts
@@ -4,8 +4,8 @@ import type HTTP from '@/library/HTTP';
 
 type Shortfin_TextToImage_SDXL_Client_Request_Outcome = Attempt.Outcome<
   Base64CharacterEncodedByteSequence,
-  | HTTP.Endpoint.RequestError
-  | HTTP.Endpoint.ResponseError
+  | HTTP.Endpoint.Error_Request
+  | HTTP.Endpoint.Error_Response
 >;
 
 export type {


### PR DESCRIPTION
- establishes `HTTP.Endpoint.Error.*`
- highlights how the error types will need to be grouped