### PR TITLE
refactor: ensures declarations include level 4 namespaces in "features/TextToImage"

### DIFF
--- a/src/features/TextToImage/Config/Dynamic/EndpointResponseError.ts
+++ b/src/features/TextToImage/Config/Dynamic/EndpointResponseError.ts
@@ -4,11 +4,11 @@ import type {
   URLComponent_Path,
 } from '@/library/URLComponent';
 
-class TextToImage_Config_Dynamic_EndpointResponseError
+class TextToImage_Config_Dynamic_Fetching_ResponseError
   extends Attempt.Error_Actionable<
-  'TextToImage_Config_Dynamic_EndpointResponseError'
+  'TextToImage_Config_Dynamic_Fetching_ResponseError'
 > {
-  public override name = 'TextToImage_Config_Dynamic_EndpointResponseError' as const;
+  public override name = 'TextToImage_Config_Dynamic_Fetching_ResponseError' as const;
 
   public constructor(given: {
     endpoint: URLComponent_Path;
@@ -19,5 +19,5 @@ class TextToImage_Config_Dynamic_EndpointResponseError
 }
 
 export {
-  TextToImage_Config_Dynamic_EndpointResponseError as default,
+  TextToImage_Config_Dynamic_Fetching_ResponseError as default,
 };

--- a/src/features/TextToImage/Config/Dynamic/FetchingError.ts
+++ b/src/features/TextToImage/Config/Dynamic/FetchingError.ts
@@ -4,11 +4,11 @@ import type {
   URLComponent_Path,
 } from '@/library/URLComponent';
 
-class TextToImage_Config_Dynamic_FetchingError
+class TextToImage_Config_Dynamic_Fetching_Error
   extends Attempt.Error_Actionable<
-  'TextToImage_Config_Dynamic_FetchingError'
+  'TextToImage_Config_Dynamic_Fetching_Error'
 > {
-  public override name = 'TextToImage_Config_Dynamic_FetchingError' as const;
+  public override name = 'TextToImage_Config_Dynamic_Fetching_Error' as const;
 
   public constructor(
     givenEndpoint: URLComponent_Path,
@@ -18,5 +18,5 @@ class TextToImage_Config_Dynamic_FetchingError
 }
 
 export {
-  TextToImage_Config_Dynamic_FetchingError as default,
+  TextToImage_Config_Dynamic_Fetching_Error as default,
 };

--- a/src/features/TextToImage/Config/Dynamic/exports.ts
+++ b/src/features/TextToImage/Config/Dynamic/exports.ts
@@ -9,25 +9,25 @@ import {
   TextToImage_Config,
 } from '../definition.ts';
 
-import TextToImage_Config_Dynamic_EndpointResponseError from './EndpointResponseError';
-import TextToImage_Config_Dynamic_FetchingError from './FetchingError';
+import TextToImage_Config_Dynamic_Fetching_ResponseError from './EndpointResponseError';
+import TextToImage_Config_Dynamic_Fetching_Error from './FetchingError';
 
 const TextToImage_Config_Dynamic_endpoint = URLComponent_Path.parsedFrom('/config/text-to-image').forciblyUnwrap();
 
-type TextToImage_Config_Dynamic_OutcomeOfFetching = Attempt.Outcome<TextToImage_Config,
-  | TextToImage_Config_Dynamic_FetchingError
-  | TextToImage_Config_Dynamic_EndpointResponseError
+type TextToImage_Config_Dynamic_Fetching_Outcome = Attempt.Outcome<TextToImage_Config,
+  | TextToImage_Config_Dynamic_Fetching_Error
+  | TextToImage_Config_Dynamic_Fetching_ResponseError
 >;
 
-const TextToImage_Config_Dynamic_fetch = (): Promise<TextToImage_Config_Dynamic_OutcomeOfFetching> => Attempt.thatEventually(async (ends) => {
+const TextToImage_Config_Dynamic_fetch = (): Promise<TextToImage_Config_Dynamic_Fetching_Outcome> => Attempt.thatEventually(async (ends) => {
   const endpointResponse = await fetch(TextToImage_Config_Dynamic_endpoint.toString());
-  const fetchingError = new TextToImage_Config_Dynamic_FetchingError(TextToImage_Config_Dynamic_endpoint);
+  const fetchingError = new TextToImage_Config_Dynamic_Fetching_Error(TextToImage_Config_Dynamic_endpoint);
 
   if (
     !endpointResponse.ok
   ) return ends.inFailureDueTo(fetchingError);
 
-  const endpointResponseError = new TextToImage_Config_Dynamic_EndpointResponseError({
+  const endpointResponseError = new TextToImage_Config_Dynamic_Fetching_ResponseError({
     endpoint: TextToImage_Config_Dynamic_endpoint,
     response: endpointResponse,
   });
@@ -44,6 +44,6 @@ const TextToImage_Config_Dynamic_fetch = (): Promise<TextToImage_Config_Dynamic_
 export {
   TextToImage_Config_Dynamic_endpoint as endpoint,
   TextToImage_Config_Dynamic_fetch as fetch,
-  TextToImage_Config_Dynamic_FetchingError as FetchingError,
-  TextToImage_Config_Dynamic_EndpointResponseError as EndpointResponseError,
+  TextToImage_Config_Dynamic_Fetching_Error as Fetching_Error,
+  TextToImage_Config_Dynamic_Fetching_ResponseError as Fetching_ResponseError,
 };

--- a/src/features/TextToImage/Config/Static/StaticConfigReadingError.ts
+++ b/src/features/TextToImage/Config/Static/StaticConfigReadingError.ts
@@ -4,11 +4,11 @@ import type {
   URLComponent_Path,
 } from '@/library/URLComponent';
 
-class TextToImage_Config_Static_ReadingError
+class TextToImage_Config_Static_Reading_Error
   extends Attempt.Error_Actionable<
-  'TextToImage_Config_Static_ReadingError'
+  'TextToImage_Config_Static_Reading_Error'
 > {
-  public override name = 'TextToImage_Config_Static_ReadingError' as const;
+  public override name = 'TextToImage_Config_Static_Reading_Error' as const;
 
   public constructor(
     givenFile: URLComponent_Path,
@@ -19,5 +19,5 @@ class TextToImage_Config_Static_ReadingError
 }
 
 export {
-  TextToImage_Config_Static_ReadingError as default,
+  TextToImage_Config_Static_Reading_Error as default,
 };

--- a/src/features/TextToImage/Config/Static/exports.ts
+++ b/src/features/TextToImage/Config/Static/exports.ts
@@ -8,21 +8,21 @@ import {
   TextToImage_Config,
 } from '../definition.ts';
 
-import TextToImage_Config_Static_ReadingError from './StaticConfigReadingError';
+import TextToImage_Config_Static_Reading_Error from './StaticConfigReadingError';
 
 const TextToImage_Config_Static_file = URLComponent_Path.parsedFrom('/config/text-to-image.json').forciblyUnwrap();
 
-type TextToImage_Config_Static_OutcomeOfReading = Attempt.Outcome<
+type TextToImage_Config_Static_Reading_Outcome = Attempt.Outcome<
   TextToImage_Config,
-  TextToImage_Config_Static_ReadingError
+  TextToImage_Config_Static_Reading_Error
 >;
 
-const TextToImage_Config_Static_read = (): Promise<TextToImage_Config_Static_OutcomeOfReading> => Attempt.thatEventually(async (ends) => {
+const TextToImage_Config_Static_read = (): Promise<TextToImage_Config_Static_Reading_Outcome> => Attempt.thatEventually(async (ends) => {
   const fileResponse = await fetch(TextToImage_Config_Static_file.toString());
 
   if (
     !fileResponse.ok
-  ) return ends.inFailureDueTo(new TextToImage_Config_Static_ReadingError(TextToImage_Config_Static_file, fileResponse));
+  ) return ends.inFailureDueTo(new TextToImage_Config_Static_Reading_Error(TextToImage_Config_Static_file, fileResponse));
 
   const rawConfig = await fileResponse.json() as unknown;
   const parsedConfig = TextToImage_Config.parsedFrom(rawConfig).forciblyUnwrap(/* Implementation must align with established contract. */);
@@ -32,5 +32,5 @@ const TextToImage_Config_Static_read = (): Promise<TextToImage_Config_Static_Out
 export {
   TextToImage_Config_Static_file as file,
   TextToImage_Config_Static_read as read,
-  TextToImage_Config_Static_ReadingError as ReadingError,
+  TextToImage_Config_Static_Reading_Error as Reading_Error,
 };


### PR DESCRIPTION
- establishes:
  - `TextToImage.Config.Dynamic.Fetching.*`
  - `TextToImage.Config.Static.Reading.*`
- makes it more obvious that some files need to be nested under a level 4 module