### PR TITLE
refactor: prefers object-oriented names for factory functions

### DIFF
--- a/src/features/TextToImage/Client/SDXL/conversions/GenerateFromTextResponse.ts
+++ b/src/features/TextToImage/Client/SDXL/conversions/GenerateFromTextResponse.ts
@@ -21,7 +21,7 @@ import {
   allSerialized,
 } from './TextPrompt';
 
-const toNullableOutput = (
+const NullableOutput_from = (
   givenImage: TextToImage_Pipeline_Output['image'] | null,
 ): TextToImage_Pipeline_Output | null => {
   if (
@@ -58,7 +58,7 @@ const textToImageOutputs = (
     .map($0 => toOutputImage($0, {
       description: allSerialized(givenInputText),
     }))
-    .map(toNullableOutput);
+    .map($0 => NullableOutput_from($0));
 
   return inferredOutputs;
 };


### PR DESCRIPTION
- factory functions:
  - usually takes some constituents and composes them into a new instance of some non-primitive or structural type
  - usually ends in `from` before the function call like `Image.from(someBytes)`
- conversion functions:
  - takes some instance and converts it to another instance that's structurally different but conceptually the same
  - usually begins with `to` before the function name like `toUSD(someAmountInGBP)`

Encountered while drafting #827