### PR TITLE
refactor: bans importing of internal modules

### DIFF
--- a/eslint.import.ts
+++ b/eslint.import.ts
@@ -43,6 +43,18 @@ const extendedConfig: ConfigWithExtends = {
         noUselessIndex: true, // Avoids noise in diffs from converting single-file modules <-> directory modules
       },
     ],
+    'import/no-internal-modules': [
+      'error',
+      {
+        allow: [
+          '**/*.vue', // .vue files must be imported directly for bundler to enable type-safety
+          '[a-z]*/**', // matches packages
+          '@/*/*', // matches src modules
+          '@/library/modifiersByType/*', // bag of tools where consumer must pick a type
+          '@/library/utilitiesByType/*', // bag of tools where consumer must pick a type
+        ],
+      },
+    ],
     'import/order': [
       'error',
       {

--- a/src/features/TextToImage/Client/SDXL/generateOutputFrom.ts
+++ b/src/features/TextToImage/Client/SDXL/generateOutputFrom.ts
@@ -8,7 +8,7 @@ import ShimmedStabilityAIClient from '@/library/ShimmedStabilityAIClient';
 
 import type {
   Output as TextToImage_Pipeline_Output,
-} from '@/features/TextToImage/Pipeline';
+} from '@/features/TextToImage/Pipeline'; // eslint-disable-line import/no-internal-modules -- more concise than relative import
 
 import * as TextToImage_Server from '../../Server';
 

--- a/src/features/TextToImage/Client/SDXL/toSharkUIOutput/Image/Description/all.ts
+++ b/src/features/TextToImage/Client/SDXL/toSharkUIOutput/Image/Description/all.ts
@@ -4,7 +4,7 @@ import type {
 
 import type {
   Output as TextToImage_Pipeline_Output,
-} from '@/features/TextToImage/Pipeline';
+} from '@/features/TextToImage/Pipeline'; // eslint-disable-line import/no-internal-modules -- more concise than relative import
 
 const isDefault = (
   givenWeight: TextPrompt['weight'],

--- a/src/features/TextToImage/Client/SDXL/toSharkUIOutput/Image/definition.ts
+++ b/src/features/TextToImage/Client/SDXL/toSharkUIOutput/Image/definition.ts
@@ -8,7 +8,7 @@ import {
 
 import type {
   Output as TextToImage_Pipeline_Output,
-} from '@/features/TextToImage/Pipeline';
+} from '@/features/TextToImage/Pipeline'; // eslint-disable-line import/no-internal-modules -- more concise than relative import
 
 const toSharkUIOutput_Image = (
   givenImage: StabilityAIClient.Image,

--- a/src/features/TextToImage/Client/SDXL/toSharkUIOutput/first.ts
+++ b/src/features/TextToImage/Client/SDXL/toSharkUIOutput/first.ts
@@ -11,7 +11,7 @@ import {
 import type {
   Input as TextToImage_Pipeline_Input,
   Output as TextToImage_Pipeline_Output,
-} from '@/features/TextToImage/Pipeline';
+} from '@/features/TextToImage/Pipeline'; // eslint-disable-line import/no-internal-modules -- more concise than relative import
 
 import {
   toSharkUIOutput_Image,

--- a/src/features/TextToImage/Config/Dynamic/fetch.ts
+++ b/src/features/TextToImage/Config/Dynamic/fetch.ts
@@ -15,7 +15,7 @@ import {
 
 import type {
   TextToImage_Config_Dynamic_Fetching_Error,
-} from './Fetching/Error';
+} from './Fetching/Error'; // eslint-disable-line import/no-internal-modules -- will be deleted once usage is extracted
 
 const TextToImage_Config_Dynamic_endpoint = URLComponent_Path.parsedFrom('/config/text-to-image').forciblyUnwrap();
 

--- a/src/features/TextToImage/Config/Static/read.ts
+++ b/src/features/TextToImage/Config/Static/read.ts
@@ -12,7 +12,7 @@ import {
   TextToImage_Config_Static_Reading,
 } from './Reading';
 
-import type TextToImage_Config_Static_Reading_Error from './Reading/Error';
+import type TextToImage_Config_Static_Reading_Error from './Reading/Error'; // eslint-disable-line import/no-internal-modules -- will be deleted once usage is extracted
 
 const TextToImage_Config_Static_file = URLComponent_Path.parsedFrom('/config/text-to-image.json').forciblyUnwrap();
 

--- a/src/library/Attempt/Adapted/Config.ts
+++ b/src/library/Attempt/Adapted/Config.ts
@@ -1,8 +1,7 @@
 import type {
   Attempt_Error_Actionable,
+  Attempt_Error_Interpreter,
 } from '../Error';
-
-import type Attempt_Error_Interpreter from '../Error/Interpreter';
 
 interface Attempt_Adapted_Config<
   SomeActionableError extends Attempt_Error_Actionable<string>,

--- a/src/library/Attempt/Outcome/Transformer.ts
+++ b/src/library/Attempt/Outcome/Transformer.ts
@@ -4,11 +4,11 @@ import type {
 
 import type {
   Attempt_Outcome_Failure_Transformer,
-} from './Failure/Transformer';
+} from './Failure';
 
 import type {
   Attempt_Outcome_Success_Transformer,
-} from './Success/Transformer';
+} from './Success';
 
 type Attempt_Outcome_Transformer<
   SomeTransformableProduct,

--- a/src/library/math/operator/hyper/rank3/squared.test.ts
+++ b/src/library/math/operator/hyper/rank3/squared.test.ts
@@ -8,7 +8,7 @@ import Attempt from '@/library/Attempt';
 
 import {
   numberTaxonomy,
-} from '@/library/math/numberTaxonomy';
+} from '@/library/math/numberTaxonomy'; // eslint-disable-line import/no-internal-modules -- more concise than relative import
 
 import {
   squared,


### PR DESCRIPTION
- With a few exceptions, importing an internal module is usually indicative of a module interface that can be greatly improved.
- Suggested course of action is to explicitly define what should be exposed to external modules via the relevant "exports" file