### PR TITLE
refactor: moves schema concerns of base-64 encoded byte sequence from "library/Schema" to "library/Sequence"

### DIFF
--- a/src/library/Schema/base64CharacterEncodedByteSequence.ts
+++ b/src/library/Schema/base64CharacterEncodedByteSequence.ts
@@ -1,7 +1,0 @@
-import Sequence from '@/library/Sequence';
-
-const Schema_base64CharacterEncodedByteSequence = () => Sequence.Byte.Encoded.Base64.Schema();
-
-export {
-  Schema_base64CharacterEncodedByteSequence,
-};

--- a/src/library/Schema/base64CharacterEncodedByteSequence.ts
+++ b/src/library/Schema/base64CharacterEncodedByteSequence.ts
@@ -1,25 +1,6 @@
 import Sequence from '@/library/Sequence';
 
-import {
-  string as Schema_string,
-  NEVER as Schema_NEVER,
-} from './core';
-
-/** An alternative to `Schema.base64()` that avoids using the deprecated `atob` conversion under the hood */
-const Schema_base64CharacterEncodedByteSequence = () => Schema_string().transform((someSubject, currentContext) => {
-  const outcomeOfParsingSubject = Sequence.Byte.Encoded.Base64.parsedFrom(someSubject);
-
-  if (
-    outcomeOfParsingSubject.isSuccess
-  ) return outcomeOfParsingSubject.unwrapped;
-
-  currentContext.addIssue({
-    code   : 'custom',
-    message: outcomeOfParsingSubject.cause.message,
-  });
-
-  return Schema_NEVER;
-});
+const Schema_base64CharacterEncodedByteSequence = () => Sequence.Byte.Encoded.Base64.Schema();
 
 export {
   Schema_base64CharacterEncodedByteSequence,

--- a/src/library/Schema/exports.ts
+++ b/src/library/Schema/exports.ts
@@ -1,5 +1,1 @@
 export * from './core';
-
-export {
-  Schema_base64CharacterEncodedByteSequence as base64CharacterEncodedByteSequence,
-} from './base64CharacterEncodedByteSequence';

--- a/src/library/Sequence/Byte/Encoded/Base64/definition.ts
+++ b/src/library/Sequence/Byte/Encoded/Base64/definition.ts
@@ -78,7 +78,7 @@ class Sequence_Byte_Encoded_Base64
   };
 
   /** An alternative to `Schema.base64()` that avoids using the deprecated `atob` conversion under the hood */
-  public static Schema = () => Schema.string().transform((someSubject, currentContext) => {
+  public static Schema = Schema.string().transform((someSubject, currentContext) => {
     const outcomeOfParsingSubject = this.parsedFrom(someSubject);
 
     if (

--- a/src/library/Sequence/Byte/Encoded/Base64/definition.ts
+++ b/src/library/Sequence/Byte/Encoded/Base64/definition.ts
@@ -77,7 +77,21 @@ class Sequence_Byte_Encoded_Base64
     return outcomeOfParsingByteSequence;
   };
 
-  public static Schema = Schema.base64CharacterEncodedByteSequence;
+  /** An alternative to `Schema.base64()` that avoids using the deprecated `atob` conversion under the hood */
+  public static Schema = () => Schema.string().transform((someSubject, currentContext) => {
+    const outcomeOfParsingSubject = Sequence.Byte.Encoded.Base64.parsedFrom(someSubject);
+
+    if (
+      outcomeOfParsingSubject.isSuccess
+    ) return outcomeOfParsingSubject.unwrapped;
+
+    currentContext.addIssue({
+      code   : 'custom',
+      message: outcomeOfParsingSubject.cause.message,
+    });
+
+    return Schema.NEVER;
+  });
 }
 
 export {

--- a/src/library/Sequence/Byte/Encoded/Base64/definition.ts
+++ b/src/library/Sequence/Byte/Encoded/Base64/definition.ts
@@ -79,7 +79,7 @@ class Sequence_Byte_Encoded_Base64
 
   /** An alternative to `Schema.base64()` that avoids using the deprecated `atob` conversion under the hood */
   public static Schema = () => Schema.string().transform((someSubject, currentContext) => {
-    const outcomeOfParsingSubject = Sequence.Byte.Encoded.Base64.parsedFrom(someSubject);
+    const outcomeOfParsingSubject = this.parsedFrom(someSubject);
 
     if (
       outcomeOfParsingSubject.isSuccess

--- a/src/library/Sequence/Byte/Encoded/Base64/definition.ts
+++ b/src/library/Sequence/Byte/Encoded/Base64/definition.ts
@@ -2,6 +2,7 @@ import Attempt from '@/library/Attempt';
 import Base64 from '@/library/Base64';
 import Byte from '@/library/Byte';
 import type Parsable from '@/library/Parsable';
+import Schema from '@/library/Schema';
 import StringSubset from '@/library/StringSubset';
 
 import {
@@ -75,6 +76,8 @@ class Sequence_Byte_Encoded_Base64
 
     return outcomeOfParsingByteSequence;
   };
+
+  public static Schema = Schema.base64CharacterEncodedByteSequence;
 }
 
 export {

--- a/src/library/Shortfin/TextToImage/SDXL/Client/Response/Body/definition.ts
+++ b/src/library/Shortfin/TextToImage/SDXL/Client/Response/Body/definition.ts
@@ -24,10 +24,10 @@ implements Parsable<
     .object({
       images: Schema
         .tuple([
-          Sequence.Byte.Encoded.Base64.Schema(),
+          Sequence.Byte.Encoded.Base64.Schema,
         ])
         .rest(
-          Sequence.Byte.Encoded.Base64.Schema(),
+          Sequence.Byte.Encoded.Base64.Schema,
         ),
     })
     .transform($0 => new Shortfin_TextToImage_SDXL_Client_Response_Body(

--- a/src/library/Shortfin/TextToImage/SDXL/Client/Response/Body/definition.ts
+++ b/src/library/Shortfin/TextToImage/SDXL/Client/Response/Body/definition.ts
@@ -2,7 +2,7 @@ import type Attempt from '@/library/Attempt';
 import type Parsable from '@/library/Parsable';
 import Parse from '@/library/Parse';
 import Schema from '@/library/Schema';
-import type Sequence from '@/library/Sequence';
+import Sequence from '@/library/Sequence';
 
 import {
   Shortfin_TextToImage_SDXL_Client_Response_Body_ParsingError,
@@ -24,10 +24,10 @@ implements Parsable<
     .object({
       images: Schema
         .tuple([
-          Schema.base64CharacterEncodedByteSequence(),
+          Sequence.Byte.Encoded.Base64.Schema(),
         ])
         .rest(
-          Schema.base64CharacterEncodedByteSequence(),
+          Sequence.Byte.Encoded.Base64.Schema(),
         ),
     })
     .transform($0 => new Shortfin_TextToImage_SDXL_Client_Response_Body(


### PR DESCRIPTION
Enabled by #810 