### PR TITLE
types: prefers connecting primitive annotations to relevant data structures

### DIFF
--- a/src/features/TextToImage/Client/SDXL/conversions/StabilityAI_Client_Image.ts
+++ b/src/features/TextToImage/Client/SDXL/conversions/StabilityAI_Client_Image.ts
@@ -10,7 +10,7 @@ import type {
 const toOutputImage = (
   givenImage: StabilityAIClient.Image,
   given: {
-    description: string;
+    description: TextToImage_Pipeline_Output['image']['description'];
   },
 ): TextToImage_Pipeline_Output['image'] | null => {
   if (

--- a/src/features/TextToImage/Client/SDXL/conversions/TextPrompt.ts
+++ b/src/features/TextToImage/Client/SDXL/conversions/TextPrompt.ts
@@ -2,6 +2,10 @@ import type {
   TextPrompt,
 } from 'stabilityai-client-typescript/models/components';
 
+import type {
+  Output as TextToImage_Pipeline_Output,
+} from '@/features/TextToImage/Pipeline';
+
 const isDefault = (
   givenWeight: TextPrompt['weight'],
 ) => {
@@ -10,7 +14,7 @@ const isDefault = (
 
 const serialized = (
   givenPrompt: TextPrompt,
-): string => {
+): TextToImage_Pipeline_Output['image']['description'] => {
   if (
     isDefault(givenPrompt.weight)
   ) return givenPrompt.text;
@@ -21,7 +25,7 @@ const serialized = (
 
 const allSerialized = (
   givenPrompts: TextPrompt[],
-): string => givenPrompts
+): TextToImage_Pipeline_Output['image']['description'] => givenPrompts
   .map(serialized)
   .join(', ');
 


### PR DESCRIPTION
- for some annotations, there's history or context as to why something is a `string` or `number` that is actually codified elsewhere in the repo
- useful when the answer to "Why is this defined as a `string`?" is something to the effect of "Because a member in this custom type of ours over here defines this idea as a `string`."
- also makes it easier to keep these types in sync when primitives are deemed to permissive and need to be replaced by a branded subset