### PR TITLE
refactor: ensures declarations include level 5 namespaces in "library/Attempt"

### DIFF
--- a/src/library/Attempt/Outcome/Failure/Transformer.ts
+++ b/src/library/Attempt/Outcome/Failure/Transformer.ts
@@ -9,7 +9,7 @@ type Attempt_Outcome_Failure_Cause_Transformer<
   transformableCause: SomeTransformableActionableError,
 ) => SomeTransformedActionableError;
 
-const Attempt_Outcome_Failure_Cause_identity = <
+const Attempt_Outcome_Failure_Cause_Transformer_identity = <
   SomeTransformableActionableError extends Attempt_Error_Actionable<string>,
   SomeTransformedActionableError extends Attempt_Error_Actionable<string>,
 >(
@@ -30,5 +30,5 @@ interface Attempt_Outcome_Failure_Transformer<
 
 export {
   type Attempt_Outcome_Failure_Transformer,
-  Attempt_Outcome_Failure_Cause_identity,
+  Attempt_Outcome_Failure_Cause_Transformer_identity,
 };

--- a/src/library/Attempt/Outcome/Failure/exports.ts
+++ b/src/library/Attempt/Outcome/Failure/exports.ts
@@ -10,7 +10,7 @@ import type {
 
 import {
   type Attempt_Outcome_Failure_Transformer,
-  Attempt_Outcome_Failure_Cause_identity,
+  Attempt_Outcome_Failure_Cause_Transformer_identity,
 } from './Transformer';
 
 interface Attempt_Outcome_Failure_SemanticallySugarfree<
@@ -74,7 +74,7 @@ const Attempt_Outcome_Failure_dueTo = <
     {
       cause: transformed,
     } = {
-      cause: Attempt_Outcome_Failure_Cause_identity<SomeActionableError, TransformedActionableError>,
+      cause: Attempt_Outcome_Failure_Cause_Transformer_identity<SomeActionableError, TransformedActionableError>,
     },
   ) => {
     const transformedCause = transformed(givenCause);
@@ -87,5 +87,5 @@ export {
   type Attempt_Outcome_Failure,
   type Attempt_Outcome_Failure_Transformer,
   Attempt_Outcome_Failure_dueTo,
-  Attempt_Outcome_Failure_Cause_identity,
+  Attempt_Outcome_Failure_Cause_Transformer_identity,
 };

--- a/src/library/Attempt/Outcome/Success/Transformer.ts
+++ b/src/library/Attempt/Outcome/Success/Transformer.ts
@@ -5,7 +5,7 @@ type Attempt_Outcome_Success_Product_Transformer<
   transformableProduct: SomeTransformableProduct,
 ) => SomeTransformedProduct;
 
-const Attempt_Outcome_Success_Product_identity = <
+const Attempt_Outcome_Success_Product_Transformer_identity = <
   SomeTransformableProduct,
   SomeTransformedProduct,
 >(
@@ -26,5 +26,5 @@ interface Attempt_Outcome_Success_Transformer<
 
 export {
   type Attempt_Outcome_Success_Transformer,
-  Attempt_Outcome_Success_Product_identity,
+  Attempt_Outcome_Success_Product_Transformer_identity,
 };

--- a/src/library/Attempt/Outcome/Success/exports.ts
+++ b/src/library/Attempt/Outcome/Success/exports.ts
@@ -6,7 +6,7 @@ import type {
 
 import {
   type Attempt_Outcome_Success_Transformer,
-  Attempt_Outcome_Success_Product_identity,
+  Attempt_Outcome_Success_Product_Transformer_identity,
 } from './Transformer';
 
 interface Attempt_Outcome_Success_SemanticallySugarfree<
@@ -82,7 +82,7 @@ const Attempt_Outcome_Success_thatYielded = <
     {
       product: transformed,
     } = {
-      product: Attempt_Outcome_Success_Product_identity<SomeProduct, TransformedProduct>,
+      product: Attempt_Outcome_Success_Product_Transformer_identity<SomeProduct, TransformedProduct>,
     },
   ) => {
     const transformedProduct = transformed(givenProduct);
@@ -95,5 +95,5 @@ export {
   type Attempt_Outcome_Success,
   type Attempt_Outcome_Success_Transformer,
   Attempt_Outcome_Success_thatYielded,
-  Attempt_Outcome_Success_Product_identity,
+  Attempt_Outcome_Success_Product_Transformer_identity,
 };

--- a/src/library/Attempt/Outcome/exports.ts
+++ b/src/library/Attempt/Outcome/exports.ts
@@ -6,14 +6,14 @@ import {
   type Attempt_Outcome_Failure,
   type Attempt_Outcome_Failure_Transformer,
   Attempt_Outcome_Failure_dueTo,
-  Attempt_Outcome_Failure_Cause_identity,
+  Attempt_Outcome_Failure_Cause_Transformer_identity,
 } from './Failure';
 
 import {
   type Attempt_Outcome_Success,
   type Attempt_Outcome_Success_Transformer,
   Attempt_Outcome_Success_thatYielded,
-  Attempt_Outcome_Success_Product_identity,
+  Attempt_Outcome_Success_Product_Transformer_identity,
 } from './Success';
 
 import type {
@@ -81,16 +81,16 @@ function Attempt_Outcome_fromRewrapping<
 >(
   givenOutcome: Attempt_Outcome<SomeTransformableProduct, SomeTransformableActionableError>,
   {
-    product: toTransformedProduct = Attempt_Outcome_Success_Product_identity<SomeTransformableProduct, SomeTransformedProduct>,
-    cause: toTransformedCause = Attempt_Outcome_Failure_Cause_identity<SomeTransformableActionableError, SomeTransformedActionableError>,
+    product: toTransformedProduct = Attempt_Outcome_Success_Product_Transformer_identity<SomeTransformableProduct, SomeTransformedProduct>,
+    cause: toTransformedCause = Attempt_Outcome_Failure_Cause_Transformer_identity<SomeTransformableActionableError, SomeTransformedActionableError>,
   }: Attempt_Outcome_Transformer<
     SomeTransformableProduct,
     SomeTransformableActionableError,
     SomeTransformedProduct,
     SomeTransformedActionableError
   > = {
-    product: Attempt_Outcome_Success_Product_identity<SomeTransformableProduct, SomeTransformedProduct>,
-    cause  : Attempt_Outcome_Failure_Cause_identity<SomeTransformableActionableError, SomeTransformedActionableError>,
+    product: Attempt_Outcome_Success_Product_Transformer_identity<SomeTransformableProduct, SomeTransformedProduct>,
+    cause  : Attempt_Outcome_Failure_Cause_Transformer_identity<SomeTransformableActionableError, SomeTransformedActionableError>,
   },
 ): Attempt_Outcome<SomeTransformedProduct, SomeTransformedActionableError> {
   return givenOutcome.isSuccess


### PR DESCRIPTION
- establishes:
  - `Attempt.Outcome.Success.Product.Transformer(.*)`
  - `Attempt.Outcome.Failure.Cause.Transformer(.*)`
- makes it obvious that these declarations need to be moved to a level 5 module