### PR TITLE
refactor: avoids non-semantic `return` expressions

### DIFF
--- a/src/components/DiscreteSlider.vue
+++ b/src/components/DiscreteSlider.vue
@@ -102,12 +102,10 @@ const tickLabelsAlong = (
     by  : givenStepSize,
   });
 
-  const labelSets = tickRange.inclusiveSteps.map((eachPosition) => {
-    return tickLabels({
-      by: eachPosition,
-      in: tickRange,
-    });
-  });
+  const labelSets = tickRange.inclusiveSteps.map(eachPosition => tickLabels({
+    by: eachPosition,
+    in: tickRange,
+  }));
 
   return shallowlyMerged(...labelSets);
 };

--- a/src/components/DiscreteSlider.vue
+++ b/src/components/DiscreteSlider.vue
@@ -83,9 +83,11 @@ const tickLabels = (
   const tickPosition = givenPosition + derivedOffset;
   const tickLabel = givenPosition.toString();
 
-  return {
+  const tickLabelByPosition = {
     [tickPosition]: tickLabel,
   };
+
+  return tickLabelByPosition;
 };
 
 const tickLabelsAlong = (
@@ -107,7 +109,8 @@ const tickLabelsAlong = (
     in: tickRange,
   }));
 
-  return shallowlyMerged(...labelSets);
+  const mergedLabelTables = shallowlyMerged(...labelSets);
+  return mergedLabelTables;
 };
 </script>
 

--- a/src/components/NavigationPanel.vue
+++ b/src/components/NavigationPanel.vue
@@ -37,7 +37,8 @@ const PanelWidth = {
   for(
     givenDisplay: Display,
   ) {
-    return this.scaleFor(givenDisplay) * this.default;
+    const computedWidth = this.scaleFor(givenDisplay) * this.default;
+    return computedWidth;
   },
 };
 

--- a/src/features/TextToImage/Client/SDXL/conversions/GenerateFromTextResponse.ts
+++ b/src/features/TextToImage/Client/SDXL/conversions/GenerateFromTextResponse.ts
@@ -28,9 +28,11 @@ const toNullableOutput = (
     givenImage === null
   ) return null;
 
