### PR TITLE
linter: migrates from `tseslint.config` to `defineConfig`

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -4,11 +4,14 @@ import {
   vueTsConfigs as VueTSConfig,
 } from '@vue/eslint-config-typescript';
 
+import {
+  defineConfig,
+} from 'eslint/config';
+
 import pluginVue from 'eslint-plugin-vue';
 
-import {
-  config,
-  type ConfigWithExtends,
+import type {
+  ConfigWithExtends,
 } from 'typescript-eslint';
 
 import pluginCypress from './cypress/eslint.config';
@@ -128,8 +131,9 @@ const configWithVueTS = defineConfigWithVueTs(
   ...pluginCypress,
 );
 
-const completeConfig = config([
+const completeConfig = defineConfig([
   {
+    // @ts-expect-error: according to bullet "2." under https://typescript-eslint.io/packages/typescript-eslint/#migrating-to-defineconfig
     extends: configWithVueTS,
     ignores: [
       '**/*.md',

--- a/eslint.markdown.ts
+++ b/eslint.markdown.ts
@@ -1,10 +1,10 @@
 import markdown from '@eslint/markdown';
 
 import type {
-  ConfigWithExtends,
-} from 'typescript-eslint';
+  Linter,
+} from 'eslint';
 
-const pluginMarkdown: ConfigWithExtends[] = [
+const pluginMarkdown: Linter.Config[] = [
   ...markdown.configs.recommended,
   {
     language: 'markdown/gfm',


### PR DESCRIPTION
Unblocks #915