### PR TITLE
refactor: prefers error unions

### DIFF
--- a/src/features/TextToImage/Config/Dynamic/Fetching/Error/Any.ts
+++ b/src/features/TextToImage/Config/Dynamic/Fetching/Error/Any.ts
@@ -1,0 +1,16 @@
+import type {
+  default as TextToImage_Config_Dynamic_Fetching_Error_Request,
+} from './Request';
+
+import type {
+  default as TextToImage_Config_Dynamic_Fetching_Error_Response,
+} from './Response';
+
+type TextToImage_Config_Dynamic_Fetching_Error_Any =
+  | TextToImage_Config_Dynamic_Fetching_Error_Request
+  | TextToImage_Config_Dynamic_Fetching_Error_Response
+;
+
+export type {
+  TextToImage_Config_Dynamic_Fetching_Error_Any,
+};

--- a/src/features/TextToImage/Config/Dynamic/Fetching/Error/exports.ts
+++ b/src/features/TextToImage/Config/Dynamic/Fetching/Error/exports.ts
@@ -5,3 +5,7 @@ export {
 export {
   default as Response,
 } from './Response';
+
+export type {
+  TextToImage_Config_Dynamic_Fetching_Error_Any as Any,
+} from './Any';

--- a/src/features/TextToImage/Config/Dynamic/exports.ts
+++ b/src/features/TextToImage/Config/Dynamic/exports.ts
@@ -20,8 +20,7 @@ import type {
 const TextToImage_Config_Dynamic_endpoint = URLComponent_Path.parsedFrom('/config/text-to-image').forciblyUnwrap();
 
 type TextToImage_Config_Dynamic_Fetching_Outcome = Attempt.Outcome<TextToImage_Config,
-  | TextToImage_Config_Dynamic_Fetching_Error.Request
-  | TextToImage_Config_Dynamic_Fetching_Error.Response
+  TextToImage_Config_Dynamic_Fetching_Error.Any
 >;
 
 const TextToImage_Config_Dynamic_fetch = (): Promise<TextToImage_Config_Dynamic_Fetching_Outcome> => Attempt.thatEventually(async (ends) => {

--- a/src/features/TextToImage/Server/Error/Any.ts
+++ b/src/features/TextToImage/Server/Error/Any.ts
@@ -1,0 +1,16 @@
+import type {
+  default as TextToImage_Server_Error_Connection,
+} from './Connection';
+
+import type {
+  default as TextToImage_Server_Error_Specification,
+} from './Specification';
+
+type TextToImage_Server_Error_Any =
+  | TextToImage_Server_Error_Specification
+  | TextToImage_Server_Error_Connection
+;
+
+export type {
+  TextToImage_Server_Error_Any,
+};

--- a/src/features/TextToImage/Server/Error/exports.ts
+++ b/src/features/TextToImage/Server/Error/exports.ts
@@ -5,3 +5,7 @@ export {
 export {
   default as Connection,
 } from './Connection';
+
+export type {
+  TextToImage_Server_Error_Any as Any,
+} from './Any';

--- a/src/features/TextToImage/components/TextToImageOutputAlert.vue
+++ b/src/features/TextToImage/components/TextToImageOutputAlert.vue
@@ -4,13 +4,8 @@ import * as TextToImage from '@/features/TextToImage';
 import TextToImageServerConnectionAlert from './TextToImageServerConnectionAlert.vue';
 import TextToImageServerSpecificationAlert from './TextToImageServerSpecificationAlert.vue';
 
-type OutputError =
-  | TextToImage.Server.Error.Connection
-  | TextToImage.Server.Error.Specification
-;
-
 defineProps<{
-  error: OutputError;
+  error: TextToImage.Server.Error.Any;
 }>();
 </script>
 

--- a/src/library/HTTP/Endpoint/Error/Any.ts
+++ b/src/library/HTTP/Endpoint/Error/Any.ts
@@ -1,0 +1,16 @@
+import type {
+  HTTP_Endpoint_Error_Request,
+} from './Request';
+
+import type {
+  HTTP_Endpoint_Error_Response,
+} from './Response';
+
+type HTTP_Endpoint_Error_Any =
+  | HTTP_Endpoint_Error_Request
+  | HTTP_Endpoint_Error_Response
+;
+
+export type {
+  HTTP_Endpoint_Error_Any,
+};

--- a/src/library/HTTP/Endpoint/Error/exports.ts
+++ b/src/library/HTTP/Endpoint/Error/exports.ts
@@ -5,3 +5,7 @@ export {
 export {
   HTTP_Endpoint_Error_Response as Response,
 } from './Response';
+
+export type {
+  HTTP_Endpoint_Error_Any as Any,
+} from './Any';

--- a/src/library/HTTP/Endpoint/Outcome.ts
+++ b/src/library/HTTP/Endpoint/Outcome.ts
@@ -6,7 +6,7 @@ import type {
 
 type HTTP_Endpoint_Outcome = Attempt.Outcome<
   unknown,
-  HTTP_Endpoint_Error.Request | HTTP_Endpoint_Error.Response
+  HTTP_Endpoint_Error.Any
 >;
 
 export type {

--- a/src/library/Shortfin/TextToImage/SDXL/Client/Request/Outcome.ts
+++ b/src/library/Shortfin/TextToImage/SDXL/Client/Request/Outcome.ts
@@ -4,8 +4,7 @@ import type HTTP from '@/library/HTTP';
 
 type Shortfin_TextToImage_SDXL_Client_Request_Outcome = Attempt.Outcome<
   Base64CharacterEncodedByteSequence,
-  | HTTP.Endpoint.Error.Request
-  | HTTP.Endpoint.Error.Response
+  HTTP.Endpoint.Error.Any
 >;
 
 export type {


### PR DESCRIPTION
- with type-safe error propagation, groups are of 2+ error types are more common, e.g.
  ```ts
  type HTTP_Endpoint_Outcome = Attempt.Outcome<
    unknown,
    HTTP_Endpoint_Error.Request | HTTP_Endpoint_Error.Response
  >;
  ```
- Since `Error` is a namespace, `Error.Any` can be extracted:
  ```ts
  type HTTP_Endpoint_Outcome = Attempt.Outcome<
    unknown,
    HTTP_Endpoint_Error.Any
  >;
  ```
- this not only reduces some of the noise in the file but also makes the group of errors extensible as finer error granularity is implemented

Unblocks steps in #745