-  return {
+  const derivedPipelineOutput = {
     image: givenImage,
   };
+
+  return derivedPipelineOutput;
 };
 
 const textToImageOutputs = (

--- a/src/features/TextToImage/Client/SDXL/conversions/TextPrompt.ts
+++ b/src/features/TextToImage/Client/SDXL/conversions/TextPrompt.ts
@@ -15,7 +15,8 @@ const serialized = (
     isDefault(givenPrompt.weight)
   ) return givenPrompt.text;
 
-  return `(${givenPrompt.text}: ${givenPrompt.weight.toString()})`;
+  const promptWithSerializedWeights = `(${givenPrompt.text}: ${givenPrompt.weight.toString()})`;
+  return promptWithSerializedWeights;
 };
 
 const allSerialized = (

--- a/src/features/TextToImage/Client/SDXL/conversions/TextPrompt.ts
+++ b/src/features/TextToImage/Client/SDXL/conversions/TextPrompt.ts
@@ -20,11 +20,9 @@ const serialized = (
 
 const allSerialized = (
   givenPrompts: TextPrompt[],
-): string => {
-  return givenPrompts
-    .map(serialized)
-    .join(', ');
-};
+): string => givenPrompts
+  .map(serialized)
+  .join(', ');
 
 export {
   allSerialized,

--- a/src/features/TextToImage/Server/exports.ts
+++ b/src/features/TextToImage/Server/exports.ts
@@ -23,9 +23,11 @@ const TextToImage_Server_Current_accordingToEnvironment = ((): WebAPI_Server | n
     originAccordingToEnvironment === undefined
   ) return null;
 
-  return WebAPI_Server.from({
+  const serverAccordingToEnvironment = WebAPI_Server.from({
     origin: originAccordingToEnvironment,
   });
+
+  return serverAccordingToEnvironment;
 })();
 
 const TextToImage_Server_Current_retrieve = (): Promise<

--- a/src/features/TextToImage/components/TextToImageInputSection.vue
+++ b/src/features/TextToImage/components/TextToImageInputSection.vue
@@ -55,29 +55,36 @@ const byQualitativeWeight = (givenInputText: StandardizedInputText): InputTextBy
         .map($0 => $0.text.trim())
         .join(', ');
 
-      return [
+      const eachDerivedEntry = [
         eachUnsafeQualitativeWeight,
         eachSerializationByWeight,
       ] as [
         QualitativeTextWeight,
         string,
       ];
+
+      return eachDerivedEntry;
     });
 
-  return Object.fromEntries(entriesForInputTextByQualitativeWeight) as unknown as InputTextByQualitativeWeight;
+  const computedInputTextByQualitativeWeight = Object.fromEntries(entriesForInputTextByQualitativeWeight);
+  return computedInputTextByQualitativeWeight as unknown as InputTextByQualitativeWeight;
 };
 
 const standardized = (givenInputText: InputTextByQualitativeWeight): StandardizedInputText => {
-  return Object.entries(qualitativeToQuantitativeTextWeightMap)
+  const computedInputText = Object.entries(qualitativeToQuantitativeTextWeightMap)
     .map(([eachUnsafeQualitativeWeight, eachQuantitativeWeight]): StandardizedInputText[number] => {
       const eachQualitativeWeight = eachUnsafeQualitativeWeight as QualitativeTextWeight;
       const weightedText = givenInputText[eachQualitativeWeight];
 
-      return {
+      const newInputTextComponent = {
         text  : weightedText,
         weight: eachQuantitativeWeight,
       };
+
+      return newInputTextComponent;
     });
+
+  return computedInputText;
 };
 
 const defaultInitialInputText: InputTextByQualitativeWeight = {

--- a/src/features/reporting.ts
+++ b/src/features/reporting.ts
@@ -4,14 +4,12 @@ import Repository from '@/utilities/Repository.ts';
 
 const formatted = (
   givenError: Contextualized<Error, Error>,
-): string => {
-  return [
-    `${givenError.message}:`,
-    '"""',
-    givenError.cause.message,
-    '"""',
-  ].join('\n');
-};
+): string => [
+  `${givenError.message}:`,
+  '"""',
+  givenError.cause.message,
+  '"""',
+].join('\n');
 
 const promptUserToReport = (givenError: Error) => {
   const unexpectedError = Contextualized.cast(givenError, 'Unexpected Error');

--- a/src/library/Attempt/Error/NonActionableBuiltInError.ts
+++ b/src/library/Attempt/Error/NonActionableBuiltInError.ts
@@ -63,16 +63,14 @@ type NonActionableBuiltInError =
 
 const isNonActionableBuiltInError = (
   givenError: Error,
-): givenError is NonActionableBuiltInError => {
-  return (
-    (givenError instanceof ReferenceError)
-    || (givenError instanceof TypeError)
-    || (givenError instanceof RangeError)
-    || (givenError instanceof URIError)
-    || (givenError instanceof EvalError)
-    || (givenError instanceof SyntaxError)
-  );
-};
+): givenError is NonActionableBuiltInError => (
+  (givenError instanceof ReferenceError)
+  || (givenError instanceof TypeError)
+  || (givenError instanceof RangeError)
+  || (givenError instanceof URIError)
+  || (givenError instanceof EvalError)
+  || (givenError instanceof SyntaxError)
+);
 
 const NonActionableBuiltInError = {
   describes: isNonActionableBuiltInError,

--- a/src/library/Base64.ts
+++ b/src/library/Base64.ts
@@ -5,7 +5,8 @@ const Base64 = {
     pattern: /A-Za-z\d\+\//,
   },
   get bitWidth() {
-    return Math.log2(this.Alphabet.length);
+    const maxBitCount = Math.log2(this.Alphabet.length);
+    return maxBitCount;
   },
 };
 

--- a/src/library/ContentDescriptor/definition.ts
+++ b/src/library/ContentDescriptor/definition.ts
@@ -26,7 +26,8 @@ class ContentDescriptor {
 
   public get serializableTopLevelDescriptor(): NonTrivialString {
     const suffixedTopLevelDescriptor = this.topLevelDescriptor.concat(ContentDescriptor.suffixForTopLevelDescriptor);
-    return NonTrivialString.parsedFrom(suffixedTopLevelDescriptor).forciblyUnwrap(/* Proven safe by inspecting intellisense of `topLevelDescriptor` */);
+    const coercedTopLevelDescriptor = NonTrivialString.parsedFrom(suffixedTopLevelDescriptor).forciblyUnwrap(/* Proven safe by inspecting intellisense of `topLevelDescriptor` */);
+    return coercedTopLevelDescriptor;
   }
 
   public static readonly treeBranchSuffix = '.';
@@ -48,7 +49,8 @@ class ContentDescriptor {
       this.structureDescriptor === null
     ) return null;
 
-    return ContentDescriptor.structureDescriptorPrefix.concat(this.structureDescriptor);
+    const prefixedStructureDescriptor = ContentDescriptor.structureDescriptorPrefix.concat(this.structureDescriptor);
+    return prefixedStructureDescriptor;
   }
 
   public static readonly parameterPrefix = ';';

--- a/src/library/NonTrivialString/definition.ts
+++ b/src/library/NonTrivialString/definition.ts
@@ -54,7 +54,8 @@ class NonTrivialString
   ): NonTrivialString {
     const concatenatedOperands = concatenated(this, ...givenOperands);
     const outcomeOfParsingConcatenatedOperands = NonTrivialString.parsedFrom(concatenatedOperands);
-    return outcomeOfParsingConcatenatedOperands.forciblyUnwrap(/* Safe to call since the leading string is always non-trivial and concatenation is purely additive */);
+    const coercedConcatenatedOperands = outcomeOfParsingConcatenatedOperands.forciblyUnwrap(/* Safe to call since the leading string is always non-trivial and concatenation is purely additive */);
+    return coercedConcatenatedOperands;
   }
 
   public static fromConcatenating(

--- a/src/library/Range/definition.ts
+++ b/src/library/Range/definition.ts
@@ -76,7 +76,8 @@ class Range {
   }
 
   public get inInclusiveNotation(): string {
-    return `[${this.lowerBound.toString()}, ${this.upperBound.toString()}]`;
+    const bracedBounds = `[${this.lowerBound.toString()}, ${this.upperBound.toString()}]`;
+    return bracedBounds;
   }
 }
 

