### PR TITLE
ci(dependabot): whitelists @vitest/eslint-plugin for non-major bumps

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -44,6 +44,7 @@ jobs:
               "@stylistic/eslint-plugin",
               "@typescript-eslint/parser",
               "@types/node",
+              "@vitest/eslint-plugin",
               "cypress",
               "eslint",
               "eslint-plugin-cypress",


### PR DESCRIPTION
Uses same rationale as #622