### PR TITLE
refactor: adds missing barrel files

### DIFF
--- a/src/features/Reporting/exports.ts
+++ b/src/features/Reporting/exports.ts
@@ -1,0 +1,1 @@
+export * from './promptUserWith';

--- a/src/features/Reporting/index.ts
+++ b/src/features/Reporting/index.ts
@@ -1,0 +1,1 @@
+export * from './exports.ts';

--- a/src/features/Reporting/promptUserWith.ts
+++ b/src/features/Reporting/promptUserWith.ts
@@ -1,4 +1,4 @@
-import Contextualized from '@/library/modifiersByType/error/Contextualized/definition';
+import Contextualized from '@/library/modifiersByType/error/Contextualized';
 
 import Repository from '@/utilities/Repository';
 

--- a/src/features/Reporting/promptUserWith.ts
+++ b/src/features/Reporting/promptUserWith.ts
@@ -1,4 +1,6 @@
-import Contextualized from '@/library/modifiersByType/error/Contextualized';
+import {
+  Contextualized,
+} from '@/library/modifiersByType/error';
 
 import Repository from '@/utilities/Repository';
 

--- a/src/features/Reporting/promptUserWith.ts
+++ b/src/features/Reporting/promptUserWith.ts
@@ -1,6 +1,6 @@
 import Contextualized from '@/library/modifiersByType/error/Contextualized/definition';
 
-import Repository from '@/utilities/Repository/definition';
+import Repository from '@/utilities/Repository';
 
 const Reporting_formatFor = (
   givenError: Contextualized<Error, Error>,

--- a/src/features/TextToImage/Client/SDXL/generateOutputFrom.ts
+++ b/src/features/TextToImage/Client/SDXL/generateOutputFrom.ts
@@ -14,7 +14,7 @@ import * as TextToImage_Server from '../../Server';
 
 import {
   toSharkUIOutput_first,
-} from './toSharkUIOutput/first';
+} from './toSharkUIOutput';
 
 const TextToImage_Client_SDXL_initialize = async (): Promise<
   Attempt.Outcome<

--- a/src/features/TextToImage/Client/SDXL/toSharkUIOutput/Image/Description/exports.ts
+++ b/src/features/TextToImage/Client/SDXL/toSharkUIOutput/Image/Description/exports.ts
@@ -1,0 +1,1 @@
+export * from './all';

--- a/src/features/TextToImage/Client/SDXL/toSharkUIOutput/Image/Description/index.ts
+++ b/src/features/TextToImage/Client/SDXL/toSharkUIOutput/Image/Description/index.ts
@@ -1,0 +1,1 @@
+export * from './exports.ts';

--- a/src/features/TextToImage/Client/SDXL/toSharkUIOutput/Image/definition.ts
+++ b/src/features/TextToImage/Client/SDXL/toSharkUIOutput/Image/definition.ts
@@ -1,7 +1,10 @@
 import type * as StabilityAIClient from 'stabilityai-client-typescript/models/components';
 
 import Sequence from '@/library/Sequence';
