### PR TITLE
refactor: ensures declarations include level 4 namespaces in "library/Attempt"

### DIFF
--- a/src/library/Attempt/Outcome/Failure/Transformer.ts
+++ b/src/library/Attempt/Outcome/Failure/Transformer.ts
@@ -2,14 +2,14 @@ import type {
   Attempt_Error_Actionable,
 } from '../../Error';
 
-type Attempt_Outcome_Failure_CauseTransformer<
+type Attempt_Outcome_Failure_Cause_Transformer<
   SomeTransformableActionableError extends Attempt_Error_Actionable<string>,
   SomeTransformedActionableError extends Attempt_Error_Actionable<string>,
 > = (
   transformableCause: SomeTransformableActionableError,
 ) => SomeTransformedActionableError;
 
-const Attempt_Outcome_Failure_causeIdentity = <
+const Attempt_Outcome_Failure_Cause_identity = <
   SomeTransformableActionableError extends Attempt_Error_Actionable<string>,
   SomeTransformedActionableError extends Attempt_Error_Actionable<string>,
 >(
@@ -22,7 +22,7 @@ interface Attempt_Outcome_Failure_Transformer<
   SomeTransformableActionableError extends Attempt_Error_Actionable<string>,
   SomeTransformedActionableError extends Attempt_Error_Actionable<string>,
 > {
-  cause: Attempt_Outcome_Failure_CauseTransformer<
+  cause: Attempt_Outcome_Failure_Cause_Transformer<
     SomeTransformableActionableError,
     SomeTransformedActionableError
   >;
@@ -30,5 +30,5 @@ interface Attempt_Outcome_Failure_Transformer<
 
 export {
   type Attempt_Outcome_Failure_Transformer,
-  Attempt_Outcome_Failure_causeIdentity,
+  Attempt_Outcome_Failure_Cause_identity,
 };

--- a/src/library/Attempt/Outcome/Failure/exports.ts
+++ b/src/library/Attempt/Outcome/Failure/exports.ts
@@ -10,7 +10,7 @@ import type {
 
 import {
   type Attempt_Outcome_Failure_Transformer,
-  Attempt_Outcome_Failure_causeIdentity,
+  Attempt_Outcome_Failure_Cause_identity,
 } from './Transformer';
 
 interface Attempt_Outcome_Failure_SemanticallySugarfree<
@@ -74,7 +74,7 @@ const Attempt_Outcome_Failure_dueTo = <
     {
       cause: transformed,
     } = {
-      cause: Attempt_Outcome_Failure_causeIdentity<SomeActionableError, TransformedActionableError>,
+      cause: Attempt_Outcome_Failure_Cause_identity<SomeActionableError, TransformedActionableError>,
     },
   ) => {
     const transformedCause = transformed(givenCause);
@@ -87,5 +87,5 @@ export {
   type Attempt_Outcome_Failure,
   type Attempt_Outcome_Failure_Transformer,
   Attempt_Outcome_Failure_dueTo,
-  Attempt_Outcome_Failure_causeIdentity,
+  Attempt_Outcome_Failure_Cause_identity,
 };

--- a/src/library/Attempt/Outcome/Success/Transformer.ts
+++ b/src/library/Attempt/Outcome/Success/Transformer.ts
@@ -1,11 +1,11 @@
-type Attempt_Outcome_Success_ProductTransformer<
+type Attempt_Outcome_Success_Product_Transformer<
   SomeTransformableProduct,
   SomeTransformedProduct,
 > = (
   transformableProduct: SomeTransformableProduct,
 ) => SomeTransformedProduct;
 
-const Attempt_Outcome_Success_productIdentity = <
+const Attempt_Outcome_Success_Product_identity = <
   SomeTransformableProduct,
   SomeTransformedProduct,
 >(
@@ -18,7 +18,7 @@ interface Attempt_Outcome_Success_Transformer<
   SomeTransformableProduct,
   SomeTransformedProduct,
 > {
-  product: Attempt_Outcome_Success_ProductTransformer<
+  product: Attempt_Outcome_Success_Product_Transformer<
     SomeTransformableProduct,
     SomeTransformedProduct
   >;
@@ -26,5 +26,5 @@ interface Attempt_Outcome_Success_Transformer<
 
 export {
   type Attempt_Outcome_Success_Transformer,
-  Attempt_Outcome_Success_productIdentity,
+  Attempt_Outcome_Success_Product_identity,
 };

--- a/src/library/Attempt/Outcome/Success/exports.ts
+++ b/src/library/Attempt/Outcome/Success/exports.ts
@@ -6,7 +6,7 @@ import type {
 
 import {
   type Attempt_Outcome_Success_Transformer,
-  Attempt_Outcome_Success_productIdentity,
+  Attempt_Outcome_Success_Product_identity,
 } from './Transformer';
 
 interface Attempt_Outcome_Success_SemanticallySugarfree<
@@ -82,7 +82,7 @@ const Attempt_Outcome_Success_thatYielded = <
     {
       product: transformed,
     } = {
-      product: Attempt_Outcome_Success_productIdentity<SomeProduct, TransformedProduct>,
+      product: Attempt_Outcome_Success_Product_identity<SomeProduct, TransformedProduct>,
     },
   ) => {
     const transformedProduct = transformed(givenProduct);
@@ -95,5 +95,5 @@ export {
   type Attempt_Outcome_Success,
   type Attempt_Outcome_Success_Transformer,
   Attempt_Outcome_Success_thatYielded,
-  Attempt_Outcome_Success_productIdentity,
+  Attempt_Outcome_Success_Product_identity,
 };

--- a/src/library/Attempt/Outcome/exports.ts
+++ b/src/library/Attempt/Outcome/exports.ts
@@ -13,7 +13,7 @@ import {
   type Attempt_Outcome_Success,
   type Attempt_Outcome_Success_Transformer,
   Attempt_Outcome_Success_thatYielded,
-  Attempt_Outcome_Success_productIdentity,
+  Attempt_Outcome_Success_Product_identity,
 } from './Success';
 
 import type {
@@ -81,7 +81,7 @@ function Attempt_Outcome_fromRewrapping<
 >(
   givenOutcome: Attempt_Outcome<SomeTransformableProduct, SomeTransformableActionableError>,
   {
-    product: toTransformedProduct = Attempt_Outcome_Success_productIdentity<SomeTransformableProduct, SomeTransformedProduct>,
+    product: toTransformedProduct = Attempt_Outcome_Success_Product_identity<SomeTransformableProduct, SomeTransformedProduct>,
     cause: toTransformedCause = Attempt_Outcome_Failure_causeIdentity<SomeTransformableActionableError, SomeTransformedActionableError>,
   }: Attempt_Outcome_Transformer<
     SomeTransformableProduct,
@@ -89,7 +89,7 @@ function Attempt_Outcome_fromRewrapping<
     SomeTransformedProduct,
     SomeTransformedActionableError
   > = {
-    product: Attempt_Outcome_Success_productIdentity<SomeTransformableProduct, SomeTransformedProduct>,
+    product: Attempt_Outcome_Success_Product_identity<SomeTransformableProduct, SomeTransformedProduct>,
     cause  : Attempt_Outcome_Failure_causeIdentity<SomeTransformableActionableError, SomeTransformedActionableError>,
   },
 ): Attempt_Outcome<SomeTransformedProduct, SomeTransformedActionableError> {

--- a/src/library/Attempt/Outcome/exports.ts
+++ b/src/library/Attempt/Outcome/exports.ts
@@ -6,7 +6,7 @@ import {
   type Attempt_Outcome_Failure,
   type Attempt_Outcome_Failure_Transformer,
   Attempt_Outcome_Failure_dueTo,
-  Attempt_Outcome_Failure_causeIdentity,
+  Attempt_Outcome_Failure_Cause_identity,
 } from './Failure';
 
 import {
@@ -82,7 +82,7 @@ function Attempt_Outcome_fromRewrapping<
   givenOutcome: Attempt_Outcome<SomeTransformableProduct, SomeTransformableActionableError>,
   {
     product: toTransformedProduct = Attempt_Outcome_Success_Product_identity<SomeTransformableProduct, SomeTransformedProduct>,
-    cause: toTransformedCause = Attempt_Outcome_Failure_causeIdentity<SomeTransformableActionableError, SomeTransformedActionableError>,
+    cause: toTransformedCause = Attempt_Outcome_Failure_Cause_identity<SomeTransformableActionableError, SomeTransformedActionableError>,
   }: Attempt_Outcome_Transformer<
     SomeTransformableProduct,
     SomeTransformableActionableError,
@@ -90,7 +90,7 @@ function Attempt_Outcome_fromRewrapping<
     SomeTransformedActionableError
   > = {
     product: Attempt_Outcome_Success_Product_identity<SomeTransformableProduct, SomeTransformedProduct>,
-    cause  : Attempt_Outcome_Failure_causeIdentity<SomeTransformableActionableError, SomeTransformedActionableError>,
+    cause  : Attempt_Outcome_Failure_Cause_identity<SomeTransformableActionableError, SomeTransformedActionableError>,
   },
 ): Attempt_Outcome<SomeTransformedProduct, SomeTransformedActionableError> {
   return givenOutcome.isSuccess


### PR DESCRIPTION
- establishes:
  - `Attempt.Outcome.Success.Product.*`
  - `Attempt.Outcome.Failure.Cause.*`
- makes it more obvious what extractions need to be performed from multi-declaration files  