### PR TITLE
types(library/Attempt): ensures semantic distinction for generic parameters

### DIFF
--- a/src/library/Attempt/Outcome/Discriminable.ts
+++ b/src/library/Attempt/Outcome/Discriminable.ts
@@ -40,12 +40,12 @@ interface Attempt_Outcome_Discriminable<
   >;
 
   rewrappedWith<
-    TransformedPayload extends (
+    SomeTransformedPayload extends (
       SomeDiscriminant extends 'success'
         ? unknown
         : Attempt_Error_Actionable<string>
     ) = SomePayload,
-  >(): Attempt_Outcome_Discriminable<SomeDiscriminant, TransformedPayload>;
+  >(): Attempt_Outcome_Discriminable<SomeDiscriminant, SomeTransformedPayload>;
 }
 
 export type {

--- a/src/library/Attempt/Outcome/Failure/exports.ts
+++ b/src/library/Attempt/Outcome/Failure/exports.ts
@@ -45,13 +45,13 @@ interface Attempt_Outcome_Failure<
   readonly causeOfFailure: this['cause'];
 
   rewrappedWith<
-    TransformedActionableError extends Attempt_Error_Actionable<string> = SomeActionableError,
+    SomeTransformedActionableError extends Attempt_Error_Actionable<string> = SomeActionableError,
   >(
     given?: Attempt_Outcome_Failure_Transformer<
       SomeActionableError,
-      TransformedActionableError
+      SomeTransformedActionableError
     >
-  ): Attempt_Outcome_Failure<TransformedActionableError>;
+  ): Attempt_Outcome_Failure<SomeTransformedActionableError>;
 }
 
 const Attempt_Outcome_Failure_dueTo = <
@@ -67,12 +67,12 @@ const Attempt_Outcome_Failure_dueTo = <
   forciblyUnwrap  : () => givenCause.throwAnyway('Unexpected forceful unwrap of a failure'),
   causeOfFailure  : givenCause,
   rewrappedWith   : <
-    TransformedActionableError extends Attempt_Error_Actionable<string>,
+    SomeTransformedActionableError extends Attempt_Error_Actionable<string>,
   >(
     {
       cause: transformed,
     } = {
-      cause: Attempt_Outcome_Failure_Cause_Transformer_identity<SomeActionableError, TransformedActionableError>,
+      cause: Attempt_Outcome_Failure_Cause_Transformer_identity<SomeActionableError, SomeTransformedActionableError>,
     },
   ) => {
     const transformedCause = transformed(givenCause);

--- a/src/library/Attempt/Outcome/Success/exports.ts
+++ b/src/library/Attempt/Outcome/Success/exports.ts
@@ -53,13 +53,13 @@ interface Attempt_Outcome_Success<
   readonly unwrapped: this['product'];
 
   rewrappedWith<
-    TransformedProduct = SomeProduct,
+    SomeTransformedProduct = SomeProduct,
   >(
     given?: Attempt_Outcome_Success_Transformer<
       SomeProduct,
-      TransformedProduct
+      SomeTransformedProduct
     >
-  ): Attempt_Outcome_Success<TransformedProduct>;
+  ): Attempt_Outcome_Success<SomeTransformedProduct>;
 }
 
 const Attempt_Outcome_Success_thatYielded = <
@@ -75,12 +75,12 @@ const Attempt_Outcome_Success_thatYielded = <
   forciblyUnwrap  : () => givenProduct,
   unwrapped       : givenProduct,
   rewrappedWith   : <
-    TransformedProduct,
+    SomeTransformedProduct,
   >(
     {
       product: transformed,
     } = {
-      product: Attempt_Outcome_Success_Product_Transformer_identity<SomeProduct, TransformedProduct>,
+      product: Attempt_Outcome_Success_Product_Transformer_identity<SomeProduct, SomeTransformedProduct>,
     },
   ) => {
     const transformedProduct = transformed(givenProduct);


### PR DESCRIPTION
- addresses cases that were overlooked in #699 