### PR TITLE
refactor(library/Base64CharacterEncodedByteSequence): maps out move to "library/Sequence"

### DIFF
--- a/src/features/TextToImage/Client/SDXL/conversions/StabilityAI_Client_Image.ts
+++ b/src/features/TextToImage/Client/SDXL/conversions/StabilityAI_Client_Image.ts
@@ -1,6 +1,6 @@
 import type * as StabilityAIClient from 'stabilityai-client-typescript/models/components';
 
-import Base64CharacterEncodedByteSequence from '@/library/Base64CharacterEncodedByteSequence';
+import Sequence_Base64CharacterEncodedByte from '@/library/Base64CharacterEncodedByteSequence';
 import URI_Image from '@/library/UniformResourceIdentifier/Image';
 
 import type {
@@ -17,7 +17,7 @@ const toOutputImage = (
     givenImage.base64 === undefined
   ) return null;
 
-  const base64DataOfRawImage = Base64CharacterEncodedByteSequence.parsedFrom(givenImage.base64).forciblyUnwrap(/* Broken web contracts require intervention */);
+  const base64DataOfRawImage = Sequence_Base64CharacterEncodedByte.parsedFrom(givenImage.base64).forciblyUnwrap(/* Broken web contracts require intervention */);
 
   const derivedImage = {
     uri        : new URI_Image('png', 'base64', base64DataOfRawImage),

--- a/src/features/TextToImage/Client/SDXL/conversions/StabilityAI_Client_Image.ts
+++ b/src/features/TextToImage/Client/SDXL/conversions/StabilityAI_Client_Image.ts
@@ -1,6 +1,6 @@
 import type * as StabilityAIClient from 'stabilityai-client-typescript/models/components';
 
-import Sequence_Byte_Encoded_Base64Character from '@/library/Base64CharacterEncodedByteSequence';
+import Sequence_Byte_Encoded_Base64 from '@/library/Base64CharacterEncodedByteSequence';
 import URI_Image from '@/library/UniformResourceIdentifier/Image';
 
 import type {
@@ -17,7 +17,7 @@ const toOutputImage = (
     givenImage.base64 === undefined
   ) return null;
 
-  const base64DataOfRawImage = Sequence_Byte_Encoded_Base64Character.parsedFrom(givenImage.base64).forciblyUnwrap(/* Broken web contracts require intervention */);
+  const base64DataOfRawImage = Sequence_Byte_Encoded_Base64.parsedFrom(givenImage.base64).forciblyUnwrap(/* Broken web contracts require intervention */);
 
   const derivedImage = {
     uri        : new URI_Image('png', 'base64', base64DataOfRawImage),

--- a/src/features/TextToImage/Client/SDXL/conversions/StabilityAI_Client_Image.ts
+++ b/src/features/TextToImage/Client/SDXL/conversions/StabilityAI_Client_Image.ts
@@ -1,6 +1,6 @@
 import type * as StabilityAIClient from 'stabilityai-client-typescript/models/components';
 
-import Sequence_Base64CharacterEncodedByte from '@/library/Base64CharacterEncodedByteSequence';
+import Sequence_Byte_Base64CharacterEncoded from '@/library/Base64CharacterEncodedByteSequence';
 import URI_Image from '@/library/UniformResourceIdentifier/Image';
 
 import type {
@@ -17,7 +17,7 @@ const toOutputImage = (
     givenImage.base64 === undefined
   ) return null;
 
-  const base64DataOfRawImage = Sequence_Base64CharacterEncodedByte.parsedFrom(givenImage.base64).forciblyUnwrap(/* Broken web contracts require intervention */);
+  const base64DataOfRawImage = Sequence_Byte_Base64CharacterEncoded.parsedFrom(givenImage.base64).forciblyUnwrap(/* Broken web contracts require intervention */);
 
   const derivedImage = {
     uri        : new URI_Image('png', 'base64', base64DataOfRawImage),

--- a/src/features/TextToImage/Client/SDXL/conversions/StabilityAI_Client_Image.ts
+++ b/src/features/TextToImage/Client/SDXL/conversions/StabilityAI_Client_Image.ts
@@ -1,6 +1,6 @@
 import type * as StabilityAIClient from 'stabilityai-client-typescript/models/components';
 
-import Sequence_Byte_Base64CharacterEncoded from '@/library/Base64CharacterEncodedByteSequence';
+import Sequence_Byte_Encoded_Base64Character from '@/library/Base64CharacterEncodedByteSequence';
 import URI_Image from '@/library/UniformResourceIdentifier/Image';
 
 import type {
@@ -17,7 +17,7 @@ const toOutputImage = (
     givenImage.base64 === undefined
   ) return null;
 
-  const base64DataOfRawImage = Sequence_Byte_Base64CharacterEncoded.parsedFrom(givenImage.base64).forciblyUnwrap(/* Broken web contracts require intervention */);
+  const base64DataOfRawImage = Sequence_Byte_Encoded_Base64Character.parsedFrom(givenImage.base64).forciblyUnwrap(/* Broken web contracts require intervention */);
 
   const derivedImage = {
     uri        : new URI_Image('png', 'base64', base64DataOfRawImage),

--- a/src/library/Base64CharacterEncodedByteSequence/ParsingError.ts
+++ b/src/library/Base64CharacterEncodedByteSequence/ParsingError.ts
@@ -2,11 +2,11 @@ import Attempt from '@/library/Attempt';
 import ParsingError from '@/library/ParsingError';
 import Sequence from '@/library/Sequence';
 
-class Sequence_Base64CharacterEncodedByte_ParsingError
+class Sequence_Byte_Base64CharacterEncoded_ParsingError
   extends ParsingError<
-  'Sequence_Base64CharacterEncodedByte'
+  'Sequence_Byte_Base64CharacterEncoded'
 > {
-  public override name = 'Sequence_Base64CharacterEncodedByte_ParsingError' as const;
+  public override name = 'Sequence_Byte_Base64CharacterEncoded_ParsingError' as const;
 
   public constructor(
     givenMessage: string,
@@ -19,7 +19,7 @@ class Sequence_Base64CharacterEncodedByte_ParsingError
     givenError:
       | Sequence.Byte.Encoded.Compatibility.Error
       | Sequence.Base64.Conformance.Error,
-  ): Sequence_Base64CharacterEncodedByte_ParsingError {
+  ): Sequence_Byte_Base64CharacterEncoded_ParsingError {
     const extraContext = (() => {
       switch (true) {
         case givenError instanceof Sequence.Byte.Encoded.Compatibility.Error:
@@ -41,5 +41,5 @@ class Sequence_Base64CharacterEncodedByte_ParsingError
 }
 
 export {
-  Sequence_Base64CharacterEncodedByte_ParsingError as default,
+  Sequence_Byte_Base64CharacterEncoded_ParsingError as default,
 };

--- a/src/library/Base64CharacterEncodedByteSequence/ParsingError.ts
+++ b/src/library/Base64CharacterEncodedByteSequence/ParsingError.ts
@@ -2,11 +2,11 @@ import Attempt from '@/library/Attempt';
 import ParsingError from '@/library/ParsingError';
 import Sequence from '@/library/Sequence';
 
-class Base64CharacterEncodedByteSequence_ParsingError
+class Sequence_Base64CharacterEncodedByte_ParsingError
   extends ParsingError<
-  'Base64CharacterEncodedByteSequence'
+  'Sequence_Base64CharacterEncodedByte'
 > {
-  public override name = 'Base64CharacterEncodedByteSequence_ParsingError' as const;
+  public override name = 'Sequence_Base64CharacterEncodedByte_ParsingError' as const;
 
   public constructor(
     givenMessage: string,
@@ -19,7 +19,7 @@ class Base64CharacterEncodedByteSequence_ParsingError
     givenError:
       | Sequence.Byte.Encoded.Compatibility.Error
       | Sequence.Base64.Conformance.Error,
-  ): Base64CharacterEncodedByteSequence_ParsingError {
+  ): Sequence_Base64CharacterEncodedByte_ParsingError {
     const extraContext = (() => {
       switch (true) {
         case givenError instanceof Sequence.Byte.Encoded.Compatibility.Error:
@@ -41,5 +41,5 @@ class Base64CharacterEncodedByteSequence_ParsingError
 }
 
 export {
-  Base64CharacterEncodedByteSequence_ParsingError as default,
+  Sequence_Base64CharacterEncodedByte_ParsingError as default,
 };

--- a/src/library/Base64CharacterEncodedByteSequence/ParsingError.ts
+++ b/src/library/Base64CharacterEncodedByteSequence/ParsingError.ts
@@ -2,11 +2,11 @@ import Attempt from '@/library/Attempt';
 import ParsingError from '@/library/ParsingError';
 import Sequence from '@/library/Sequence';
 
-class Sequence_Byte_Base64CharacterEncoded_ParsingError
+class Sequence_Byte_Encoded_Base64Character_ParsingError
   extends ParsingError<
-  'Sequence_Byte_Base64CharacterEncoded'
+  'Sequence_Byte_Encoded_Base64Character'
 > {
-  public override name = 'Sequence_Byte_Base64CharacterEncoded_ParsingError' as const;
+  public override name = 'Sequence_Byte_Encoded_Base64Character_ParsingError' as const;
 
   public constructor(
     givenMessage: string,
@@ -19,7 +19,7 @@ class Sequence_Byte_Base64CharacterEncoded_ParsingError
     givenError:
       | Sequence.Byte.Encoded.Compatibility.Error
       | Sequence.Base64.Conformance.Error,
-  ): Sequence_Byte_Base64CharacterEncoded_ParsingError {
+  ): Sequence_Byte_Encoded_Base64Character_ParsingError {
     const extraContext = (() => {
       switch (true) {
         case givenError instanceof Sequence.Byte.Encoded.Compatibility.Error:
@@ -41,5 +41,5 @@ class Sequence_Byte_Base64CharacterEncoded_ParsingError
 }
 
 export {
-  Sequence_Byte_Base64CharacterEncoded_ParsingError as default,
+  Sequence_Byte_Encoded_Base64Character_ParsingError as default,
 };

--- a/src/library/Base64CharacterEncodedByteSequence/ParsingError.ts
+++ b/src/library/Base64CharacterEncodedByteSequence/ParsingError.ts
@@ -2,11 +2,11 @@ import Attempt from '@/library/Attempt';
 import ParsingError from '@/library/ParsingError';
 import Sequence from '@/library/Sequence';
 
-class Sequence_Byte_Encoded_Base64Character_ParsingError
+class Sequence_Byte_Encoded_Base64_ParsingError
   extends ParsingError<
-  'Sequence_Byte_Encoded_Base64Character'
+  'Sequence_Byte_Encoded_Base64'
 > {
-  public override name = 'Sequence_Byte_Encoded_Base64Character_ParsingError' as const;
+  public override name = 'Sequence_Byte_Encoded_Base64_ParsingError' as const;
 
   public constructor(
     givenMessage: string,
@@ -19,7 +19,7 @@ class Sequence_Byte_Encoded_Base64Character_ParsingError
     givenError:
       | Sequence.Byte.Encoded.Compatibility.Error
       | Sequence.Base64.Conformance.Error,
-  ): Sequence_Byte_Encoded_Base64Character_ParsingError {
+  ): Sequence_Byte_Encoded_Base64_ParsingError {
     const extraContext = (() => {
       switch (true) {
         case givenError instanceof Sequence.Byte.Encoded.Compatibility.Error:
@@ -41,5 +41,5 @@ class Sequence_Byte_Encoded_Base64Character_ParsingError
 }
 
 export {
-  Sequence_Byte_Encoded_Base64Character_ParsingError as default,
+  Sequence_Byte_Encoded_Base64_ParsingError as default,
 };

--- a/src/library/Base64CharacterEncodedByteSequence/definition.ts
+++ b/src/library/Base64CharacterEncodedByteSequence/definition.ts
@@ -10,15 +10,15 @@ import {
   lastCharacterOf,
 } from '@/library/utilitiesByType/string.ts';
 
-import Sequence_Byte_Encoded_Base64Character_ParsingError from './ParsingError.ts';
+import Sequence_Byte_Encoded_Base64_ParsingError from './ParsingError.ts';
 
 /** See [RFC 4648 Section 4](https://www.rfc-editor.org/rfc/rfc4648.html#section-4) for more information */
-class Sequence_Byte_Encoded_Base64Character
+class Sequence_Byte_Encoded_Base64
   extends StringSubset<
-  'Sequence_Byte_Encoded_Base64Character'
+  'Sequence_Byte_Encoded_Base64'
 > implements Parsable.String<
-  typeof Sequence_Byte_Encoded_Base64Character,
-  /*  */ Sequence_Byte_Encoded_Base64Character_ParsingError
+  typeof Sequence_Byte_Encoded_Base64,
+  /*  */ Sequence_Byte_Encoded_Base64_ParsingError
 > {
   public static paddingCharacter = '=';
 
@@ -44,14 +44,14 @@ class Sequence_Byte_Encoded_Base64Character
 
   public static parsedFrom = (
     givenCharacters: string,
-  ): Attempt.Outcome<Sequence_Byte_Encoded_Base64Character, Sequence_Byte_Encoded_Base64Character_ParsingError> => {
+  ): Attempt.Outcome<Sequence_Byte_Encoded_Base64, Sequence_Byte_Encoded_Base64_ParsingError> => {
     const outcomeOfEnsuringEncodableCharacters = Sequence.Byte.Encoded.Compatibility.ensure(givenCharacters, {
       assuming: Base64.bitWidth,
     });
 
     if (outcomeOfEnsuringEncodableCharacters.isFailure) {
       const failureToEnsureEncodableCharacters = outcomeOfEnsuringEncodableCharacters.rewrappedWith({
-        cause: $0 => Sequence_Byte_Encoded_Base64Character_ParsingError.thatEscorts($0),
+        cause: $0 => Sequence_Byte_Encoded_Base64_ParsingError.thatEscorts($0),
       });
 
       return failureToEnsureEncodableCharacters;
@@ -63,7 +63,7 @@ class Sequence_Byte_Encoded_Base64Character
 
     const outcomeOfParsingByteSequence = Attempt.Outcome.fromRewrapping(outcomeOfEnsuringConformantCharacters, {
       product: $0 => new this($0.concat(padding)),
-      cause  : $0 => Sequence_Byte_Encoded_Base64Character_ParsingError.thatEscorts($0),
+      cause  : $0 => Sequence_Byte_Encoded_Base64_ParsingError.thatEscorts($0),
     });
 
     return outcomeOfParsingByteSequence;
@@ -71,5 +71,5 @@ class Sequence_Byte_Encoded_Base64Character
 }
 
 export {
-  Sequence_Byte_Encoded_Base64Character,
+  Sequence_Byte_Encoded_Base64,
 };

--- a/src/library/Base64CharacterEncodedByteSequence/definition.ts
+++ b/src/library/Base64CharacterEncodedByteSequence/definition.ts
@@ -10,15 +10,15 @@ import {
   lastCharacterOf,
 } from '@/library/utilitiesByType/string.ts';
 
-import Sequence_Base64CharacterEncodedByte_ParsingError from './ParsingError.ts';
+import Sequence_Byte_Base64CharacterEncoded_ParsingError from './ParsingError.ts';
 
 /** See [RFC 4648 Section 4](https://www.rfc-editor.org/rfc/rfc4648.html#section-4) for more information */
-class Sequence_Base64CharacterEncodedByte
+class Sequence_Byte_Base64CharacterEncoded
   extends StringSubset<
-  'Sequence_Base64CharacterEncodedByte'
+  'Sequence_Byte_Base64CharacterEncoded'
 > implements Parsable.String<
-  typeof Sequence_Base64CharacterEncodedByte,
-  /*  */ Sequence_Base64CharacterEncodedByte_ParsingError
+  typeof Sequence_Byte_Base64CharacterEncoded,
+  /*  */ Sequence_Byte_Base64CharacterEncoded_ParsingError
 > {
   public static paddingCharacter = '=';
 
@@ -44,14 +44,14 @@ class Sequence_Base64CharacterEncodedByte
 
   public static parsedFrom = (
     givenCharacters: string,
-  ): Attempt.Outcome<Sequence_Base64CharacterEncodedByte, Sequence_Base64CharacterEncodedByte_ParsingError> => {
+  ): Attempt.Outcome<Sequence_Byte_Base64CharacterEncoded, Sequence_Byte_Base64CharacterEncoded_ParsingError> => {
     const outcomeOfEnsuringEncodableCharacters = Sequence.Byte.Encoded.Compatibility.ensure(givenCharacters, {
       assuming: Base64.bitWidth,
     });
 
     if (outcomeOfEnsuringEncodableCharacters.isFailure) {
       const failureToEnsureEncodableCharacters = outcomeOfEnsuringEncodableCharacters.rewrappedWith({
-        cause: $0 => Sequence_Base64CharacterEncodedByte_ParsingError.thatEscorts($0),
+        cause: $0 => Sequence_Byte_Base64CharacterEncoded_ParsingError.thatEscorts($0),
       });
 
       return failureToEnsureEncodableCharacters;
@@ -63,7 +63,7 @@ class Sequence_Base64CharacterEncodedByte
 
     const outcomeOfParsingByteSequence = Attempt.Outcome.fromRewrapping(outcomeOfEnsuringConformantCharacters, {
       product: $0 => new this($0.concat(padding)),
-      cause  : $0 => Sequence_Base64CharacterEncodedByte_ParsingError.thatEscorts($0),
+      cause  : $0 => Sequence_Byte_Base64CharacterEncoded_ParsingError.thatEscorts($0),
     });
 
     return outcomeOfParsingByteSequence;
@@ -71,5 +71,5 @@ class Sequence_Base64CharacterEncodedByte
 }
 
 export {
-  Sequence_Base64CharacterEncodedByte,
+  Sequence_Byte_Base64CharacterEncoded,
 };

--- a/src/library/Base64CharacterEncodedByteSequence/definition.ts
+++ b/src/library/Base64CharacterEncodedByteSequence/definition.ts
@@ -10,15 +10,15 @@ import {
   lastCharacterOf,
 } from '@/library/utilitiesByType/string.ts';
 
-import Sequence_Byte_Base64CharacterEncoded_ParsingError from './ParsingError.ts';
+import Sequence_Byte_Encoded_Base64Character_ParsingError from './ParsingError.ts';
 
 /** See [RFC 4648 Section 4](https://www.rfc-editor.org/rfc/rfc4648.html#section-4) for more information */
-class Sequence_Byte_Base64CharacterEncoded
+class Sequence_Byte_Encoded_Base64Character
   extends StringSubset<
-  'Sequence_Byte_Base64CharacterEncoded'
+  'Sequence_Byte_Encoded_Base64Character'
 > implements Parsable.String<
-  typeof Sequence_Byte_Base64CharacterEncoded,
-  /*  */ Sequence_Byte_Base64CharacterEncoded_ParsingError
+  typeof Sequence_Byte_Encoded_Base64Character,
+  /*  */ Sequence_Byte_Encoded_Base64Character_ParsingError
 > {
   public static paddingCharacter = '=';
 
@@ -44,14 +44,14 @@ class Sequence_Byte_Base64CharacterEncoded
 
   public static parsedFrom = (
     givenCharacters: string,
-  ): Attempt.Outcome<Sequence_Byte_Base64CharacterEncoded, Sequence_Byte_Base64CharacterEncoded_ParsingError> => {
+  ): Attempt.Outcome<Sequence_Byte_Encoded_Base64Character, Sequence_Byte_Encoded_Base64Character_ParsingError> => {
     const outcomeOfEnsuringEncodableCharacters = Sequence.Byte.Encoded.Compatibility.ensure(givenCharacters, {
       assuming: Base64.bitWidth,
     });
 
     if (outcomeOfEnsuringEncodableCharacters.isFailure) {
       const failureToEnsureEncodableCharacters = outcomeOfEnsuringEncodableCharacters.rewrappedWith({
-        cause: $0 => Sequence_Byte_Base64CharacterEncoded_ParsingError.thatEscorts($0),
+        cause: $0 => Sequence_Byte_Encoded_Base64Character_ParsingError.thatEscorts($0),
       });
 
       return failureToEnsureEncodableCharacters;
@@ -63,7 +63,7 @@ class Sequence_Byte_Base64CharacterEncoded
 
     const outcomeOfParsingByteSequence = Attempt.Outcome.fromRewrapping(outcomeOfEnsuringConformantCharacters, {
       product: $0 => new this($0.concat(padding)),
-      cause  : $0 => Sequence_Byte_Base64CharacterEncoded_ParsingError.thatEscorts($0),
+      cause  : $0 => Sequence_Byte_Encoded_Base64Character_ParsingError.thatEscorts($0),
     });
 
     return outcomeOfParsingByteSequence;
@@ -71,5 +71,5 @@ class Sequence_Byte_Base64CharacterEncoded
 }
 
 export {
-  Sequence_Byte_Base64CharacterEncoded,
+  Sequence_Byte_Encoded_Base64Character,
 };

--- a/src/library/Base64CharacterEncodedByteSequence/definition.ts
+++ b/src/library/Base64CharacterEncodedByteSequence/definition.ts
@@ -10,15 +10,15 @@ import {
   lastCharacterOf,
 } from '@/library/utilitiesByType/string.ts';
 
-import Base64CharacterEncodedByteSequence_ParsingError from './ParsingError.ts';
+import Sequence_Base64CharacterEncodedByte_ParsingError from './ParsingError.ts';
 
 /** See [RFC 4648 Section 4](https://www.rfc-editor.org/rfc/rfc4648.html#section-4) for more information */
-class Base64CharacterEncodedByteSequence
+class Sequence_Base64CharacterEncodedByte
   extends StringSubset<
-  'Base64CharacterEncodedByteSequence'
+  'Sequence_Base64CharacterEncodedByte'
 > implements Parsable.String<
-  typeof Base64CharacterEncodedByteSequence,
-  /*  */ Base64CharacterEncodedByteSequence_ParsingError
+  typeof Sequence_Base64CharacterEncodedByte,
+  /*  */ Sequence_Base64CharacterEncodedByte_ParsingError
 > {
   public static paddingCharacter = '=';
 
@@ -44,14 +44,14 @@ class Base64CharacterEncodedByteSequence
 
   public static parsedFrom = (
     givenCharacters: string,
-  ): Attempt.Outcome<Base64CharacterEncodedByteSequence, Base64CharacterEncodedByteSequence_ParsingError> => {
+  ): Attempt.Outcome<Sequence_Base64CharacterEncodedByte, Sequence_Base64CharacterEncodedByte_ParsingError> => {
     const outcomeOfEnsuringEncodableCharacters = Sequence.Byte.Encoded.Compatibility.ensure(givenCharacters, {
       assuming: Base64.bitWidth,
     });
 
     if (outcomeOfEnsuringEncodableCharacters.isFailure) {
       const failureToEnsureEncodableCharacters = outcomeOfEnsuringEncodableCharacters.rewrappedWith({
-        cause: $0 => Base64CharacterEncodedByteSequence_ParsingError.thatEscorts($0),
+        cause: $0 => Sequence_Base64CharacterEncodedByte_ParsingError.thatEscorts($0),
       });
 
       return failureToEnsureEncodableCharacters;
@@ -63,7 +63,7 @@ class Base64CharacterEncodedByteSequence
 
     const outcomeOfParsingByteSequence = Attempt.Outcome.fromRewrapping(outcomeOfEnsuringConformantCharacters, {
       product: $0 => new this($0.concat(padding)),
-      cause  : $0 => Base64CharacterEncodedByteSequence_ParsingError.thatEscorts($0),
+      cause  : $0 => Sequence_Base64CharacterEncodedByte_ParsingError.thatEscorts($0),
     });
 
     return outcomeOfParsingByteSequence;
@@ -71,5 +71,5 @@ class Base64CharacterEncodedByteSequence
 }
 
 export {
-  Base64CharacterEncodedByteSequence,
+  Sequence_Base64CharacterEncodedByte,
 };

--- a/src/library/Base64CharacterEncodedByteSequence/exports.ts
+++ b/src/library/Base64CharacterEncodedByteSequence/exports.ts
@@ -1,3 +1,3 @@
 export {
-  Sequence_Byte_Encoded_Base64Character,
+  Sequence_Byte_Encoded_Base64,
 } from './definition.ts';

--- a/src/library/Base64CharacterEncodedByteSequence/exports.ts
+++ b/src/library/Base64CharacterEncodedByteSequence/exports.ts
@@ -1,3 +1,3 @@
 export {
-  Sequence_Byte_Base64CharacterEncoded,
+  Sequence_Byte_Encoded_Base64Character,
 } from './definition.ts';

--- a/src/library/Base64CharacterEncodedByteSequence/exports.ts
+++ b/src/library/Base64CharacterEncodedByteSequence/exports.ts
@@ -1,3 +1,3 @@
 export {
-  Base64CharacterEncodedByteSequence,
+  Sequence_Base64CharacterEncodedByte,
 } from './definition.ts';

--- a/src/library/Base64CharacterEncodedByteSequence/exports.ts
+++ b/src/library/Base64CharacterEncodedByteSequence/exports.ts
@@ -1,3 +1,3 @@
 export {
-  Sequence_Base64CharacterEncodedByte,
+  Sequence_Byte_Base64CharacterEncoded,
 } from './definition.ts';

--- a/src/library/Base64CharacterEncodedByteSequence/index.ts
+++ b/src/library/Base64CharacterEncodedByteSequence/index.ts
@@ -1,3 +1,3 @@
 export {
-  Base64CharacterEncodedByteSequence as default,
+  Sequence_Base64CharacterEncodedByte as default,
 } from './exports.ts';

--- a/src/library/Base64CharacterEncodedByteSequence/index.ts
+++ b/src/library/Base64CharacterEncodedByteSequence/index.ts
@@ -1,3 +1,3 @@
 export {
-  Sequence_Byte_Encoded_Base64Character as default,
+  Sequence_Byte_Encoded_Base64 as default,
 } from './exports.ts';

--- a/src/library/Base64CharacterEncodedByteSequence/index.ts
+++ b/src/library/Base64CharacterEncodedByteSequence/index.ts
@@ -1,3 +1,3 @@
 export {
-  Sequence_Byte_Base64CharacterEncoded as default,
+  Sequence_Byte_Encoded_Base64Character as default,
 } from './exports.ts';

--- a/src/library/Base64CharacterEncodedByteSequence/index.ts
+++ b/src/library/Base64CharacterEncodedByteSequence/index.ts
@@ -1,3 +1,3 @@
 export {
-  Sequence_Base64CharacterEncodedByte as default,
+  Sequence_Byte_Base64CharacterEncoded as default,
 } from './exports.ts';

--- a/src/library/Schema/base64CharacterEncodedByteSequence.ts
+++ b/src/library/Schema/base64CharacterEncodedByteSequence.ts
@@ -1,4 +1,4 @@
-import Sequence_Byte_Base64CharacterEncoded from '@/library/Base64CharacterEncodedByteSequence';
+import Sequence_Byte_Encoded_Base64Character from '@/library/Base64CharacterEncodedByteSequence';
 
 import {
   string as Schema_string,
@@ -7,7 +7,7 @@ import {
 
 /** An alternative to `Schema.base64()` that avoids using the deprecated `atob` conversion under the hood */
 const Schema_base64CharacterEncodedByteSequence = () => Schema_string().transform((someSubject, currentContext) => {
-  const outcomeOfParsingSubject = Sequence_Byte_Base64CharacterEncoded.parsedFrom(someSubject);
+  const outcomeOfParsingSubject = Sequence_Byte_Encoded_Base64Character.parsedFrom(someSubject);
 
   if (
     outcomeOfParsingSubject.isSuccess

--- a/src/library/Schema/base64CharacterEncodedByteSequence.ts
+++ b/src/library/Schema/base64CharacterEncodedByteSequence.ts
@@ -1,4 +1,4 @@
-import Sequence_Base64CharacterEncodedByte from '@/library/Base64CharacterEncodedByteSequence';
+import Sequence_Byte_Base64CharacterEncoded from '@/library/Base64CharacterEncodedByteSequence';
 
 import {
   string as Schema_string,
@@ -7,7 +7,7 @@ import {
 
 /** An alternative to `Schema.base64()` that avoids using the deprecated `atob` conversion under the hood */
 const Schema_base64CharacterEncodedByteSequence = () => Schema_string().transform((someSubject, currentContext) => {
-  const outcomeOfParsingSubject = Sequence_Base64CharacterEncodedByte.parsedFrom(someSubject);
+  const outcomeOfParsingSubject = Sequence_Byte_Base64CharacterEncoded.parsedFrom(someSubject);
 
   if (
     outcomeOfParsingSubject.isSuccess

--- a/src/library/Schema/base64CharacterEncodedByteSequence.ts
+++ b/src/library/Schema/base64CharacterEncodedByteSequence.ts
@@ -1,4 +1,4 @@
-import Sequence_Byte_Encoded_Base64Character from '@/library/Base64CharacterEncodedByteSequence';
+import Sequence_Byte_Encoded_Base64 from '@/library/Base64CharacterEncodedByteSequence';
 
 import {
   string as Schema_string,
@@ -7,7 +7,7 @@ import {
 
 /** An alternative to `Schema.base64()` that avoids using the deprecated `atob` conversion under the hood */
 const Schema_base64CharacterEncodedByteSequence = () => Schema_string().transform((someSubject, currentContext) => {
-  const outcomeOfParsingSubject = Sequence_Byte_Encoded_Base64Character.parsedFrom(someSubject);
+  const outcomeOfParsingSubject = Sequence_Byte_Encoded_Base64.parsedFrom(someSubject);
 
   if (
     outcomeOfParsingSubject.isSuccess

--- a/src/library/Schema/base64CharacterEncodedByteSequence.ts
+++ b/src/library/Schema/base64CharacterEncodedByteSequence.ts
@@ -1,4 +1,4 @@
-import Base64CharacterEncodedByteSequence from '@/library/Base64CharacterEncodedByteSequence';
+import Sequence_Base64CharacterEncodedByte from '@/library/Base64CharacterEncodedByteSequence';
 
 import {
   string as Schema_string,
@@ -7,7 +7,7 @@ import {
 
 /** An alternative to `Schema.base64()` that avoids using the deprecated `atob` conversion under the hood */
 const Schema_base64CharacterEncodedByteSequence = () => Schema_string().transform((someSubject, currentContext) => {
-  const outcomeOfParsingSubject = Base64CharacterEncodedByteSequence.parsedFrom(someSubject);
+  const outcomeOfParsingSubject = Sequence_Base64CharacterEncodedByte.parsedFrom(someSubject);
 
   if (
     outcomeOfParsingSubject.isSuccess

--- a/src/library/Shortfin/TextToImage/SDXL/Client/Request/Outcome.ts
+++ b/src/library/Shortfin/TextToImage/SDXL/Client/Request/Outcome.ts
@@ -1,9 +1,9 @@
 import type Attempt from '@/library/Attempt';
-import type Sequence_Base64CharacterEncodedByte from '@/library/Base64CharacterEncodedByteSequence';
+import type Sequence_Byte_Base64CharacterEncoded from '@/library/Base64CharacterEncodedByteSequence';
 import type HTTP from '@/library/HTTP';
 
 type Shortfin_TextToImage_SDXL_Client_Request_Outcome = Attempt.Outcome<
-  Sequence_Base64CharacterEncodedByte,
+  Sequence_Byte_Base64CharacterEncoded,
   HTTP.Endpoint.Error.Any
 >;
 

--- a/src/library/Shortfin/TextToImage/SDXL/Client/Request/Outcome.ts
+++ b/src/library/Shortfin/TextToImage/SDXL/Client/Request/Outcome.ts
@@ -1,9 +1,9 @@
 import type Attempt from '@/library/Attempt';
-import type Sequence_Byte_Encoded_Base64Character from '@/library/Base64CharacterEncodedByteSequence';
+import type Sequence_Byte_Encoded_Base64 from '@/library/Base64CharacterEncodedByteSequence';
 import type HTTP from '@/library/HTTP';
 
 type Shortfin_TextToImage_SDXL_Client_Request_Outcome = Attempt.Outcome<
-  Sequence_Byte_Encoded_Base64Character,
+  Sequence_Byte_Encoded_Base64,
   HTTP.Endpoint.Error.Any
 >;
 

--- a/src/library/Shortfin/TextToImage/SDXL/Client/Request/Outcome.ts
+++ b/src/library/Shortfin/TextToImage/SDXL/Client/Request/Outcome.ts
@@ -1,9 +1,9 @@
 import type Attempt from '@/library/Attempt';
-import type Sequence_Byte_Base64CharacterEncoded from '@/library/Base64CharacterEncodedByteSequence';
+import type Sequence_Byte_Encoded_Base64Character from '@/library/Base64CharacterEncodedByteSequence';
 import type HTTP from '@/library/HTTP';
 
 type Shortfin_TextToImage_SDXL_Client_Request_Outcome = Attempt.Outcome<
-  Sequence_Byte_Base64CharacterEncoded,
+  Sequence_Byte_Encoded_Base64Character,
   HTTP.Endpoint.Error.Any
 >;
 

--- a/src/library/Shortfin/TextToImage/SDXL/Client/Request/Outcome.ts
+++ b/src/library/Shortfin/TextToImage/SDXL/Client/Request/Outcome.ts
@@ -1,9 +1,9 @@
 import type Attempt from '@/library/Attempt';
-import type Base64CharacterEncodedByteSequence from '@/library/Base64CharacterEncodedByteSequence';
+import type Sequence_Base64CharacterEncodedByte from '@/library/Base64CharacterEncodedByteSequence';
 import type HTTP from '@/library/HTTP';
 
 type Shortfin_TextToImage_SDXL_Client_Request_Outcome = Attempt.Outcome<
-  Base64CharacterEncodedByteSequence,
+  Sequence_Base64CharacterEncodedByte,
   HTTP.Endpoint.Error.Any
 >;
 

--- a/src/library/Shortfin/TextToImage/SDXL/Client/Response/Body/definition.ts
+++ b/src/library/Shortfin/TextToImage/SDXL/Client/Response/Body/definition.ts
@@ -1,5 +1,5 @@
 import type Attempt from '@/library/Attempt';
-import type Sequence_Base64CharacterEncodedByte from '@/library/Base64CharacterEncodedByteSequence';
+import type Sequence_Byte_Base64CharacterEncoded from '@/library/Base64CharacterEncodedByteSequence';
 import type Parsable from '@/library/Parsable';
 import Parse from '@/library/Parse';
 import Schema from '@/library/Schema';
@@ -15,8 +15,8 @@ implements Parsable<
 > {
   public constructor(
     public images: [
-      Sequence_Base64CharacterEncodedByte,
-      ...Sequence_Base64CharacterEncodedByte[],
+      Sequence_Byte_Base64CharacterEncoded,
+      ...Sequence_Byte_Base64CharacterEncoded[],
     ],
   ) {}
 

--- a/src/library/Shortfin/TextToImage/SDXL/Client/Response/Body/definition.ts
+++ b/src/library/Shortfin/TextToImage/SDXL/Client/Response/Body/definition.ts
@@ -1,5 +1,5 @@
 import type Attempt from '@/library/Attempt';
-import type Sequence_Byte_Encoded_Base64Character from '@/library/Base64CharacterEncodedByteSequence';
+import type Sequence_Byte_Encoded_Base64 from '@/library/Base64CharacterEncodedByteSequence';
 import type Parsable from '@/library/Parsable';
 import Parse from '@/library/Parse';
 import Schema from '@/library/Schema';
@@ -15,8 +15,8 @@ implements Parsable<
 > {
   public constructor(
     public images: [
-      Sequence_Byte_Encoded_Base64Character,
-      ...Sequence_Byte_Encoded_Base64Character[],
+      Sequence_Byte_Encoded_Base64,
+      ...Sequence_Byte_Encoded_Base64[],
     ],
   ) {}
 

--- a/src/library/Shortfin/TextToImage/SDXL/Client/Response/Body/definition.ts
+++ b/src/library/Shortfin/TextToImage/SDXL/Client/Response/Body/definition.ts
@@ -1,5 +1,5 @@
 import type Attempt from '@/library/Attempt';
-import type Sequence_Byte_Base64CharacterEncoded from '@/library/Base64CharacterEncodedByteSequence';
+import type Sequence_Byte_Encoded_Base64Character from '@/library/Base64CharacterEncodedByteSequence';
 import type Parsable from '@/library/Parsable';
 import Parse from '@/library/Parse';
 import Schema from '@/library/Schema';
@@ -15,8 +15,8 @@ implements Parsable<
 > {
   public constructor(
     public images: [
-      Sequence_Byte_Base64CharacterEncoded,
-      ...Sequence_Byte_Base64CharacterEncoded[],
+      Sequence_Byte_Encoded_Base64Character,
+      ...Sequence_Byte_Encoded_Base64Character[],
     ],
   ) {}
 

--- a/src/library/Shortfin/TextToImage/SDXL/Client/Response/Body/definition.ts
+++ b/src/library/Shortfin/TextToImage/SDXL/Client/Response/Body/definition.ts
@@ -1,5 +1,5 @@
 import type Attempt from '@/library/Attempt';
-import type Base64CharacterEncodedByteSequence from '@/library/Base64CharacterEncodedByteSequence';
+import type Sequence_Base64CharacterEncodedByte from '@/library/Base64CharacterEncodedByteSequence';
 import type Parsable from '@/library/Parsable';
 import Parse from '@/library/Parse';
 import Schema from '@/library/Schema';
@@ -15,8 +15,8 @@ implements Parsable<
 > {
   public constructor(
     public images: [
-      Base64CharacterEncodedByteSequence,
-      ...Base64CharacterEncodedByteSequence[],
+      Sequence_Base64CharacterEncodedByte,
+      ...Sequence_Base64CharacterEncodedByte[],
     ],
   ) {}
 

--- a/src/library/UniformResourceIdentifier/Data/definition.ts
+++ b/src/library/UniformResourceIdentifier/Data/definition.ts
@@ -1,5 +1,5 @@
 import Attempt from '@/library/Attempt';
-import type Sequence_Byte_Encoded_Base64Character from '@/library/Base64CharacterEncodedByteSequence';
+import type Sequence_Byte_Encoded_Base64 from '@/library/Base64CharacterEncodedByteSequence';
 import type ContentDescriptor from '@/library/ContentDescriptor';
 import NonTrivialString from '@/library/NonTrivialString';
 
@@ -19,7 +19,7 @@ class URI_Data
   public constructor(
     private readonly overridableDescriptor: ContentDescriptor | null,
     public readonly encoding: URI_Data_EncodingIdentifier.Any,
-    public readonly data: Sequence_Byte_Encoded_Base64Character,
+    public readonly data: Sequence_Byte_Encoded_Base64,
   ) {
     super(
       URI_Data.scheme,

--- a/src/library/UniformResourceIdentifier/Data/definition.ts
+++ b/src/library/UniformResourceIdentifier/Data/definition.ts
@@ -1,5 +1,5 @@
 import Attempt from '@/library/Attempt';
-import type Base64CharacterEncodedByteSequence from '@/library/Base64CharacterEncodedByteSequence';
+import type Sequence_Base64CharacterEncodedByte from '@/library/Base64CharacterEncodedByteSequence';
 import type ContentDescriptor from '@/library/ContentDescriptor';
 import NonTrivialString from '@/library/NonTrivialString';
 
@@ -19,7 +19,7 @@ class URI_Data
   public constructor(
     private readonly overridableDescriptor: ContentDescriptor | null,
     public readonly encoding: URI_Data_EncodingIdentifier.Any,
-    public readonly data: Base64CharacterEncodedByteSequence,
+    public readonly data: Sequence_Base64CharacterEncodedByte,
   ) {
     super(
       URI_Data.scheme,

--- a/src/library/UniformResourceIdentifier/Data/definition.ts
+++ b/src/library/UniformResourceIdentifier/Data/definition.ts
@@ -1,5 +1,5 @@
 import Attempt from '@/library/Attempt';
-import type Sequence_Base64CharacterEncodedByte from '@/library/Base64CharacterEncodedByteSequence';
+import type Sequence_Byte_Base64CharacterEncoded from '@/library/Base64CharacterEncodedByteSequence';
 import type ContentDescriptor from '@/library/ContentDescriptor';
 import NonTrivialString from '@/library/NonTrivialString';
 
@@ -19,7 +19,7 @@ class URI_Data
   public constructor(
     private readonly overridableDescriptor: ContentDescriptor | null,
     public readonly encoding: URI_Data_EncodingIdentifier.Any,
-    public readonly data: Sequence_Base64CharacterEncodedByte,
+    public readonly data: Sequence_Byte_Base64CharacterEncoded,
   ) {
     super(
       URI_Data.scheme,

--- a/src/library/UniformResourceIdentifier/Data/definition.ts
+++ b/src/library/UniformResourceIdentifier/Data/definition.ts
@@ -1,5 +1,5 @@
 import Attempt from '@/library/Attempt';
-import type Sequence_Byte_Base64CharacterEncoded from '@/library/Base64CharacterEncodedByteSequence';
+import type Sequence_Byte_Encoded_Base64Character from '@/library/Base64CharacterEncodedByteSequence';
 import type ContentDescriptor from '@/library/ContentDescriptor';
 import NonTrivialString from '@/library/NonTrivialString';
 
@@ -19,7 +19,7 @@ class URI_Data
   public constructor(
     private readonly overridableDescriptor: ContentDescriptor | null,
     public readonly encoding: URI_Data_EncodingIdentifier.Any,
-    public readonly data: Sequence_Byte_Base64CharacterEncoded,
+    public readonly data: Sequence_Byte_Encoded_Base64Character,
   ) {
     super(
       URI_Data.scheme,

--- a/src/library/UniformResourceIdentifier/Image/definition.ts
+++ b/src/library/UniformResourceIdentifier/Image/definition.ts
@@ -1,4 +1,4 @@
-import type Base64CharacterEncodedByteSequence from '@/library/Base64CharacterEncodedByteSequence';
+import type Sequence_Base64CharacterEncodedByte from '@/library/Base64CharacterEncodedByteSequence';
 import ContentDescriptor from '@/library/ContentDescriptor';
 
 import {
@@ -16,7 +16,7 @@ class URI_Image
   public constructor(
     public readonly format: URI_Image_Format.Any,
     givenEncoding: URI_Data.EncodingIdentifier.Any,
-    givenData: Base64CharacterEncodedByteSequence,
+    givenData: Sequence_Base64CharacterEncodedByte,
   ) {
     super(
       null,

--- a/src/library/UniformResourceIdentifier/Image/definition.ts
+++ b/src/library/UniformResourceIdentifier/Image/definition.ts
@@ -1,4 +1,4 @@
-import type Sequence_Base64CharacterEncodedByte from '@/library/Base64CharacterEncodedByteSequence';
+import type Sequence_Byte_Base64CharacterEncoded from '@/library/Base64CharacterEncodedByteSequence';
 import ContentDescriptor from '@/library/ContentDescriptor';
 
 import {
@@ -16,7 +16,7 @@ class URI_Image
   public constructor(
     public readonly format: URI_Image_Format.Any,
     givenEncoding: URI_Data.EncodingIdentifier.Any,
-    givenData: Sequence_Base64CharacterEncodedByte,
+    givenData: Sequence_Byte_Base64CharacterEncoded,
   ) {
     super(
       null,

--- a/src/library/UniformResourceIdentifier/Image/definition.ts
+++ b/src/library/UniformResourceIdentifier/Image/definition.ts
@@ -1,4 +1,4 @@
-import type Sequence_Byte_Base64CharacterEncoded from '@/library/Base64CharacterEncodedByteSequence';
+import type Sequence_Byte_Encoded_Base64Character from '@/library/Base64CharacterEncodedByteSequence';
 import ContentDescriptor from '@/library/ContentDescriptor';
 
 import {
@@ -16,7 +16,7 @@ class URI_Image
   public constructor(
     public readonly format: URI_Image_Format.Any,
     givenEncoding: URI_Data.EncodingIdentifier.Any,
-    givenData: Sequence_Byte_Base64CharacterEncoded,
+    givenData: Sequence_Byte_Encoded_Base64Character,
   ) {
     super(
       null,

--- a/src/library/UniformResourceIdentifier/Image/definition.ts
+++ b/src/library/UniformResourceIdentifier/Image/definition.ts
@@ -1,4 +1,4 @@
-import type Sequence_Byte_Encoded_Base64Character from '@/library/Base64CharacterEncodedByteSequence';
+import type Sequence_Byte_Encoded_Base64 from '@/library/Base64CharacterEncodedByteSequence';
 import ContentDescriptor from '@/library/ContentDescriptor';
 
 import {
@@ -16,7 +16,7 @@ class URI_Image
   public constructor(
     public readonly format: URI_Image_Format.Any,
     givenEncoding: URI_Data.EncodingIdentifier.Any,
-    givenData: Sequence_Byte_Encoded_Base64Character,
+    givenData: Sequence_Byte_Encoded_Base64,
   ) {
     super(
       null,


### PR DESCRIPTION
- the use of a long, specific name for this library indicates that several levels of abstraction are present
- identifying the labels associated with those levels:
  1. "Sequence": the core nature of the custom type defined in this library.
  2. "Byte": specifies the contents of the sequence
  3. "Encoded": denotes that the contents of the sequence cannot be directly interpreted
  4. "Base64": specifies actual interpretation of the contents of the sequence
- "Character" was omitted because it didn't actually reduce any ambiguity
- makes it obvious that this library should be moved to the `Sequence.Byte.Encoded` module