### PR TITLE
ci(dependabot): auto-approves `@eslint/markdown` for non-major bumps

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -40,6 +40,7 @@ jobs:
         if: |
           contains(
             fromJSON('[
+              "@eslint/markdown",
               "@stylistic/eslint-plugin",
               "@typescript-eslint/parser",
               "@types/node",


### PR DESCRIPTION
Follows #589. Targets #798.