### PR TITLE
docs(IDE): adds "vitest" to dictionary

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,6 +3,7 @@
         "SDXL",
         "stabilityai",
         "vite",
+        "vitest",
         "vuetify"
     ],
     "cSpell.customDictionaries": {


### PR DESCRIPTION
- [vitest](http://vitest.dev/) is used to write unit tests in this codebase