--- a/src/library/ShimmedStabilityAIClient/Version1/Image.ts
+++ b/src/library/ShimmedStabilityAIClient/Version1/Image.ts
@@ -32,7 +32,7 @@ class ShimmedStabilityAIClient_Version1_Image
       seed        : givenRequest.textToImageRequestBody.seed,
     };
 
-    return {
+    const newStabilityAIGenerationResponse = {
       headers: {},
       result : {
         artifacts: [
@@ -40,6 +40,8 @@ class ShimmedStabilityAIClient_Version1_Image
         ],
       },
     };
+
+    return newStabilityAIGenerationResponse;
   }
 }
 

--- a/src/library/UniformResourceIdentifier/Data/definition.ts
+++ b/src/library/UniformResourceIdentifier/Data/definition.ts
@@ -41,13 +41,15 @@ class URI_Data
       this.encoding !== 'base64'
     ) return null;
 
-    return URI_Data.encodingPrefix.concat(this.encoding);
+    const prefixedEncoding = URI_Data.encodingPrefix.concat(this.encoding);
+    return prefixedEncoding;
   }
 
   public static readonly dataPrefix = ',';
 
   public get serializableData(): string {
-    return this.data.prependedWith(URI_Data.dataPrefix);
+    const prefixedData = this.data.prependedWith(URI_Data.dataPrefix);
+    return prefixedData;
   }
 
   public override get path(): NonTrivialString {

--- a/src/library/UniformResourceIdentifier/definition.ts
+++ b/src/library/UniformResourceIdentifier/definition.ts
@@ -21,7 +21,8 @@ class UniformResourceIdentifier {
   public static readonly schemeSuffix = ':';
 
   public get serializableScheme(): string {
-    return this.scheme.concat(UniformResourceIdentifier.schemeSuffix);
+    const suffixedScheme = this.scheme.concat(UniformResourceIdentifier.schemeSuffix);
+    return suffixedScheme;
   }
 
   public static readonly authorityPrefix = '//';
@@ -31,7 +32,8 @@ class UniformResourceIdentifier {
       this.authority === null
     ) return null;
 
-    return this.authority.prependedWith(UniformResourceIdentifier.authorityPrefix);
+    const prefixedAuthority = this.authority.prependedWith(UniformResourceIdentifier.authorityPrefix);
+    return prefixedAuthority;
   }
 
   public get path(): Exclude<UniformResourceIdentifier['overridablePath'], null> {
@@ -49,7 +51,8 @@ class UniformResourceIdentifier {
       this.query === null
     ) return null;
 
-    return this.query.prependedWith(UniformResourceIdentifier.queryPrefix);
+    const prefixedQuery = this.query.prependedWith(UniformResourceIdentifier.queryPrefix);
+    return prefixedQuery;
   }
 
   public static readonly fragmentPrefix = '#';
@@ -59,7 +62,8 @@ class UniformResourceIdentifier {
       this.fragment === null
     ) return null;
 
-    return this.fragment.prependedWith(UniformResourceIdentifier.fragmentPrefix);
+    const prefixedFragment = this.fragment.prependedWith(UniformResourceIdentifier.fragmentPrefix);
+    return prefixedFragment;
   }
 
   public get serialized(): string {

--- a/src/library/utilitiesByType/error.ts
+++ b/src/library/utilitiesByType/error.ts
@@ -12,7 +12,8 @@ const asError = (givenSubject: unknown): Error => {
   ) return givenSubject;
 
   const castedMessage = asString(givenSubject);
-  return new Error(castedMessage);
+  const castedError = new Error(castedMessage);
+  return castedError;
 };
 
 export {


### PR DESCRIPTION
- some return expressions from within a function scope did not semantically neighbor the function's signature:
  ```typescript
  class URI_Data {
    ...
    public get serializableData(): string {
      return this.data.prependedWith(URI_Data.dataPrefix);
    }
    ...
  }
  ``` 
  - this can obfuscate linguistic code smells
- to avoid this, an opportunity is taken to close the gap and pin down intent:
  ```typescript
  class URI_Data {
    ...
    public get serializableData(): string {
      const prefixedData = this.data.prependedWith(URI_Data.dataPrefix);
      return prefixedData;
    }
    ...
  }
  ``` 
  - this essentially says "To get serializable data, we compute the prefixed data. Here's how we do that..."
- by sticking to this pattern throughout the codebase, the author's intent is baked in, making future changes just a tiny bit easier.