### PR TITLE
refactor: ensures declarations have level 3 namespaces in "library/Sequence"

### DIFF
--- a/src/library/Base64CharacterEncodedByteSequence/ParsingError.ts
+++ b/src/library/Base64CharacterEncodedByteSequence/ParsingError.ts
@@ -18,13 +18,13 @@ class Base64CharacterEncodedByteSequence_ParsingError
   public static thatEscorts(
     givenError:
       | Sequence.Byte.Encoded_CompatibilityError
-      | Sequence.Base64.ConformanceError,
+      | Sequence.Base64.Conformance_Error,
   ): Base64CharacterEncodedByteSequence_ParsingError {
     const extraContext = (() => {
       switch (true) {
         case givenError instanceof Sequence.Byte.Encoded_CompatibilityError:
           return 'Could not use given characters to encode byte sequence.';
-        case givenError instanceof Sequence.Base64.ConformanceError:
+        case givenError instanceof Sequence.Base64.Conformance_Error:
           return 'Could not use given characters to encode byte sequence in Base64.';
         default: return Attempt.abandon('Unexpected error type.');
       }

--- a/src/library/Base64CharacterEncodedByteSequence/ParsingError.ts
+++ b/src/library/Base64CharacterEncodedByteSequence/ParsingError.ts
@@ -17,12 +17,12 @@ class Base64CharacterEncodedByteSequence_ParsingError
 
   public static thatEscorts(
     givenError:
-      | Sequence.Byte.EncodingCompatibilityError
+      | Sequence.Byte.Encoded_CompatibilityError
       | Sequence.Base64.ConformanceError,
   ): Base64CharacterEncodedByteSequence_ParsingError {
     const extraContext = (() => {
       switch (true) {
-        case givenError instanceof Sequence.Byte.EncodingCompatibilityError:
+        case givenError instanceof Sequence.Byte.Encoded_CompatibilityError:
           return 'Could not use given characters to encode byte sequence.';
         case givenError instanceof Sequence.Base64.ConformanceError:
           return 'Could not use given characters to encode byte sequence in Base64.';

--- a/src/library/Base64CharacterEncodedByteSequence/definition.ts
+++ b/src/library/Base64CharacterEncodedByteSequence/definition.ts
@@ -59,7 +59,7 @@ class Base64CharacterEncodedByteSequence
 
     const paddedByteEncodableCharacters = outcomeOfEnsuringEncodableCharacters.unwrapped;
     const [byteEncodableCharacters, padding] = this.withPaddingDecoupled(paddedByteEncodableCharacters);
-    const outcomeOfEnsuringConformantCharacters = Sequence.Base64.ensureConformanceOf(byteEncodableCharacters);
+    const outcomeOfEnsuringConformantCharacters = Sequence.Base64.Conformance_ensure(byteEncodableCharacters);
 
     const outcomeOfParsingByteSequence = Attempt.Outcome.fromRewrapping(outcomeOfEnsuringConformantCharacters, {
       product: $0 => new this($0.concat(padding)),

--- a/src/library/Base64CharacterEncodedByteSequence/definition.ts
+++ b/src/library/Base64CharacterEncodedByteSequence/definition.ts
@@ -45,7 +45,7 @@ class Base64CharacterEncodedByteSequence
   public static parsedFrom = (
     givenCharacters: string,
   ): Attempt.Outcome<Base64CharacterEncodedByteSequence, Base64CharacterEncodedByteSequence_ParsingError> => {
-    const outcomeOfEnsuringEncodableCharacters = Sequence.Byte.ensureEncodable(givenCharacters, {
+    const outcomeOfEnsuringEncodableCharacters = Sequence.Byte.Encoded_ensureCompatibility(givenCharacters, {
       assuming: Base64.bitWidth,
     });
 

--- a/src/library/Sequence/Base64/ConformanceError.ts
+++ b/src/library/Sequence/Base64/ConformanceError.ts
@@ -1,11 +1,11 @@
 import Attempt from '@/library/Attempt';
 import Base64 from '@/library/Base64';
 
-class Sequence_Base64_ConformanceError
+class Sequence_Base64_Conformance_Error
   extends Attempt.Error_Actionable<
-  'Sequence_Base64_ConformanceError'
+  'Sequence_Base64_Conformance_Error'
 > {
-  public override name = 'Sequence_Base64_ConformanceError' as const;
+  public override name = 'Sequence_Base64_Conformance_Error' as const;
 
   public constructor() {
     super(`Sequence contained 1+ character(s) outside of the Base64 Alphabet: ${Base64.Alphabet.pattern.toString()}`);
@@ -13,5 +13,5 @@ class Sequence_Base64_ConformanceError
 }
 
 export {
-  Sequence_Base64_ConformanceError as default,
+  Sequence_Base64_Conformance_Error as default,
 };

--- a/src/library/Sequence/Base64/exports.ts
+++ b/src/library/Sequence/Base64/exports.ts
@@ -1,21 +1,21 @@
 import Attempt from '@/library/Attempt';
 import Base64 from '@/library/Base64';
 
-import Sequence_Base64_ConformanceError from './ConformanceError';
+import Sequence_Base64_Conformance_Error from './ConformanceError';
 
 const Sequence_Base64_pattern = new RegExp(`^[${Base64.Alphabet.pattern.source}]+$`);
 
-const Sequence_Base64_ensureConformanceOf = (
+const Sequence_Base64_Conformance_ensure = (
   givenCharacterSequence: string,
-): Attempt.Outcome<string, Sequence_Base64_ConformanceError> => Attempt.that((ends) => {
+): Attempt.Outcome<string, Sequence_Base64_Conformance_Error> => Attempt.that((ends) => {
   if (
     !Sequence_Base64_pattern.test(givenCharacterSequence)
-  ) return ends.inFailureDueTo(new Sequence_Base64_ConformanceError());
+  ) return ends.inFailureDueTo(new Sequence_Base64_Conformance_Error());
 
   return ends.inSuccessWith(givenCharacterSequence);
 });
 
 export {
-  Sequence_Base64_ensureConformanceOf as ensureConformanceOf,
-  Sequence_Base64_ConformanceError as ConformanceError,
+  Sequence_Base64_Conformance_ensure as Conformance_ensure,
+  Sequence_Base64_Conformance_Error as Conformance_Error,
 };

--- a/src/library/Sequence/Byte/EncodingCompatibilityError.ts
+++ b/src/library/Sequence/Byte/EncodingCompatibilityError.ts
@@ -1,11 +1,11 @@
 import Attempt from '@/library/Attempt';
 import Byte from '@/library/Byte';
 
-class Sequence_Byte_EncodingCompatibilityError
+class Sequence_Byte_Encoded_CompatibilityError
   extends Attempt.Error_Actionable<
-  'Sequence_Byte_EncodingCompatibilityError'
+  'Sequence_Byte_Encoded_CompatibilityError'
 > {
-  public override name = 'Sequence_Byte_EncodingCompatibilityError' as const;
+  public override name = 'Sequence_Byte_Encoded_CompatibilityError' as const;
 
   public constructor(
     givenBitWidth: number,
@@ -16,5 +16,5 @@ class Sequence_Byte_EncodingCompatibilityError
 }
 
 export {
-  Sequence_Byte_EncodingCompatibilityError as default,
+  Sequence_Byte_Encoded_CompatibilityError as default,
 };

--- a/src/library/Sequence/Byte/exports.ts
+++ b/src/library/Sequence/Byte/exports.ts
@@ -1,26 +1,26 @@
 import Attempt from '@/library/Attempt';
 import Byte from '@/library/Byte';
 
-import Sequence_Byte_EncodingCompatibilityError from './EncodingCompatibilityError';
+import Sequence_Byte_Encoded_CompatibilityError from './EncodingCompatibilityError';
 
-const Sequence_Byte_ensureEncodable = (
+const Sequence_Byte_Encoded_ensureCompatibility = (
   givenSequence: string,
   {
     assuming: givenBitWidth,
   }: {
     assuming: number;
   },
-): Attempt.Outcome<string, Sequence_Byte_EncodingCompatibilityError> => Attempt.that((ends) => {
+): Attempt.Outcome<string, Sequence_Byte_Encoded_CompatibilityError> => Attempt.that((ends) => {
   const byteCofactor = Byte.cofactorTo(givenBitWidth);
 
   if (
     givenSequence.length % byteCofactor !== 0
-  ) return ends.inFailureDueTo(new Sequence_Byte_EncodingCompatibilityError(givenBitWidth));
+  ) return ends.inFailureDueTo(new Sequence_Byte_Encoded_CompatibilityError(givenBitWidth));
 
   return ends.inSuccessWith(givenSequence);
 });
 
 export {
-  Sequence_Byte_EncodingCompatibilityError as EncodingCompatibilityError,
-  Sequence_Byte_ensureEncodable as ensureEncodable,
+  Sequence_Byte_Encoded_CompatibilityError as Encoded_CompatibilityError,
+  Sequence_Byte_Encoded_ensureCompatibility as Encoded_ensureCompatibility,
 };


### PR DESCRIPTION
- establishes:
  - `Sequence.Byte.Encoded.*`
  - `Sequence.Base64.Conformance.*`
- highlights how the declarations will need to be modularized according to the namespaces