### PR TITLE
refactor(library/Parser): reverses nesting for "Static" and "String" namespaces

### DIFF
--- a/src/library/Parsable/String.ts
+++ b/src/library/Parsable/String.ts
@@ -10,7 +10,7 @@ import type {
  * Implement this type to ensure that the class follows the standard interface for this.
  */
 type Parsable_String<
-  SomeImplementer extends Parser.Static_String<
+  SomeImplementer extends Parser.String_Static<
     SomeImplementer['prototype'],
     SomeParsingError
   >,

--- a/src/library/Parser/StaticString.ts
+++ b/src/library/Parser/StaticString.ts
@@ -4,7 +4,7 @@ import type {
   Parser_Static,
 } from './Static';
 
-type Parser_Static_String<
+type Parser_String_Static<
   SomeParsedOutput,
   SomeParsingError extends ParsingError<string>,
 > = Parser_Static<
@@ -14,5 +14,5 @@ type Parser_Static_String<
 >;
 
 export type {
-  Parser_Static_String,
+  Parser_String_Static,
 };

--- a/src/library/Parser/definitionAugmentation.ts
+++ b/src/library/Parser/definitionAugmentation.ts
@@ -3,14 +3,14 @@ import type {
 } from './Static';
 
 import type {
-  Parser_Static_String,
+  Parser_String_Static,
 } from './StaticString';
 
 declare module './definition.ts' {
   namespace Parser {
     export type {
       Parser_Static as Static,
-      Parser_Static_String as Static_String,
+      Parser_String_Static as String_Static,
     };
   }
 }


### PR DESCRIPTION
- the idea of "static" (i.e. on the meta-type) comes secondary to "string" (i.e. the type taken by the parser as an input)
- in human language, the convention is to order modifiers for a noun by specificity
- e.g. in English, it's more acceptable to say "a _static_ string parser" rather than "a _string_ static parser"
- this distinction is important because the namespaces in this codebase are nested conceptually from "coarse" to "fine" or "broad" to "narrow" to align with the intuition captured by natural language

Pre-req to #788