### PR TITLE
refactor: adds missing re-exports

### DIFF
--- a/src/components/DiscreteSlider.vue
+++ b/src/components/DiscreteSlider.vue
@@ -17,7 +17,10 @@ import {
 } from 'vuetify/components/VSlider';
 
 import type Range from '@/library/Range';
-import Range_Discrete from '@/library/Range/Discrete';
+
+import {
+  Range_Discrete,
+} from '@/library/Range';
 
 import {
   shallowlyMerged,

--- a/src/features/TextToImage/Client/SDXL/toSharkUIOutput/Image/exports.ts
+++ b/src/features/TextToImage/Client/SDXL/toSharkUIOutput/Image/exports.ts
@@ -1,1 +1,3 @@
 export * from './definition.ts';
+
+export * from './Description';

--- a/src/features/TextToImage/Client/SDXL/toSharkUIOutput/first.ts
+++ b/src/features/TextToImage/Client/SDXL/toSharkUIOutput/first.ts
@@ -15,11 +15,8 @@ import type {
 
 import {
   toSharkUIOutput_Image,
-} from './Image';
-
-import {
   toSharkUIOutput_Image_Description_all,
-} from './Image/Description';
+} from './Image';
 
 const TextToImage_Pipeline_Output_Nullable_from = (
   givenImage: TextToImage_Pipeline_Output['image'] | null,

--- a/src/library/Attempt/Error/Actionable.ts
+++ b/src/library/Attempt/Error/Actionable.ts
@@ -1,6 +1,6 @@
 import type {
   Branded,
-} from '@/library/typeUtilities/Branded';
+} from '@/library/typeUtilities';
 
 import {
   default as Attempt_Error_NonActionable,

--- a/src/library/Attempt/Error/NonActionable.ts
+++ b/src/library/Attempt/Error/NonActionable.ts
@@ -1,6 +1,6 @@
 import type {
   Branded,
-} from '@/library/typeUtilities/Branded';
+} from '@/library/typeUtilities';
 
 interface Attempt_Error_NonActionable_Options
   extends ErrorOptions {

--- a/src/library/Attempt/Error/NonActionableBuiltInError/definition.ts
+++ b/src/library/Attempt/Error/NonActionableBuiltInError/definition.ts
@@ -1,6 +1,6 @@
 import type {
   Branded,
-} from '@/library/typeUtilities/Branded';
+} from '@/library/typeUtilities';
 
 // These augmentations allow TypeScript to distinguish these error types from `Error` at the annotation level.
 declare global {

--- a/src/library/Attempt/Error/exports.ts
+++ b/src/library/Attempt/Error/exports.ts
@@ -3,6 +3,10 @@ export {
 } from './NonActionable';
 
 export {
+  default as Attempt_Error_Creation,
+} from './Creation';
+
+export {
   default as Attempt_Error_Actionable,
 } from './Actionable';
 

--- a/src/library/Attempt/Error/exports.ts
+++ b/src/library/Attempt/Error/exports.ts
@@ -13,3 +13,5 @@ export {
 export type {
   default as Attempt_Error_Interpreter,
 } from './Interpreter';
+
+export * from './modifier';

--- a/src/library/Attempt/Fresh/that.ts
+++ b/src/library/Attempt/Fresh/that.ts
@@ -1,8 +1,7 @@
-import type {
-  Attempt_Error_Actionable,
+import {
+  type Attempt_Error_Actionable,
+  Attempt_Error_Creation,
 } from '../Error';
-
-import Attempt_Error_Creation from '../Error/Creation';
 
 import type {
   Attempt_Outcome,

--- a/src/library/Attempt/Fresh/thatEventually.ts
+++ b/src/library/Attempt/Fresh/thatEventually.ts
@@ -1,8 +1,7 @@
-import type {
-  Attempt_Error_Actionable,
+import {
+  type Attempt_Error_Actionable,
+  Attempt_Error_Creation,
 } from '../Error';
-
-import Attempt_Error_Creation from '../Error/Creation';
 
 import type {
   Attempt_Outcome,

--- a/src/library/Attempt/Outcome/Discriminable/definition.ts
+++ b/src/library/Attempt/Outcome/Discriminable/definition.ts
@@ -2,7 +2,7 @@ import type {
   Is,
   If,
   Not,
-} from '@/library/typeUtilities/boolean';
+} from '@/library/typeUtilities';
 
 import type {
   Attempt_Error_Actionable,

--- a/src/library/Attempt/tryCatchStatements/safeAsync.ts
+++ b/src/library/Attempt/tryCatchStatements/safeAsync.ts
@@ -5,7 +5,7 @@ import {
 import {
   type AppropriatelyThrown,
   AppropriatelyThrown_assume,
-} from '../Error/modifier';
+} from '../Error';
 
 const safe = <
   SomeTryBlockOutput,

--- a/src/library/Parser/Static.ts
+++ b/src/library/Parser/Static.ts
@@ -1,5 +1,8 @@
 import type ParsingError from '@/library/ParsingError';
-import type Static from '@/library/typeUtilities/Static';
+
+import type {
+  Static,
+} from '@/library/typeUtilities';
 
 import type {
   Parser,

--- a/src/library/Range/exports.ts
+++ b/src/library/Range/exports.ts
@@ -1,3 +1,7 @@
 export {
   Range,
 } from './definitionWithAugmentation.ts';
+
+export {
+  default as Range_Discrete,
+} from './Discrete';

--- a/src/library/Range/index.ts
+++ b/src/library/Range/index.ts
@@ -1,3 +1,4 @@
 export {
   Range as default,
+  Range_Discrete,
 } from './exports.ts';

--- a/src/library/ShimmedStabilityAIClient/SDXL/DiffusionStepCount.ts
+++ b/src/library/ShimmedStabilityAIClient/SDXL/DiffusionStepCount.ts
@@ -1,4 +1,6 @@
-import Range_Discrete from '@/library/Range/Discrete';
+import {
+  Range_Discrete,
+} from '@/library/Range';
 
 /**
  * Sourced from the [StabilityAI OpenAPI spec](https://github.com/nod-ai/StabilityAI-client-typescript/blob/HEAD/openapi.json)

--- a/src/library/ShimmedStabilityAIClient/exports.ts
+++ b/src/library/ShimmedStabilityAIClient/exports.ts
@@ -1,3 +1,5 @@
 export {
   ShimmedStabilityAIClient,
 } from './definition.ts';
+
+export * from './SDXL';

--- a/src/library/ShimmedStabilityAIClient/index.ts
+++ b/src/library/ShimmedStabilityAIClient/index.ts
@@ -1,3 +1,4 @@
 export {
   ShimmedStabilityAIClient as default,
+  SDXL_DiffusionStepCount,
 } from './exports.ts';

--- a/src/library/StringSubset.ts
+++ b/src/library/StringSubset.ts
@@ -1,6 +1,6 @@
 import type {
   Branded,
-} from '@/library/typeUtilities/Branded';
+} from '@/library/typeUtilities';
 
 import {
   type StringLike,

--- a/src/library/typeUtilities/exports.ts
+++ b/src/library/typeUtilities/exports.ts
@@ -5,3 +5,5 @@ export type * from './Batched';
 export type {
   default as Static,
 } from './Static';
+
+export type * from './Branded';

--- a/src/library/typeUtilities/exports.ts
+++ b/src/library/typeUtilities/exports.ts
@@ -1,1 +1,5 @@
 export type * from './Batched';
+
+export type {
+  default as Static,
+} from './Static';

--- a/src/library/typeUtilities/exports.ts
+++ b/src/library/typeUtilities/exports.ts
@@ -1,3 +1,5 @@
+export type * from './boolean';
+
 export type * from './Batched';
 
 export type {

--- a/src/pages/TextToImagePage.vue
+++ b/src/pages/TextToImagePage.vue
@@ -28,7 +28,7 @@ import {
 
 import {
   SDXL_DiffusionStepCount,
-} from '@/library/ShimmedStabilityAIClient/SDXL';
+} from '@/library/ShimmedStabilityAIClient';
 
 import DiscreteSlider from '@/components/DiscreteSlider.vue';
 import NavigationPanel from '@/components/NavigationPanel.vue';


### PR DESCRIPTION
- similar to #854, but the barrel files already exist and just need additional entries