-import URI_Image from '@/library/UniformResourceIdentifier/Image';
+
+import {
+  URI_Image,
+} from '@/library/UniformResourceIdentifier';
 
 import type {
   Output as TextToImage_Pipeline_Output,

--- a/src/features/TextToImage/Client/SDXL/toSharkUIOutput/Image/exports.ts
+++ b/src/features/TextToImage/Client/SDXL/toSharkUIOutput/Image/exports.ts
@@ -1,0 +1,1 @@
+export * from './definition.ts';

--- a/src/features/TextToImage/Client/SDXL/toSharkUIOutput/Image/index.ts
+++ b/src/features/TextToImage/Client/SDXL/toSharkUIOutput/Image/index.ts
@@ -1,0 +1,1 @@
+export * from './exports.ts';

--- a/src/features/TextToImage/Client/SDXL/toSharkUIOutput/exports.ts
+++ b/src/features/TextToImage/Client/SDXL/toSharkUIOutput/exports.ts
@@ -1,0 +1,1 @@
+export * from './first';

--- a/src/features/TextToImage/Client/SDXL/toSharkUIOutput/first.ts
+++ b/src/features/TextToImage/Client/SDXL/toSharkUIOutput/first.ts
@@ -14,12 +14,12 @@ import type {
 } from '@/features/TextToImage/Pipeline';
 
 import {
-  toSharkUIOutput_Image_Description_all,
-} from './Image/Description/all';
+  toSharkUIOutput_Image,
+} from './Image';
 
 import {
-  toSharkUIOutput_Image,
-} from './Image/definition';
+  toSharkUIOutput_Image_Description_all,
+} from './Image/Description/all';
 
 const TextToImage_Pipeline_Output_Nullable_from = (
   givenImage: TextToImage_Pipeline_Output['image'] | null,

--- a/src/features/TextToImage/Client/SDXL/toSharkUIOutput/first.ts
+++ b/src/features/TextToImage/Client/SDXL/toSharkUIOutput/first.ts
@@ -6,7 +6,7 @@ import Attempt from '@/library/Attempt';
 
 import {
   hasAtLeastOne,
-} from '@/library/utilitiesByType/array/hasAtLeastOne';
+} from '@/library/utilitiesByType/array';
 
 import type {
   Input as TextToImage_Pipeline_Input,

--- a/src/features/TextToImage/Client/SDXL/toSharkUIOutput/first.ts
+++ b/src/features/TextToImage/Client/SDXL/toSharkUIOutput/first.ts
@@ -19,7 +19,7 @@ import {
 
 import {
   toSharkUIOutput_Image_Description_all,
-} from './Image/Description/all';
+} from './Image/Description';
 
 const TextToImage_Pipeline_Output_Nullable_from = (
   givenImage: TextToImage_Pipeline_Output['image'] | null,

--- a/src/features/TextToImage/Client/SDXL/toSharkUIOutput/index.ts
+++ b/src/features/TextToImage/Client/SDXL/toSharkUIOutput/index.ts
@@ -1,0 +1,1 @@
+export * from './exports.ts';

--- a/src/features/TextToImage/Pipeline/Output/Image.ts
+++ b/src/features/TextToImage/Pipeline/Output/Image.ts
@@ -1,4 +1,6 @@
-import type URI_Image from '@/library/UniformResourceIdentifier/Image';
+import type {
+  URI_Image,
+} from '@/library/UniformResourceIdentifier';
 
 interface TextToImage_Pipeline_Output_Image {
   uri: URI_Image;

--- a/src/library/Attempt/Adapted/to.ts
+++ b/src/library/Attempt/Adapted/to.ts
@@ -13,7 +13,7 @@ import type {
 
 import {
   safe,
-} from '../tryCatchStatements/safeAsync';
+} from '../tryCatchStatements';
 
 import type Attempt_Adapted_Config from './Config';
 

--- a/src/library/Attempt/Adapted/toSettle.ts
+++ b/src/library/Attempt/Adapted/toSettle.ts
@@ -13,7 +13,7 @@ import type {
 
 import {
   safeAsync,
-} from '../tryCatchStatements/safeAsync';
+} from '../tryCatchStatements';
 
 import type Attempt_Adapted_Config from './Config';
 

--- a/src/library/Attempt/Error/NonActionableBuiltInError/exports.ts
+++ b/src/library/Attempt/Error/NonActionableBuiltInError/exports.ts
@@ -1,0 +1,3 @@
+export {
+  default,
+} from './definition.ts';

--- a/src/library/Attempt/Error/NonActionableBuiltInError/index.ts
+++ b/src/library/Attempt/Error/NonActionableBuiltInError/index.ts
@@ -1,0 +1,3 @@
+export {
+  default,
+} from './exports.ts';

--- a/src/library/Attempt/Error/assertActionable.ts
+++ b/src/library/Attempt/Error/assertActionable.ts
@@ -8,7 +8,7 @@ import {
   default as Attempt_Error_NonActionable,
 } from './NonActionable';
 
-import NonActionableBuiltInError from './NonActionableBuiltInError/definition.ts';
+import NonActionableBuiltInError from './NonActionableBuiltInError';
 
 import {
   type AppropriatelyThrown,

--- a/src/library/Attempt/Fresh/that.ts
+++ b/src/library/Attempt/Fresh/that.ts
@@ -16,7 +16,7 @@ import {
 
 import {
   safe,
-} from '../tryCatchStatements/safeAsync';
+} from '../tryCatchStatements';
 
 type Attempt_End_Getter<
   SomeInferredOutcome extends Attempt_Outcome<unknown, Attempt_Error_Actionable<string>>,

--- a/src/library/Attempt/Fresh/thatEventually.ts
+++ b/src/library/Attempt/Fresh/thatEventually.ts
@@ -16,7 +16,7 @@ import {
 
 import {
   safeAsync,
-} from '../tryCatchStatements/safeAsync';
+} from '../tryCatchStatements';
 
 type Attempt_End_Retriever<
   SomeInferredOutcome extends Attempt_Outcome<unknown, Attempt_Error_Actionable<string>>,

--- a/src/library/Attempt/Outcome/Discriminable/definition.ts
+++ b/src/library/Attempt/Outcome/Discriminable/definition.ts
@@ -2,7 +2,7 @@ import type {
   Is,
   If,
   Not,
-} from '@/library/typeUtilities/boolean/Not';
+} from '@/library/typeUtilities/boolean';
 
 import type {
   Attempt_Error_Actionable,

--- a/src/library/Attempt/Outcome/Discriminable/exports.ts
+++ b/src/library/Attempt/Outcome/Discriminable/exports.ts
@@ -1,0 +1,1 @@
+export type * from './definition.ts';

--- a/src/library/Attempt/Outcome/Discriminable/index.ts
+++ b/src/library/Attempt/Outcome/Discriminable/index.ts
@@ -1,0 +1,1 @@
+export type * from './exports.ts';

--- a/src/library/Attempt/Outcome/Failure/dueTo.ts
+++ b/src/library/Attempt/Outcome/Failure/dueTo.ts
@@ -4,7 +4,7 @@ import type {
 
 import type {
   Attempt_Outcome_Discriminable,
-} from '../Discriminable/definition';
+} from '../Discriminable';
 
 import {
   type Attempt_Outcome_Failure_Transformer,

--- a/src/library/Attempt/Outcome/Success/thatYielded.ts
+++ b/src/library/Attempt/Outcome/Success/thatYielded.ts
@@ -1,6 +1,6 @@
 import type {
   Attempt_Outcome_Discriminable,
-} from '../Discriminable/definition';
+} from '../Discriminable';
 
 import {
   type Attempt_Outcome_Success_Transformer,

--- a/src/library/Attempt/tryCatchStatements/exports.ts
+++ b/src/library/Attempt/tryCatchStatements/exports.ts
@@ -1,0 +1,1 @@
+export * from './safeAsync';

--- a/src/library/Attempt/tryCatchStatements/index.ts
+++ b/src/library/Attempt/tryCatchStatements/index.ts
@@ -1,0 +1,1 @@
+export * from './exports.ts';

--- a/src/library/Attempt/tryCatchStatements/safeAsync.ts
+++ b/src/library/Attempt/tryCatchStatements/safeAsync.ts
@@ -1,6 +1,6 @@
 import {
   asError,
-} from '@/library/utilitiesByType/error/asError';
+} from '@/library/utilitiesByType/error';
 
 import {
   type AppropriatelyThrown,

--- a/src/library/ContentDescriptor/definition.ts
+++ b/src/library/ContentDescriptor/definition.ts
@@ -2,7 +2,7 @@ import NonTrivialString from '@/library/NonTrivialString';
 
 import {
   concatenated,
-} from '@/library/utilitiesByType/string/concatenated';
+} from '@/library/utilitiesByType/string';
 
 import type {
   ContentDescriptor_StructuredSyntaxNameSuffix,

--- a/src/library/NonTrivialString/definition.ts
+++ b/src/library/NonTrivialString/definition.ts
@@ -6,7 +6,7 @@ import {
   concatenated,
   isEmpty,
   type StringLike,
-} from '@/library/utilitiesByType/string/concatenated.ts';
+} from '@/library/utilitiesByType/string';
 
 import NonTrivialString_ParsingError from './ParsingError.ts';
 

--- a/src/library/Sequence/Byte/Encoded/Base64/definition.ts
+++ b/src/library/Sequence/Byte/Encoded/Base64/definition.ts
@@ -8,7 +8,7 @@ import StringSubset from '@/library/StringSubset';
 import {
   droppingLastCharacter,
   lastCharacterOf,
-} from '@/library/utilitiesByType/string/concatenated.ts';
+} from '@/library/utilitiesByType/string';
 
 import {
   Sequence_Base64,

--- a/src/library/ShimmedStabilityAIClient/SDXL/exports.ts
+++ b/src/library/ShimmedStabilityAIClient/SDXL/exports.ts
@@ -1,0 +1,3 @@
+export {
+  default as SDXL_DiffusionStepCount,
+} from './DiffusionStepCount';

--- a/src/library/ShimmedStabilityAIClient/SDXL/index.ts
+++ b/src/library/ShimmedStabilityAIClient/SDXL/index.ts
@@ -1,0 +1,1 @@
+export * from './exports.ts';

--- a/src/library/StringSubset.ts
+++ b/src/library/StringSubset.ts
@@ -5,7 +5,7 @@ import type {
 import {
   type StringLike,
   concatenated,
-} from '@/library/utilitiesByType/string/concatenated';
+} from '@/library/utilitiesByType/string';
 
 /**
  * When an open-ended `string` is too permissive, extend this class and provide a means to instantiate some subset

--- a/src/library/URLComponent/Origin/exports.ts
+++ b/src/library/URLComponent/Origin/exports.ts
@@ -1,0 +1,1 @@
+export * from './definition.ts';

--- a/src/library/URLComponent/Origin/index.ts
+++ b/src/library/URLComponent/Origin/index.ts
@@ -1,0 +1,1 @@
+export * from './exports.ts';

--- a/src/library/URLComponent/Path/exports.ts
+++ b/src/library/URLComponent/Path/exports.ts
@@ -1,0 +1,1 @@
+export * from './definition.ts';

--- a/src/library/URLComponent/Path/index.ts
+++ b/src/library/URLComponent/Path/index.ts
@@ -1,0 +1,1 @@
+export * from './exports.ts';

--- a/src/library/URLComponent/exports.ts
+++ b/src/library/URLComponent/exports.ts
@@ -1,2 +1,2 @@
-export * from './Origin/definition.ts';
+export * from './Origin';
 export * from './Path/definition.ts';

--- a/src/library/URLComponent/exports.ts
+++ b/src/library/URLComponent/exports.ts
@@ -1,2 +1,2 @@
 export * from './Origin';
-export * from './Path/definition.ts';
+export * from './Path';

--- a/src/library/UniformResourceIdentifier/definition.ts
+++ b/src/library/UniformResourceIdentifier/definition.ts
@@ -3,7 +3,7 @@ import type NonTrivialString from '@/library/NonTrivialString';
 
 import {
   concatenated,
-} from '@/library/utilitiesByType/string/concatenated';
+} from '@/library/utilitiesByType/string';
 
 /**
  * Identifies an abstract or physical resource.

--- a/src/library/UniformResourceIdentifier/exports.ts
+++ b/src/library/UniformResourceIdentifier/exports.ts
@@ -1,0 +1,3 @@
+export {
+  default as URI_Image,
+} from './Image';

--- a/src/library/UniformResourceIdentifier/index.ts
+++ b/src/library/UniformResourceIdentifier/index.ts
@@ -1,0 +1,1 @@
+export * from './exports.ts';

--- a/src/library/math/operator/constructive/absoluteValueOf/aliases/exports.ts
+++ b/src/library/math/operator/constructive/absoluteValueOf/aliases/exports.ts
@@ -1,0 +1,1 @@
+export * from './modulusOf';

--- a/src/library/math/operator/constructive/absoluteValueOf/aliases/index.ts
+++ b/src/library/math/operator/constructive/absoluteValueOf/aliases/index.ts
@@ -1,0 +1,1 @@
+export * from './exports.ts';

--- a/src/library/math/operator/constructive/absoluteValueOf/definition.test.ts
+++ b/src/library/math/operator/constructive/absoluteValueOf/definition.test.ts
@@ -12,7 +12,7 @@ import {
 
 import {
   absoluteValueOf,
-} from './aliases/modulusOf';
+} from './aliases';
 
 describe(absoluteValueOf, () => {
   const {

--- a/src/library/math/operator/constructive/absoluteValueOf/exports.ts
+++ b/src/library/math/operator/constructive/absoluteValueOf/exports.ts
@@ -1,0 +1,1 @@
+export * from './aliases';

--- a/src/library/math/operator/constructive/absoluteValueOf/index.ts
+++ b/src/library/math/operator/constructive/absoluteValueOf/index.ts
@@ -1,0 +1,1 @@
+export * from './exports.ts';

--- a/src/library/math/operator/constructive/exports.ts
+++ b/src/library/math/operator/constructive/exports.ts
@@ -1,6 +1,6 @@
 export * from './absoluteValueOf';
 
-export * from './greatestCommonDivisor/abbreviations/gcf';
+export * from './greatestCommonDivisor';
 
 export * from './leastCommonMultiple';
 

--- a/src/library/math/operator/constructive/exports.ts
+++ b/src/library/math/operator/constructive/exports.ts
@@ -1,4 +1,4 @@
-export * from './absoluteValueOf/aliases/modulusOf';
+export * from './absoluteValueOf';
 
 export * from './greatestCommonDivisor/abbreviations/gcf';
 

--- a/src/library/math/operator/constructive/greatestCommonDivisor/abbreviations/exports.ts
+++ b/src/library/math/operator/constructive/greatestCommonDivisor/abbreviations/exports.ts
@@ -1,0 +1,5 @@
+export {
+  default,
+} from './gcf';
+
+export * from './gcf';

--- a/src/library/math/operator/constructive/greatestCommonDivisor/abbreviations/gcf.ts
+++ b/src/library/math/operator/constructive/greatestCommonDivisor/abbreviations/gcf.ts
@@ -6,7 +6,7 @@ import {
 
 import {
   absoluteValueOf,
-} from '../../absoluteValueOf/aliases/modulusOf';
+} from '../../absoluteValueOf';
 
 const greatestCommonDivisor = (
   leftHandOperand: number,

--- a/src/library/math/operator/constructive/greatestCommonDivisor/abbreviations/index.ts
+++ b/src/library/math/operator/constructive/greatestCommonDivisor/abbreviations/index.ts
@@ -1,0 +1,5 @@
+export {
+  default,
+} from './exports.ts';
+
+export * from './exports.ts';

--- a/src/library/math/operator/constructive/greatestCommonDivisor/definition.test.ts
+++ b/src/library/math/operator/constructive/greatestCommonDivisor/definition.test.ts
@@ -14,7 +14,7 @@ import {
   squared,
 } from '../../hyper';
 
-import * as GCDAlias from './abbreviations/gcf';
+import * as GCDAlias from './abbreviations';
 
 const pairCombos = <
   SomeLeftElement extends number,

--- a/src/library/math/operator/constructive/greatestCommonDivisor/exports.ts
+++ b/src/library/math/operator/constructive/greatestCommonDivisor/exports.ts
@@ -1,0 +1,1 @@
+export * from './abbreviations';

--- a/src/library/math/operator/constructive/greatestCommonDivisor/index.ts
+++ b/src/library/math/operator/constructive/greatestCommonDivisor/index.ts
@@ -1,0 +1,1 @@
+export * from './exports.ts';

--- a/src/library/math/operator/constructive/leastCommonMultiple.ts
+++ b/src/library/math/operator/constructive/leastCommonMultiple.ts
@@ -1,6 +1,6 @@
 import {
   greatestCommonDivisor,
-} from './greatestCommonDivisor/abbreviations/gcf';
+} from './greatestCommonDivisor';
 
 const leastCommonMultiple = (
   a: number,

--- a/src/library/math/operator/predicate/exports.ts
+++ b/src/library/math/operator/predicate/exports.ts
@@ -4,4 +4,4 @@ export * from './isFinite';
 
 export * from './isNegative';
 
-export * from './isWhole/aliases/isInteger';
+export * from './isWhole';

--- a/src/library/math/operator/predicate/isWhole/aliases/exports.ts
+++ b/src/library/math/operator/predicate/isWhole/aliases/exports.ts
@@ -1,0 +1,1 @@
+export * from './isInteger';

--- a/src/library/math/operator/predicate/isWhole/aliases/index.ts
+++ b/src/library/math/operator/predicate/isWhole/aliases/index.ts
@@ -1,0 +1,1 @@
+export * from './exports.ts';

--- a/src/library/math/operator/predicate/isWhole/definition.test.ts
+++ b/src/library/math/operator/predicate/isWhole/definition.test.ts
@@ -12,7 +12,7 @@ import {
 
 import {
   isWhole,
-} from './aliases/isInteger';
+} from './aliases';
 
 describe(isWhole, () => {
   describe('the sad outcomes', () => {

--- a/src/library/math/operator/predicate/isWhole/exports.ts
+++ b/src/library/math/operator/predicate/isWhole/exports.ts
@@ -1,0 +1,1 @@
+export * from './aliases';

--- a/src/library/math/operator/predicate/isWhole/index.ts
+++ b/src/library/math/operator/predicate/isWhole/index.ts
@@ -1,0 +1,1 @@
+export * from './exports.ts';

--- a/src/library/modifiersByType/error/Contextualized/exports.ts
+++ b/src/library/modifiersByType/error/Contextualized/exports.ts
@@ -1,0 +1,3 @@
+export {
+  default,
+} from './definition.ts';

--- a/src/library/modifiersByType/error/Contextualized/index.ts
+++ b/src/library/modifiersByType/error/Contextualized/index.ts
@@ -1,0 +1,3 @@
+export {
+  default,
+} from './exports.ts';

--- a/src/library/modifiersByType/error/exports.ts
+++ b/src/library/modifiersByType/error/exports.ts
@@ -1,0 +1,3 @@
+export {
+  default as Contextualized,
+} from './Contextualized';

--- a/src/library/modifiersByType/error/index.ts
+++ b/src/library/modifiersByType/error/index.ts
@@ -1,0 +1,1 @@
+export * from './exports.ts';

--- a/src/library/typeUtilities/boolean/exports.ts
+++ b/src/library/typeUtilities/boolean/exports.ts
@@ -1,0 +1,1 @@
+export type * from './Not';

--- a/src/library/typeUtilities/boolean/index.ts
+++ b/src/library/typeUtilities/boolean/index.ts
@@ -1,0 +1,1 @@
+export type * from './exports.ts';

--- a/src/library/utilitiesByType/array/exports.ts
+++ b/src/library/utilitiesByType/array/exports.ts
@@ -1,0 +1,1 @@
+export * from './hasAtLeastOne';

--- a/src/library/utilitiesByType/array/index.ts
+++ b/src/library/utilitiesByType/array/index.ts
@@ -1,0 +1,1 @@
+export * from './exports.ts';

--- a/src/library/utilitiesByType/error/asError.ts
+++ b/src/library/utilitiesByType/error/asError.ts
@@ -1,6 +1,6 @@
 import {
   asString,
-} from '../string/concatenated';
+} from '../string';
 
 const isError = (givenSubject: unknown): givenSubject is Error => {
   return (givenSubject instanceof Error);

--- a/src/library/utilitiesByType/error/exports.ts
+++ b/src/library/utilitiesByType/error/exports.ts
@@ -1,0 +1,1 @@
+export * from './asError';

--- a/src/library/utilitiesByType/error/index.ts
+++ b/src/library/utilitiesByType/error/index.ts
@@ -1,0 +1,1 @@
+export * from './exports.ts';

--- a/src/library/utilitiesByType/string/exports.ts
+++ b/src/library/utilitiesByType/string/exports.ts
@@ -1,0 +1,1 @@
+export * from './concatenated';

--- a/src/library/utilitiesByType/string/index.ts
+++ b/src/library/utilitiesByType/string/index.ts
@@ -1,0 +1,1 @@
+export * from './exports.ts';

--- a/src/library/vue/composables/exports.ts
+++ b/src/library/vue/composables/exports.ts
@@ -1,0 +1,1 @@
+export * from './useStatefulAttemptThatEventually';

--- a/src/library/vue/composables/index.ts
+++ b/src/library/vue/composables/index.ts
@@ -1,0 +1,1 @@
+export * from './exports.ts';

--- a/src/library/vue/exports.ts
+++ b/src/library/vue/exports.ts
@@ -13,4 +13,4 @@ export {
   set,
 } from './reactivity';
 
-export * from './composables/useStatefulAttemptThatEventually';
+export * from './composables';

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,7 +4,7 @@ import {
 
 import {
   asError,
-} from '@/library/utilitiesByType/error/asError';
+} from '@/library/utilitiesByType/error';
 
 import App from '@/App.vue';
 import vuetify from '@/plugins/vuetify.ts';

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,7 +12,7 @@ import router from '@/router';
 
 import {
   Reporting_promptUserWith,
-} from '@/features/Reporting/promptUserWith';
+} from '@/features/Reporting';
 
 const app = createApp(App);
 app.use(router);

--- a/src/pages/TextToImagePage.vue
+++ b/src/pages/TextToImagePage.vue
@@ -26,7 +26,9 @@ import {
   VSkeletonLoader,
 } from 'vuetify/components/VSkeletonLoader';
 
-import SDXL_DiffusionStepCount from '@/library/ShimmedStabilityAIClient/SDXL/DiffusionStepCount';
+import {
+  SDXL_DiffusionStepCount,
+} from '@/library/ShimmedStabilityAIClient/SDXL';
 
 import DiscreteSlider from '@/components/DiscreteSlider.vue';
 import NavigationPanel from '@/components/NavigationPanel.vue';

--- a/src/utilities/Repository/exports.ts
+++ b/src/utilities/Repository/exports.ts
@@ -1,0 +1,3 @@
+export {
+  default,
+} from './definition.ts';

--- a/src/utilities/Repository/index.ts
+++ b/src/utilities/Repository/index.ts
@@ -1,0 +1,3 @@
+export {
+  default,
+} from './exports.ts';


### PR DESCRIPTION
- consumers should not have to reach into internal modules to import something that's meant to be exposed
- these changes are pervasive but simple with only two ideas presented:
  - "exports.ts" and "index.ts" files are added where needed
  - imports are updated to route through the "index" rather than reaching into submodule via the path

Follows up on #847