### PR TITLE
ci(dependabot): auto-approves vite-plugin-vue-devtools for non-major bumps

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -51,6 +51,7 @@ jobs:
               "typescript-eslint",
               "typescript",
               "vite",
+              "vite-plugin-vue-devtools"
             ]'),
             steps.metadata.outputs.dependency-names
           )


### PR DESCRIPTION
Follows #641. Targets #796.