### PR TITLE
refactor(text-to-image): avoids unnecessary simulation of module aliases

### DIFF
--- a/src/features/TextToImage/Client/SDXL/generateOutputFrom.ts
+++ b/src/features/TextToImage/Client/SDXL/generateOutputFrom.ts
@@ -73,10 +73,6 @@ const TextToImage_Client_SDXL_generateOutputFrom = async (
   return outcomeOfSettlingSoleTextToImageOutput;
 };
 
-const TextToImage_Client_SDXL = {
-  generateOutputFrom: TextToImage_Client_SDXL_generateOutputFrom,
-};
-
 export {
-  TextToImage_Client_SDXL,
+  TextToImage_Client_SDXL_generateOutputFrom as generateOutputFrom,
 };

--- a/src/features/TextToImage/Client/SDXL/index.ts
+++ b/src/features/TextToImage/Client/SDXL/index.ts
@@ -1,3 +1,5 @@
+import * as TextToImage_Client_SDXL from './exports.ts';
+
 export {
   TextToImage_Client_SDXL as default,
-} from './exports.ts';
+};


### PR DESCRIPTION
- object literals are preferred only when the constituent members are concise enough to warrant packing into the same unit