### PR TITLE
refactor: ensures declarations include level 3 namespaces in "library/Parser"

### DIFF
--- a/src/library/Parsable/String.ts
+++ b/src/library/Parsable/String.ts
@@ -10,7 +10,7 @@ import type {
  * Implement this type to ensure that the class follows the standard interface for this.
  */
 type Parsable_String<
-  SomeImplementer extends Parser.StaticString<
+  SomeImplementer extends Parser.Static_String<
     SomeImplementer['prototype'],
     SomeParsingError
   >,

--- a/src/library/Parser/StaticString.ts
+++ b/src/library/Parser/StaticString.ts
@@ -4,7 +4,7 @@ import type {
   Parser_Static,
 } from './Static';
 
-type Parser_StaticString<
+type Parser_Static_String<
   SomeParsedOutput,
   SomeParsingError extends ParsingError<string>,
 > = Parser_Static<
@@ -14,5 +14,5 @@ type Parser_StaticString<
 >;
 
 export type {
-  Parser_StaticString,
+  Parser_Static_String,
 };

--- a/src/library/Parser/definitionAugmentation.ts
+++ b/src/library/Parser/definitionAugmentation.ts
@@ -3,14 +3,14 @@ import type {
 } from './Static';
 
 import type {
-  Parser_StaticString,
+  Parser_Static_String,
 } from './StaticString';
 
 declare module './definition.ts' {
   namespace Parser {
     export type {
       Parser_Static as Static,
-      Parser_StaticString as StaticString,
+      Parser_Static_String as Static_String,
     };
   }
 }


### PR DESCRIPTION
- establishes `Parser.Static.String`
- highlights how "Parser/Static" needs to become a directory module