### PR TITLE
refactor: ensures declarations include level 4 namespaces in "library/Sequence"

### DIFF
--- a/src/library/Base64CharacterEncodedByteSequence/ParsingError.ts
+++ b/src/library/Base64CharacterEncodedByteSequence/ParsingError.ts
@@ -17,12 +17,12 @@ class Base64CharacterEncodedByteSequence_ParsingError
 
   public static thatEscorts(
     givenError:
-      | Sequence.Byte.Encoded.CompatibilityError
+      | Sequence.Byte.Encoded.Compatibility_Error
       | Sequence.Base64.Conformance.Error,
   ): Base64CharacterEncodedByteSequence_ParsingError {
     const extraContext = (() => {
       switch (true) {
-        case givenError instanceof Sequence.Byte.Encoded.CompatibilityError:
+        case givenError instanceof Sequence.Byte.Encoded.Compatibility_Error:
           return 'Could not use given characters to encode byte sequence.';
         case givenError instanceof Sequence.Base64.Conformance.Error:
           return 'Could not use given characters to encode byte sequence in Base64.';

--- a/src/library/Base64CharacterEncodedByteSequence/definition.ts
+++ b/src/library/Base64CharacterEncodedByteSequence/definition.ts
@@ -45,7 +45,7 @@ class Base64CharacterEncodedByteSequence
   public static parsedFrom = (
     givenCharacters: string,
   ): Attempt.Outcome<Base64CharacterEncodedByteSequence, Base64CharacterEncodedByteSequence_ParsingError> => {
-    const outcomeOfEnsuringEncodableCharacters = Sequence.Byte.Encoded.ensureCompatibility(givenCharacters, {
+    const outcomeOfEnsuringEncodableCharacters = Sequence.Byte.Encoded.Compatibility_ensure(givenCharacters, {
       assuming: Base64.bitWidth,
     });
 

--- a/src/library/Sequence/Byte/Encoded/CompatibilityError.ts
+++ b/src/library/Sequence/Byte/Encoded/CompatibilityError.ts
@@ -1,11 +1,11 @@
 import Attempt from '@/library/Attempt';
 import Byte from '@/library/Byte';
 
-class Sequence_Byte_Encoded_CompatibilityError
+class Sequence_Byte_Encoded_Compatibility_Error
   extends Attempt.Error_Actionable<
-  'Sequence_Byte_Encoded_CompatibilityError'
+  'Sequence_Byte_Encoded_Compatibility_Error'
 > {
-  public override name = 'Sequence_Byte_Encoded_CompatibilityError' as const;
+  public override name = 'Sequence_Byte_Encoded_Compatibility_Error' as const;
 
   public constructor(
     givenBitWidth: number,
@@ -16,5 +16,5 @@ class Sequence_Byte_Encoded_CompatibilityError
 }
 
 export {
-  Sequence_Byte_Encoded_CompatibilityError as default,
+  Sequence_Byte_Encoded_Compatibility_Error as default,
 };

--- a/src/library/Sequence/Byte/Encoded/exports.ts
+++ b/src/library/Sequence/Byte/Encoded/exports.ts
@@ -1,26 +1,26 @@
 import Attempt from '@/library/Attempt';
 import Byte from '@/library/Byte';
 
-import Sequence_Byte_Encoded_CompatibilityError from './CompatibilityError';
+import Sequence_Byte_Encoded_Compatibility_Error from './CompatibilityError';
 
-const Sequence_Byte_Encoded_ensureCompatibility = (
+const Sequence_Byte_Encoded_Compatibility_ensure = (
   givenSequence: string,
   {
     assuming: givenBitWidth,
   }: {
     assuming: number;
   },
-): Attempt.Outcome<string, Sequence_Byte_Encoded_CompatibilityError> => Attempt.that((ends) => {
+): Attempt.Outcome<string, Sequence_Byte_Encoded_Compatibility_Error> => Attempt.that((ends) => {
   const byteCofactor = Byte.cofactorTo(givenBitWidth);
 
   if (
     givenSequence.length % byteCofactor !== 0
-  ) return ends.inFailureDueTo(new Sequence_Byte_Encoded_CompatibilityError(givenBitWidth));
+  ) return ends.inFailureDueTo(new Sequence_Byte_Encoded_Compatibility_Error(givenBitWidth));
 
   return ends.inSuccessWith(givenSequence);
 });
 
 export {
-  Sequence_Byte_Encoded_CompatibilityError as CompatibilityError,
-  Sequence_Byte_Encoded_ensureCompatibility as ensureCompatibility,
+  Sequence_Byte_Encoded_Compatibility_Error as Compatibility_Error,
+  Sequence_Byte_Encoded_Compatibility_ensure as Compatibility_ensure,
 };


### PR DESCRIPTION
- establishes `Sequence.Byte.Encoded.Compatibility.*`
- makes it more obvious what extractions need to be performed from multi-declaration files   