### PR TITLE
refactor: ensures declarations include level 5 namespaces in "library/TextToImage"

### DIFF
--- a/src/features/TextToImage/Config/Dynamic/Fetching/Error.ts
+++ b/src/features/TextToImage/Config/Dynamic/Fetching/Error.ts
@@ -4,11 +4,11 @@ import type {
   URLComponent_Path,
 } from '@/library/URLComponent';
 
-class TextToImage_Config_Dynamic_Fetching_Error
+class TextToImage_Config_Dynamic_Fetching_Error_Request
   extends Attempt.Error_Actionable<
-  'TextToImage_Config_Dynamic_Fetching_Error'
+  'TextToImage_Config_Dynamic_Fetching_Error_Request'
 > {
-  public override name = 'TextToImage_Config_Dynamic_Fetching_Error' as const;
+  public override name = 'TextToImage_Config_Dynamic_Fetching_Error_Request' as const;
 
   public constructor(
     givenEndpoint: URLComponent_Path,
@@ -18,5 +18,5 @@ class TextToImage_Config_Dynamic_Fetching_Error
 }
 
 export {
-  TextToImage_Config_Dynamic_Fetching_Error as default,
+  TextToImage_Config_Dynamic_Fetching_Error_Request as default,
 };

--- a/src/features/TextToImage/Config/Dynamic/Fetching/ResponseError.ts
+++ b/src/features/TextToImage/Config/Dynamic/Fetching/ResponseError.ts
@@ -4,11 +4,11 @@ import type {
   URLComponent_Path,
 } from '@/library/URLComponent';
 
-class TextToImage_Config_Dynamic_Fetching_ResponseError
+class TextToImage_Config_Dynamic_Fetching_Error_Response
   extends Attempt.Error_Actionable<
-  'TextToImage_Config_Dynamic_Fetching_ResponseError'
+  'TextToImage_Config_Dynamic_Fetching_Error_Response'
 > {
-  public override name = 'TextToImage_Config_Dynamic_Fetching_ResponseError' as const;
+  public override name = 'TextToImage_Config_Dynamic_Fetching_Error_Response' as const;
 
   public constructor(given: {
     endpoint: URLComponent_Path;
@@ -19,5 +19,5 @@ class TextToImage_Config_Dynamic_Fetching_ResponseError
 }
 
 export {
-  TextToImage_Config_Dynamic_Fetching_ResponseError as default,
+  TextToImage_Config_Dynamic_Fetching_Error_Response as default,
 };

--- a/src/features/TextToImage/Config/Dynamic/Fetching/exports.ts
+++ b/src/features/TextToImage/Config/Dynamic/Fetching/exports.ts
@@ -3,5 +3,5 @@ export {
 } from './Error';
 
 export {
-  default as ResponseError,
+  default as Error_Response,
 } from './ResponseError';

--- a/src/features/TextToImage/Config/Dynamic/Fetching/exports.ts
+++ b/src/features/TextToImage/Config/Dynamic/Fetching/exports.ts
@@ -1,5 +1,5 @@
 export {
-  default as Error,
+  default as Error_Request,
 } from './Error';
 
 export {

--- a/src/features/TextToImage/Config/Dynamic/exports.ts
+++ b/src/features/TextToImage/Config/Dynamic/exports.ts
@@ -13,19 +13,19 @@ import {
   TextToImage_Config_Dynamic_Fetching,
 } from './Fetching';
 
-import type TextToImage_Config_Dynamic_Fetching_Error from './Fetching/Error';
+import type TextToImage_Config_Dynamic_Fetching_Error_Request from './Fetching/Error';
 import type TextToImage_Config_Dynamic_Fetching_ResponseError from './Fetching/ResponseError';
 
 const TextToImage_Config_Dynamic_endpoint = URLComponent_Path.parsedFrom('/config/text-to-image').forciblyUnwrap();
 
 type TextToImage_Config_Dynamic_Fetching_Outcome = Attempt.Outcome<TextToImage_Config,
-  | TextToImage_Config_Dynamic_Fetching_Error
+  | TextToImage_Config_Dynamic_Fetching_Error_Request
   | TextToImage_Config_Dynamic_Fetching_ResponseError
 >;
 
 const TextToImage_Config_Dynamic_fetch = (): Promise<TextToImage_Config_Dynamic_Fetching_Outcome> => Attempt.thatEventually(async (ends) => {
   const endpointResponse = await fetch(TextToImage_Config_Dynamic_endpoint.toString());
-  const fetchingError = new TextToImage_Config_Dynamic_Fetching.Error(TextToImage_Config_Dynamic_endpoint);
+  const fetchingError = new TextToImage_Config_Dynamic_Fetching.Error_Request(TextToImage_Config_Dynamic_endpoint);
 
   if (
     !endpointResponse.ok

--- a/src/features/TextToImage/Config/Dynamic/exports.ts
+++ b/src/features/TextToImage/Config/Dynamic/exports.ts
@@ -14,13 +14,13 @@ import {
 } from './Fetching';
 
 import type TextToImage_Config_Dynamic_Fetching_Error_Request from './Fetching/Error';
-import type TextToImage_Config_Dynamic_Fetching_ResponseError from './Fetching/ResponseError';
+import type TextToImage_Config_Dynamic_Fetching_Error_Response from './Fetching/ResponseError';
 
 const TextToImage_Config_Dynamic_endpoint = URLComponent_Path.parsedFrom('/config/text-to-image').forciblyUnwrap();
 
 type TextToImage_Config_Dynamic_Fetching_Outcome = Attempt.Outcome<TextToImage_Config,
   | TextToImage_Config_Dynamic_Fetching_Error_Request
-  | TextToImage_Config_Dynamic_Fetching_ResponseError
+  | TextToImage_Config_Dynamic_Fetching_Error_Response
 >;
 
 const TextToImage_Config_Dynamic_fetch = (): Promise<TextToImage_Config_Dynamic_Fetching_Outcome> => Attempt.thatEventually(async (ends) => {
@@ -31,7 +31,7 @@ const TextToImage_Config_Dynamic_fetch = (): Promise<TextToImage_Config_Dynamic_
     !endpointResponse.ok
   ) return ends.inFailureDueTo(fetchingError);
 
-  const endpointResponseError = new TextToImage_Config_Dynamic_Fetching.ResponseError({
+  const endpointResponseError = new TextToImage_Config_Dynamic_Fetching.Error_Response({
     endpoint: TextToImage_Config_Dynamic_endpoint,
     response: endpointResponse,
   });


### PR DESCRIPTION
- establishes `TextToImage.Config.Dynamic.Fetching.Error.*`
- makes it obvious that the errors need to be moved into level 5 module