### PR TITLE
refactor: aligns file structure with level 3 namespaces in "library/Parser"

### DIFF
--- a/src/library/Parsable/String.ts
+++ b/src/library/Parsable/String.ts
@@ -10,7 +10,7 @@ import type {
  * Implement this type to ensure that the class follows the standard interface for this.
  */
 type Parsable_String<
-  SomeImplementer extends Parser.String_Static<
+  SomeImplementer extends Parser.String.Static<
     SomeImplementer['prototype'],
     SomeParsingError
   >,

--- a/src/library/Parser/String/Static.ts
+++ b/src/library/Parser/String/Static.ts
@@ -2,7 +2,7 @@ import type ParsingError from '@/library/ParsingError';
 
 import type {
   Parser_Static,
-} from './Static';
+} from '../Static';
 
 type Parser_String_Static<
   SomeParsedOutput,

--- a/src/library/Parser/String/definition.ts
+++ b/src/library/Parser/String/definition.ts
@@ -1,0 +1,18 @@
+import type ParsingError from '@/library/ParsingError';
+
+import type {
+  Parser,
+} from '../definition.ts';
+
+type Parser_String<
+  SomeParsedOutput,
+  SomeParsingError extends ParsingError<string>,
+> = Parser<
+  string,
+  SomeParsedOutput,
+  SomeParsingError
+>;
+
+export type {
+  Parser_String,
+};

--- a/src/library/Parser/String/definitionAugmentation.ts
+++ b/src/library/Parser/String/definitionAugmentation.ts
@@ -1,6 +1,6 @@
 import type {
   Parser_String_Static,
-} from '../StaticString';
+} from './Static';
 
 declare module './definition.ts' {
   namespace Parser_String {

--- a/src/library/Parser/String/definitionAugmentation.ts
+++ b/src/library/Parser/String/definitionAugmentation.ts
@@ -1,0 +1,11 @@
+import type {
+  Parser_String_Static,
+} from '../StaticString';
+
+declare module './definition.ts' {
+  namespace Parser_String {
+    export type {
+      Parser_String_Static as Static,
+    };
+  }
+}

--- a/src/library/Parser/String/definitionWithAugmentation.ts
+++ b/src/library/Parser/String/definitionWithAugmentation.ts
@@ -1,0 +1,3 @@
+import './definitionAugmentation.ts';
+
+export * from './definition.ts';

--- a/src/library/Parser/String/exports.ts
+++ b/src/library/Parser/String/exports.ts
@@ -1,1 +1,1 @@
-export type * from './definition.ts';
+export type * from './definitionWithAugmentation.ts';

--- a/src/library/Parser/String/exports.ts
+++ b/src/library/Parser/String/exports.ts
@@ -1,0 +1,1 @@
+export type * from './definition.ts';

--- a/src/library/Parser/String/index.ts
+++ b/src/library/Parser/String/index.ts
@@ -1,0 +1,1 @@
+export type * from './exports.ts';

--- a/src/library/Parser/definitionAugmentation.ts
+++ b/src/library/Parser/definitionAugmentation.ts
@@ -6,11 +6,16 @@ import type {
   Parser_String_Static,
 } from './StaticString';
 
+import type {
+  Parser_String,
+} from './String';
+
 declare module './definition.ts' {
   namespace Parser {
     export type {
       Parser_Static as Static,
       Parser_String_Static as String_Static,
+      Parser_String as String,
     };
   }
 }

--- a/src/library/Parser/definitionAugmentation.ts
+++ b/src/library/Parser/definitionAugmentation.ts
@@ -3,10 +3,6 @@ import type {
 } from './Static';
 
 import type {
-  Parser_String_Static,
-} from './StaticString';
-
-import type {
   Parser_String,
 } from './String';
 
@@ -14,7 +10,6 @@ declare module './definition.ts' {
   namespace Parser {
     export type {
       Parser_Static as Static,
-      Parser_String_Static as String_Static,
       Parser_String as String,
     };
   }


### PR DESCRIPTION
- plugs the leak of the informally namespaced `String_Static`