### PR TITLE
refactor(utilities/Repository): avoids unnecessary declaration in "Issue/definition.ts"

### DIFF
--- a/src/utilities/Repository/Issue/definition.ts
+++ b/src/utilities/Repository/Issue/definition.ts
@@ -2,18 +2,16 @@ import type {
   Repository_Issue_Label,
 } from './Label';
 
-type Repository_Issue_Category =
-  | 'Feature'
-  | 'Bug'
-  | 'Task'
-;
-
 interface Repository_Issue {
   title: string;
   body: string;
   labels: Repository_Issue_Label[];
   /** a.k.a. "type" */
-  category: Repository_Issue_Category;
+  category:
+    | 'Feature'
+    | 'Bug'
+    | 'Task'
+  ;
 }
 
 export type {


### PR DESCRIPTION
- prefers using `Repository_Issue['category']` to access the type