### PR TITLE
refactor: ensures declarations have level 3 namespaces in "library/Attempt"

### DIFF
--- a/src/library/Attempt/Outcome/Discriminable.ts
+++ b/src/library/Attempt/Outcome/Discriminable.ts
@@ -11,7 +11,7 @@ import type {
 type Attempt_Outcome_Discriminant = 'success' | 'failure';
 
 // cspell:words sugarfree discriminable
-interface Attempt_Outcome_SyntacticallySugarfreeDiscriminable<
+interface Attempt_Outcome_Discriminable_SyntacticallySugarfree<
   SomeDiscriminant extends Attempt_Outcome_Discriminant,
 > {
   readonly discriminant: SomeDiscriminant;
@@ -24,7 +24,7 @@ interface Attempt_Outcome_Discriminable<
       ? unknown
       : Attempt_Error_Actionable<string>
   ),
-> extends Attempt_Outcome_SyntacticallySugarfreeDiscriminable<
+> extends Attempt_Outcome_Discriminable_SyntacticallySugarfree<
   SomeDiscriminant
 > {
   readonly isSuccess: Is<this['discriminant'], 'success'>;

--- a/src/library/Attempt/Outcome/Failure/Transformer.ts
+++ b/src/library/Attempt/Outcome/Failure/Transformer.ts
@@ -2,14 +2,14 @@ import type {
   Attempt_Error_Actionable,
 } from '../../Error';
 
-type Attempt_Outcome_CauseTransformer<
+type Attempt_Outcome_Failure_CauseTransformer<
   SomeTransformableActionableError extends Attempt_Error_Actionable<string>,
   SomeTransformedActionableError extends Attempt_Error_Actionable<string>,
 > = (
   transformableCause: SomeTransformableActionableError,
 ) => SomeTransformedActionableError;
 
-const Attempt_Outcome_causeIdentity = <
+const Attempt_Outcome_Failure_causeIdentity = <
   SomeTransformableActionableError extends Attempt_Error_Actionable<string>,
   SomeTransformedActionableError extends Attempt_Error_Actionable<string>,
 >(
@@ -22,7 +22,7 @@ interface Attempt_Outcome_Failure_Transformer<
   SomeTransformableActionableError extends Attempt_Error_Actionable<string>,
   SomeTransformedActionableError extends Attempt_Error_Actionable<string>,
 > {
-  cause: Attempt_Outcome_CauseTransformer<
+  cause: Attempt_Outcome_Failure_CauseTransformer<
     SomeTransformableActionableError,
     SomeTransformedActionableError
   >;
@@ -30,5 +30,5 @@ interface Attempt_Outcome_Failure_Transformer<
 
 export {
   type Attempt_Outcome_Failure_Transformer,
-  Attempt_Outcome_causeIdentity,
+  Attempt_Outcome_Failure_causeIdentity,
 };

--- a/src/library/Attempt/Outcome/Failure/exports.ts
+++ b/src/library/Attempt/Outcome/Failure/exports.ts
@@ -10,10 +10,10 @@ import type {
 
 import {
   type Attempt_Outcome_Failure_Transformer,
-  Attempt_Outcome_causeIdentity,
+  Attempt_Outcome_Failure_causeIdentity,
 } from './Transformer';
 
-interface Attempt_Outcome_SemanticallySugarfreeFailure<
+interface Attempt_Outcome_Failure_SemanticallySugarfree<
   SomeActionableError extends Attempt_Error_Actionable<string>,
 > extends Attempt_Outcome_Discriminable<
   'failure',
@@ -24,7 +24,7 @@ interface Attempt_Outcome_SemanticallySugarfreeFailure<
 
 interface Attempt_Outcome_Failure<
   SomeActionableError extends Attempt_Error_Actionable<string>,
-> extends Attempt_Outcome_SemanticallySugarfreeFailure<
+> extends Attempt_Outcome_Failure_SemanticallySugarfree<
   SomeActionableError
 > {
   /**
@@ -56,7 +56,7 @@ interface Attempt_Outcome_Failure<
   ): Attempt_Outcome_Failure<TransformedActionableError>;
 }
 
-const Attempt_Outcome_failureDueTo = <
+const Attempt_Outcome_Failure_dueTo = <
   SomeActionableError extends Attempt_Error_Actionable<string>,
 >(
   givenCause: SomeActionableError,
@@ -74,11 +74,11 @@ const Attempt_Outcome_failureDueTo = <
     {
       cause: transformed,
     } = {
-      cause: Attempt_Outcome_causeIdentity<SomeActionableError, TransformedActionableError>,
+      cause: Attempt_Outcome_Failure_causeIdentity<SomeActionableError, TransformedActionableError>,
     },
   ) => {
     const transformedCause = transformed(givenCause);
-    const transformedFailure = Attempt_Outcome_failureDueTo(transformedCause);
+    const transformedFailure = Attempt_Outcome_Failure_dueTo(transformedCause);
     return transformedFailure;
   },
 });
@@ -86,6 +86,6 @@ const Attempt_Outcome_failureDueTo = <
 export {
   type Attempt_Outcome_Failure,
   type Attempt_Outcome_Failure_Transformer,
-  Attempt_Outcome_failureDueTo,
-  Attempt_Outcome_causeIdentity,
+  Attempt_Outcome_Failure_dueTo,
+  Attempt_Outcome_Failure_causeIdentity,
 };

--- a/src/library/Attempt/Outcome/Success/Transformer.ts
+++ b/src/library/Attempt/Outcome/Success/Transformer.ts
@@ -1,11 +1,11 @@
-type Attempt_Outcome_ProductTransformer<
+type Attempt_Outcome_Success_ProductTransformer<
   SomeTransformableProduct,
   SomeTransformedProduct,
 > = (
   transformableProduct: SomeTransformableProduct,
 ) => SomeTransformedProduct;
 
-const Attempt_Outcome_productIdentity = <
+const Attempt_Outcome_Success_productIdentity = <
   SomeTransformableProduct,
   SomeTransformedProduct,
 >(
@@ -18,7 +18,7 @@ interface Attempt_Outcome_Success_Transformer<
   SomeTransformableProduct,
   SomeTransformedProduct,
 > {
-  product: Attempt_Outcome_ProductTransformer<
+  product: Attempt_Outcome_Success_ProductTransformer<
     SomeTransformableProduct,
     SomeTransformedProduct
   >;
@@ -26,5 +26,5 @@ interface Attempt_Outcome_Success_Transformer<
 
 export {
   type Attempt_Outcome_Success_Transformer,
-  Attempt_Outcome_productIdentity,
+  Attempt_Outcome_Success_productIdentity,
 };

--- a/src/library/Attempt/Outcome/Success/exports.ts
+++ b/src/library/Attempt/Outcome/Success/exports.ts
@@ -6,10 +6,10 @@ import type {
 
 import {
   type Attempt_Outcome_Success_Transformer,
-  Attempt_Outcome_productIdentity,
+  Attempt_Outcome_Success_productIdentity,
 } from './Transformer';
 
-interface Attempt_Outcome_SemanticallySugarfreeSuccess<
+interface Attempt_Outcome_Success_SemanticallySugarfree<
   SomeProduct,
 > extends Attempt_Outcome_Discriminable<
   'success',
@@ -20,7 +20,7 @@ interface Attempt_Outcome_SemanticallySugarfreeSuccess<
 
 interface Attempt_Outcome_Success<
   SomeProduct,
-> extends Attempt_Outcome_SemanticallySugarfreeSuccess<
+> extends Attempt_Outcome_Success_SemanticallySugarfree<
   SomeProduct
 > {
   /**
@@ -64,7 +64,7 @@ interface Attempt_Outcome_Success<
   ): Attempt_Outcome_Success<TransformedProduct>;
 }
 
-const Attempt_Outcome_successThatYielded = <
+const Attempt_Outcome_Success_thatYielded = <
   SomeProduct,
 >(
   givenProduct: SomeProduct,
@@ -82,11 +82,11 @@ const Attempt_Outcome_successThatYielded = <
     {
       product: transformed,
     } = {
-      product: Attempt_Outcome_productIdentity<SomeProduct, TransformedProduct>,
+      product: Attempt_Outcome_Success_productIdentity<SomeProduct, TransformedProduct>,
     },
   ) => {
     const transformedProduct = transformed(givenProduct);
-    const transformedSuccess = Attempt_Outcome_successThatYielded(transformedProduct);
+    const transformedSuccess = Attempt_Outcome_Success_thatYielded(transformedProduct);
     return transformedSuccess;
   },
 });
@@ -94,6 +94,6 @@ const Attempt_Outcome_successThatYielded = <
 export {
   type Attempt_Outcome_Success,
   type Attempt_Outcome_Success_Transformer,
-  Attempt_Outcome_successThatYielded,
-  Attempt_Outcome_productIdentity,
+  Attempt_Outcome_Success_thatYielded,
+  Attempt_Outcome_Success_productIdentity,
 };

--- a/src/library/Attempt/Outcome/exports.ts
+++ b/src/library/Attempt/Outcome/exports.ts
@@ -12,8 +12,8 @@ import {
 import {
   type Attempt_Outcome_Success,
   type Attempt_Outcome_Success_Transformer,
-  Attempt_Outcome_successThatYielded,
-  Attempt_Outcome_productIdentity,
+  Attempt_Outcome_Success_thatYielded,
+  Attempt_Outcome_Success_productIdentity,
 } from './Success';
 
 import type {
@@ -81,7 +81,7 @@ function Attempt_Outcome_fromRewrapping<
 >(
   givenOutcome: Attempt_Outcome<SomeTransformableProduct, SomeTransformableActionableError>,
   {
-    product: toTransformedProduct = Attempt_Outcome_productIdentity<SomeTransformableProduct, SomeTransformedProduct>,
+    product: toTransformedProduct = Attempt_Outcome_Success_productIdentity<SomeTransformableProduct, SomeTransformedProduct>,
     cause: toTransformedCause = Attempt_Outcome_Failure_causeIdentity<SomeTransformableActionableError, SomeTransformedActionableError>,
   }: Attempt_Outcome_Transformer<
     SomeTransformableProduct,
@@ -89,7 +89,7 @@ function Attempt_Outcome_fromRewrapping<
     SomeTransformedProduct,
     SomeTransformedActionableError
   > = {
-    product: Attempt_Outcome_productIdentity<SomeTransformableProduct, SomeTransformedProduct>,
+    product: Attempt_Outcome_Success_productIdentity<SomeTransformableProduct, SomeTransformedProduct>,
     cause  : Attempt_Outcome_Failure_causeIdentity<SomeTransformableActionableError, SomeTransformedActionableError>,
   },
 ): Attempt_Outcome<SomeTransformedProduct, SomeTransformedActionableError> {
@@ -103,9 +103,9 @@ function Attempt_Outcome_fromRewrapping<
 }
 
 const Attempt_Outcome = {
-  Failure_dueTo     : Attempt_Outcome_Failure_dueTo,
-  successThatYielded: Attempt_Outcome_successThatYielded,
-  fromRewrapping    : Attempt_Outcome_fromRewrapping,
+  Failure_dueTo      : Attempt_Outcome_Failure_dueTo,
+  Success_thatYielded: Attempt_Outcome_Success_thatYielded,
+  fromRewrapping     : Attempt_Outcome_fromRewrapping,
 };
 
 type ProductOf<

--- a/src/library/Attempt/Outcome/exports.ts
+++ b/src/library/Attempt/Outcome/exports.ts
@@ -5,8 +5,8 @@ import type {
 import {
   type Attempt_Outcome_Failure,
   type Attempt_Outcome_Failure_Transformer,
-  Attempt_Outcome_failureDueTo,
-  Attempt_Outcome_causeIdentity,
+  Attempt_Outcome_Failure_dueTo,
+  Attempt_Outcome_Failure_causeIdentity,
 } from './Failure';
 
 import {
@@ -82,7 +82,7 @@ function Attempt_Outcome_fromRewrapping<
   givenOutcome: Attempt_Outcome<SomeTransformableProduct, SomeTransformableActionableError>,
   {
     product: toTransformedProduct = Attempt_Outcome_productIdentity<SomeTransformableProduct, SomeTransformedProduct>,
-    cause: toTransformedCause = Attempt_Outcome_causeIdentity<SomeTransformableActionableError, SomeTransformedActionableError>,
+    cause: toTransformedCause = Attempt_Outcome_Failure_causeIdentity<SomeTransformableActionableError, SomeTransformedActionableError>,
   }: Attempt_Outcome_Transformer<
     SomeTransformableProduct,
     SomeTransformableActionableError,
@@ -90,7 +90,7 @@ function Attempt_Outcome_fromRewrapping<
     SomeTransformedActionableError
   > = {
     product: Attempt_Outcome_productIdentity<SomeTransformableProduct, SomeTransformedProduct>,
-    cause  : Attempt_Outcome_causeIdentity<SomeTransformableActionableError, SomeTransformedActionableError>,
+    cause  : Attempt_Outcome_Failure_causeIdentity<SomeTransformableActionableError, SomeTransformedActionableError>,
   },
 ): Attempt_Outcome<SomeTransformedProduct, SomeTransformedActionableError> {
   return givenOutcome.isSuccess
@@ -103,7 +103,7 @@ function Attempt_Outcome_fromRewrapping<
 }
 
 const Attempt_Outcome = {
-  failureDueTo      : Attempt_Outcome_failureDueTo,
+  Failure_dueTo     : Attempt_Outcome_Failure_dueTo,
   successThatYielded: Attempt_Outcome_successThatYielded,
   fromRewrapping    : Attempt_Outcome_fromRewrapping,
 };

--- a/src/library/Attempt/ended.ts
+++ b/src/library/Attempt/ended.ts
@@ -14,7 +14,7 @@ import {
 */
 const Attempt_ended = {
   /** Call this when the attempt has completed and was considered successful */
-  inSuccessWith  : Attempt_Outcome.successThatYielded,
+  inSuccessWith  : Attempt_Outcome.Success_thatYielded,
   /** Call this when the attempt has completed and was considered a failure */
   inFailureDueTo : Attempt_Outcome.Failure_dueTo,
   /** Call this when the attempt has completed in terms of a prior outcome */

--- a/src/library/Attempt/ended.ts
+++ b/src/library/Attempt/ended.ts
@@ -16,7 +16,7 @@ const Attempt_ended = {
   /** Call this when the attempt has completed and was considered successful */
   inSuccessWith  : Attempt_Outcome.successThatYielded,
   /** Call this when the attempt has completed and was considered a failure */
-  inFailureDueTo : Attempt_Outcome.failureDueTo,
+  inFailureDueTo : Attempt_Outcome.Failure_dueTo,
   /** Call this when the attempt has completed in terms of a prior outcome */
   inTermsOf      : Attempt_Outcome.fromRewrapping,
   /** Call this when it's not possible to complete the attempt */


### PR DESCRIPTION
- establishes:
  - `Attempt.Outcome.Success.*`
  - `Attempt.Outcome.Failure.*`
  - `Attempt.Outcome.Discriminable.*` 
- highlights how the declarations will need to be modularized to reflect the namespaces through level 3