### PR TITLE
refactor(library/Sequence): preps for file restructure around "Sequence/Base64/Conformance"

### DIFF
--- a/src/library/Sequence/Base64/Conformance/exports.ts
+++ b/src/library/Sequence/Base64/Conformance/exports.ts
@@ -1,7 +1,7 @@
 import Attempt from '@/library/Attempt';
 import Base64 from '@/library/Base64';
 
-import Sequence_Base64_Conformance_Error from './ConformanceError';
+import Sequence_Base64_Conformance_Error from '../ConformanceError';
 
 const Sequence_Base64_pattern = new RegExp(`^[${Base64.Alphabet.pattern.source}]+$`);
 

--- a/src/library/Sequence/Base64/index.ts
+++ b/src/library/Sequence/Base64/index.ts
@@ -1,1 +1,1 @@
-export * as Sequence_Base64 from './exports.ts';
+export * as Sequence_Base64 from './Conformance/exports.ts';


### PR DESCRIPTION
- the "exports" file was nested too shallow to align with dominant declarations

Facilitates #791