### PR TITLE
refactor: avoids passthrough re-exports

### DIFF
--- a/src/features/TextToImage/Config/Dynamic/exports.ts
+++ b/src/features/TextToImage/Config/Dynamic/exports.ts
@@ -1,1 +1,9 @@
+export {
+  TextToImage_Config_Dynamic_endpoint as endpoint,
+} from './endpoint';
+
 export * from './fetch';
+
+export {
+  TextToImage_Config_Dynamic_Fetching as Fetching,
+} from './Fetching';

--- a/src/features/TextToImage/Config/Dynamic/fetch.ts
+++ b/src/features/TextToImage/Config/Dynamic/fetch.ts
@@ -38,7 +38,5 @@ const TextToImage_Config_Dynamic_fetch = (): Promise<
 });
 
 export {
-  TextToImage_Config_Dynamic_endpoint as endpoint,
   TextToImage_Config_Dynamic_fetch as fetch,
-  TextToImage_Config_Dynamic_Fetching as Fetching,
 };

--- a/src/features/TextToImage/Config/Static/exports.ts
+++ b/src/features/TextToImage/Config/Static/exports.ts
@@ -1,1 +1,9 @@
+export {
+  TextToImage_Config_Static_file as file,
+} from './file';
+
 export * from './read';
+
+export {
+  TextToImage_Config_Static_Reading as Reading,
+} from './Reading';

--- a/src/features/TextToImage/Config/Static/read.ts
+++ b/src/features/TextToImage/Config/Static/read.ts
@@ -27,7 +27,5 @@ const TextToImage_Config_Static_read = (): Promise<
 });
 
 export {
-  TextToImage_Config_Static_file as file,
   TextToImage_Config_Static_read as read,
-  TextToImage_Config_Static_Reading as Reading,
 };

--- a/src/features/TextToImage/Server/Current/exports.ts
+++ b/src/features/TextToImage/Server/Current/exports.ts
@@ -1,1 +1,9 @@
+export {
+  TextToImage_Server_Error as Error,
+} from '../Error';
+
+export {
+  TextToImage_Server_Current_accordingToEnvironment as Current_accordingToEnvironment,
+} from './accordingToEnvironment';
+
 export * from './retrieve';

--- a/src/features/TextToImage/Server/Current/retrieve.ts
+++ b/src/features/TextToImage/Server/Current/retrieve.ts
@@ -54,7 +54,5 @@ const TextToImage_Server_Current_retrieve = (): Promise<
 });
 
 export {
-  TextToImage_Server_Current_accordingToEnvironment as Current_accordingToEnvironment,
   TextToImage_Server_Current_retrieve as Current_retrieve,
-  TextToImage_Server_Error as Error,
 };

--- a/src/library/Attempt/Adapted/exports.ts
+++ b/src/library/Attempt/Adapted/exports.ts
@@ -2,8 +2,9 @@ export {
   Attempt_Adapted_to,
 } from './to';
 
+export * from './toEventually';
+
 export {
-  Attempt_Adapted_toEventually,
   Attempt_Adapted_toSettle,
 } from './toSettle';
 

--- a/src/library/Attempt/Adapted/toSettle.ts
+++ b/src/library/Attempt/Adapted/toSettle.ts
@@ -29,6 +29,5 @@ const Attempt_Adapted_toSettle = async <
 };
 
 export {
-  Attempt_Adapted_toEventually,
   Attempt_Adapted_toSettle,
 };

--- a/src/library/Attempt/Fresh/exports.ts
+++ b/src/library/Attempt/Fresh/exports.ts
@@ -1,2 +1,4 @@
+export type * from '../End';
+
 export * from './that';
 export * from './thatEventually';

--- a/src/library/Attempt/Fresh/that.ts
+++ b/src/library/Attempt/Fresh/that.ts
@@ -42,6 +42,5 @@ const Attempt_Fresh_that = <
 };
 
 export {
-  type Attempt_End_Getter,
   Attempt_Fresh_that,
 };

--- a/src/library/Attempt/Fresh/thatEventually.ts
+++ b/src/library/Attempt/Fresh/thatEventually.ts
@@ -42,6 +42,5 @@ const Attempt_Fresh_thatEventually = async <
 };
 
 export {
-  type Attempt_End_Retriever,
   Attempt_Fresh_thatEventually,
 };

--- a/src/library/Attempt/Outcome/Failure/Cause/Transformer/exports.ts
+++ b/src/library/Attempt/Outcome/Failure/Cause/Transformer/exports.ts
@@ -1,1 +1,3 @@
+export type * from './definition.ts';
+
 export * from './identity';

--- a/src/library/Attempt/Outcome/Failure/Cause/Transformer/identity.ts
+++ b/src/library/Attempt/Outcome/Failure/Cause/Transformer/identity.ts
@@ -2,10 +2,6 @@ import type {
   Attempt_Error_Actionable,
 } from '@/library/Attempt/Error'; // eslint-disable-line import/no-internal-modules -- avoids lengthy relative paths
 
-import type {
-  Attempt_Outcome_Failure_Cause_Transformer,
-} from './definition.ts';
-
 const Attempt_Outcome_Failure_Cause_Transformer_identity = <
   SomeTransformableActionableError extends Attempt_Error_Actionable<string>,
   SomeTransformedActionableError extends Attempt_Error_Actionable<string>,
@@ -16,6 +12,5 @@ const Attempt_Outcome_Failure_Cause_Transformer_identity = <
 };
 
 export {
-  type Attempt_Outcome_Failure_Cause_Transformer,
-  /**/ Attempt_Outcome_Failure_Cause_Transformer_identity,
+  Attempt_Outcome_Failure_Cause_Transformer_identity,
 };

--- a/src/library/Attempt/Outcome/Failure/Transformer.ts
+++ b/src/library/Attempt/Outcome/Failure/Transformer.ts
@@ -2,9 +2,8 @@ import type {
   Attempt_Error_Actionable,
 } from '../../Error';
 
-import {
-  type Attempt_Outcome_Failure_Cause_Transformer,
-  /**/ Attempt_Outcome_Failure_Cause_Transformer_identity,
+import type {
+  Attempt_Outcome_Failure_Cause_Transformer,
 } from './Cause';
 
 interface Attempt_Outcome_Failure_Transformer<
@@ -17,7 +16,6 @@ interface Attempt_Outcome_Failure_Transformer<
   >;
 }
 
-export {
-  type Attempt_Outcome_Failure_Transformer,
-  Attempt_Outcome_Failure_Cause_Transformer_identity,
+export type {
+  Attempt_Outcome_Failure_Transformer,
 };

--- a/src/library/Attempt/Outcome/Failure/dueTo.ts
+++ b/src/library/Attempt/Outcome/Failure/dueTo.ts
@@ -7,10 +7,6 @@ import {
 } from './Cause';
 
 import type {
-  Attempt_Outcome_Failure_Transformer,
-} from './Transformer';
-
-import type {
   Attempt_Outcome_Failure,
 } from './definition.ts';
 
@@ -45,8 +41,5 @@ const Attempt_Outcome_Failure_dueTo = <
 });
 
 export {
-  type Attempt_Outcome_Failure,
-  type Attempt_Outcome_Failure_Transformer,
   Attempt_Outcome_Failure_dueTo,
-  Attempt_Outcome_Failure_Cause_Transformer_identity,
 };

--- a/src/library/Attempt/Outcome/Failure/dueTo.ts
+++ b/src/library/Attempt/Outcome/Failure/dueTo.ts
@@ -3,8 +3,11 @@ import type {
 } from '../../Error';
 
 import {
-  type Attempt_Outcome_Failure_Transformer,
   Attempt_Outcome_Failure_Cause_Transformer_identity,
+} from './Cause';
+
+import type {
+  Attempt_Outcome_Failure_Transformer,
 } from './Transformer';
 
 import type {

--- a/src/library/Attempt/Outcome/Failure/exports.ts
+++ b/src/library/Attempt/Outcome/Failure/exports.ts
@@ -1,1 +1,7 @@
+export type * from './definition.ts';
+
+export * from './Cause';
+
+export type * from './Transformer';
+
 export * from './dueTo';

--- a/src/library/Attempt/Outcome/Success/Product/Transformer/exports.ts
+++ b/src/library/Attempt/Outcome/Success/Product/Transformer/exports.ts
@@ -1,1 +1,3 @@
+export type * from './definition.ts';
+
 export * from './identity';

--- a/src/library/Attempt/Outcome/Success/Product/Transformer/identity.ts
+++ b/src/library/Attempt/Outcome/Success/Product/Transformer/identity.ts
@@ -1,7 +1,3 @@
-import type {
-  Attempt_Outcome_Success_Product_Transformer,
-} from './definition.ts';
-
 const Attempt_Outcome_Success_Product_Transformer_identity = <
   SomeTransformableProduct,
   SomeTransformedProduct,
@@ -12,6 +8,5 @@ const Attempt_Outcome_Success_Product_Transformer_identity = <
 };
 
 export {
-  type Attempt_Outcome_Success_Product_Transformer,
-  /**/ Attempt_Outcome_Success_Product_Transformer_identity,
+  Attempt_Outcome_Success_Product_Transformer_identity,
 };

--- a/src/library/Attempt/Outcome/Success/Transformer.ts
+++ b/src/library/Attempt/Outcome/Success/Transformer.ts
@@ -1,6 +1,5 @@
-import {
-  type Attempt_Outcome_Success_Product_Transformer,
-  Attempt_Outcome_Success_Product_Transformer_identity,
+import type {
+  Attempt_Outcome_Success_Product_Transformer,
 } from './Product';
 
 interface Attempt_Outcome_Success_Transformer<
@@ -13,7 +12,6 @@ interface Attempt_Outcome_Success_Transformer<
   >;
 }
 
-export {
-  type Attempt_Outcome_Success_Transformer,
-  Attempt_Outcome_Success_Product_Transformer_identity,
+export type {
+  Attempt_Outcome_Success_Transformer,
 };

--- a/src/library/Attempt/Outcome/Success/exports.ts
+++ b/src/library/Attempt/Outcome/Success/exports.ts
@@ -1,1 +1,7 @@
+export type * from './definition.ts';
+
+export * from './Product';
+
+export type * from './Transformer';
+
 export * from './thatYielded';

--- a/src/library/Attempt/Outcome/Success/thatYielded.ts
+++ b/src/library/Attempt/Outcome/Success/thatYielded.ts
@@ -3,10 +3,6 @@ import {
 } from './Product';
 
 import type {
-  Attempt_Outcome_Success_Transformer,
-} from './Transformer';
-
-import type {
   Attempt_Outcome_Success,
 } from './definition.ts';
 
@@ -41,8 +37,5 @@ const Attempt_Outcome_Success_thatYielded = <
 });
 
 export {
-  type Attempt_Outcome_Success,
-  type Attempt_Outcome_Success_Transformer,
   Attempt_Outcome_Success_thatYielded,
-  Attempt_Outcome_Success_Product_Transformer_identity,
 };

--- a/src/library/Attempt/Outcome/Success/thatYielded.ts
+++ b/src/library/Attempt/Outcome/Success/thatYielded.ts
@@ -1,6 +1,9 @@
 import {
-  type Attempt_Outcome_Success_Transformer,
   Attempt_Outcome_Success_Product_Transformer_identity,
+} from './Product';
+
+import type {
+  Attempt_Outcome_Success_Transformer,
 } from './Transformer';
 
 import type {

--- a/src/library/Attempt/Outcome/definition.ts
+++ b/src/library/Attempt/Outcome/definition.ts
@@ -16,11 +16,6 @@ import {
   Attempt_Outcome_fromRewrapping,
 } from './fromRewrapping';
 
-import type {
-  CauseOf,
-  ProductOf,
-} from './typeParameters';
-
 type Attempt_Outcome<
   SomeProduct,
   SomeActionableError extends Attempt_Error_Actionable<string>,
@@ -37,8 +32,4 @@ const Attempt_Outcome = {
 
 export {
   Attempt_Outcome,
-  type Attempt_Outcome_Success,
-  type Attempt_Outcome_Failure,
-  type ProductOf,
-  type CauseOf,
 };

--- a/src/library/Attempt/Outcome/exports.ts
+++ b/src/library/Attempt/Outcome/exports.ts
@@ -1,1 +1,7 @@
 export * from './definition.ts';
+
+export * from './Success';
+
+export * from './Failure';
+
+export type * from './typeParameters';

--- a/src/library/Attempt/Outcome/typeParameters/CauseOf.ts
+++ b/src/library/Attempt/Outcome/typeParameters/CauseOf.ts
@@ -3,8 +3,11 @@ import type {
 } from '../../Error';
 
 import type {
-  Attempt_Outcome,
   Attempt_Outcome_Failure,
+} from '../Failure';
+
+import type {
+  Attempt_Outcome,
 } from '../definition.ts';
 
 type CauseOf<

--- a/src/library/Attempt/Outcome/typeParameters/ProductOf.ts
+++ b/src/library/Attempt/Outcome/typeParameters/ProductOf.ts
@@ -3,8 +3,11 @@ import type {
 } from '../../Error';
 
 import type {
-  Attempt_Outcome,
   Attempt_Outcome_Success,
+} from '../Success';
+
+import type {
+  Attempt_Outcome,
 } from '../definition.ts';
 
 type ProductOf<

--- a/src/library/Attempt/tryCatchStatements/exports.ts
+++ b/src/library/Attempt/tryCatchStatements/exports.ts
@@ -1,1 +1,3 @@
+export * from './safe';
+
 export * from './safeAsync';

--- a/src/library/Attempt/tryCatchStatements/safeAsync.ts
+++ b/src/library/Attempt/tryCatchStatements/safeAsync.ts
@@ -31,6 +31,5 @@ const safeAsync = async <
 };
 
 export {
-  safe,
   safeAsync,
 };

--- a/src/library/Sequence/Base64/Conformance/ensure.ts
+++ b/src/library/Sequence/Base64/Conformance/ensure.ts
@@ -21,5 +21,4 @@ const Sequence_Base64_Conformance_ensure = (
 
 export {
   Sequence_Base64_Conformance_ensure as ensure,
-  Sequence_Base64_Conformance_Error as Error,
 };

--- a/src/library/Sequence/Base64/Conformance/exports.ts
+++ b/src/library/Sequence/Base64/Conformance/exports.ts
@@ -1,1 +1,5 @@
 export * from './ensure';
+
+export {
+  default as Error,
+} from './Error';

--- a/src/library/Sequence/Byte/Encoded/Compatibility/ensure.ts
+++ b/src/library/Sequence/Byte/Encoded/Compatibility/ensure.ts
@@ -24,6 +24,5 @@ const Sequence_Byte_Encoded_Compatibility_ensure = (
 });
 
 export {
-  Sequence_Byte_Encoded_Compatibility_Error as Error,
   Sequence_Byte_Encoded_Compatibility_ensure as ensure,
 };

--- a/src/library/Sequence/Byte/Encoded/Compatibility/exports.ts
+++ b/src/library/Sequence/Byte/Encoded/Compatibility/exports.ts
@@ -1,1 +1,5 @@
 export * from './ensure';
+
+export {
+  default as Error,
+} from './Error';

--- a/src/library/URLComponent/Origin/definition.ts
+++ b/src/library/URLComponent/Origin/definition.ts
@@ -37,5 +37,4 @@ class URLComponent_Origin
 
 export {
   URLComponent_Origin,
-  URLComponent_Origin_ParsingError,
 };

--- a/src/library/URLComponent/Origin/exports.ts
+++ b/src/library/URLComponent/Origin/exports.ts
@@ -1,1 +1,3 @@
 export * from './definition.ts';
+
+export * from './ParsingError';

--- a/src/library/URLComponent/Path/definition.ts
+++ b/src/library/URLComponent/Path/definition.ts
@@ -37,5 +37,4 @@ class URLComponent_Path
 
 export {
   URLComponent_Path,
-  URLComponent_Path_ParsingError,
 };

--- a/src/library/URLComponent/Path/exports.ts
+++ b/src/library/URLComponent/Path/exports.ts
@@ -1,1 +1,3 @@
 export * from './definition.ts';
+
+export * from './ParsingError';

--- a/src/library/math/operator/constructive/absoluteValueOf/aliases/exports.ts
+++ b/src/library/math/operator/constructive/absoluteValueOf/aliases/exports.ts
@@ -1,1 +1,5 @@
+export * from '../definition.ts';
+
+export * from './unsigned';
+
 export * from './modulusOf';

--- a/src/library/math/operator/constructive/absoluteValueOf/aliases/modulusOf.ts
+++ b/src/library/math/operator/constructive/absoluteValueOf/aliases/modulusOf.ts
@@ -2,15 +2,9 @@ import {
   absoluteValueOf,
 } from '../definition.ts';
 
-import {
-  unsigned,
-} from './unsigned.ts';
-
 /** Alias for {@link absoluteValueOf} */
 const modulusOf = absoluteValueOf;
 
 export {
-  absoluteValueOf,
   modulusOf,
-  unsigned,
 };

--- a/src/library/math/operator/constructive/greatestCommonDivisor/abbreviations/exports.ts
+++ b/src/library/math/operator/constructive/greatestCommonDivisor/abbreviations/exports.ts
@@ -1,5 +1,10 @@
 export {
-  default,
-} from './gcf';
+  greatestCommonDivisor as default,
+  greatestCommonDivisor,
+} from '../definition.ts';
+
+export * from '../aliases';
+
+export * from './gcd';
 
 export * from './gcf';

--- a/src/library/math/operator/constructive/greatestCommonDivisor/abbreviations/gcf.ts
+++ b/src/library/math/operator/constructive/greatestCommonDivisor/abbreviations/gcf.ts
@@ -1,26 +1,10 @@
 import {
   greatestCommonFactor,
-  highestCommonDivisor,
-  highestCommonFactor,
 } from '../aliases';
-
-import {
-  greatestCommonDivisor,
-} from '../definition.ts';
-
-import {
-  gcd,
-} from './gcd';
 
 /** Abbreviation for {@link greatestCommonFactor} */
 const gcf = greatestCommonFactor;
 
 export {
-  greatestCommonDivisor as default,
-  greatestCommonDivisor,
-  greatestCommonFactor,
-  highestCommonDivisor,
-  highestCommonFactor,
-  gcd,
   gcf,
 };

--- a/src/library/math/operator/constructive/greatestCommonDivisor/aliases/exports.ts
+++ b/src/library/math/operator/constructive/greatestCommonDivisor/aliases/exports.ts
@@ -1,1 +1,5 @@
+export * from './greatestCommonFactor';
+
+export * from './highestCommonDivisor';
+
 export * from './highestCommonFactor';

--- a/src/library/math/operator/constructive/greatestCommonDivisor/aliases/highestCommonFactor.ts
+++ b/src/library/math/operator/constructive/greatestCommonDivisor/aliases/highestCommonFactor.ts
@@ -2,19 +2,9 @@ import {
   greatestCommonDivisor,
 } from '../definition.ts';
 
-import {
-  greatestCommonFactor,
-} from './greatestCommonFactor';
-
-import {
-  highestCommonDivisor,
-} from './highestCommonDivisor';
-
 /** Alias for {@link greatestCommonDivisor} */
 const highestCommonFactor = greatestCommonDivisor;
 
 export {
-  greatestCommonFactor,
-  highestCommonDivisor,
   highestCommonFactor,
 };

--- a/src/library/math/operator/predicate/isWhole/aliases/exports.ts
+++ b/src/library/math/operator/predicate/isWhole/aliases/exports.ts
@@ -1,1 +1,3 @@
+export * from '../definition.ts';
+
 export * from './isInteger';

--- a/src/library/math/operator/predicate/isWhole/aliases/isInteger.ts
+++ b/src/library/math/operator/predicate/isWhole/aliases/isInteger.ts
@@ -6,6 +6,5 @@ import {
 const isInteger = isWhole;
 
 export {
-  isWhole,
   isInteger,
 };

--- a/src/library/typeUtilities/boolean/Not.ts
+++ b/src/library/typeUtilities/boolean/Not.ts
@@ -1,11 +1,3 @@
-import type {
-  If,
-} from './If';
-
-import type {
-  Is,
-} from './Is';
-
 type Not<
   SomeBoolean extends boolean,
 > = SomeBoolean extends true
@@ -13,7 +5,5 @@ type Not<
   : true;
 
 export type {
-  Is,
-  If,
   Not,
 };

--- a/src/library/typeUtilities/boolean/exports.ts
+++ b/src/library/typeUtilities/boolean/exports.ts
@@ -1,1 +1,5 @@
+export type * from './If';
+
+export type * from './Is';
+
 export type * from './Not';

--- a/src/library/utilitiesByType/array/exports.ts
+++ b/src/library/utilitiesByType/array/exports.ts
@@ -1,1 +1,3 @@
+export * from './isEmpty';
+
 export * from './hasAtLeastOne';

--- a/src/library/utilitiesByType/array/hasAtLeastOne.ts
+++ b/src/library/utilitiesByType/array/hasAtLeastOne.ts
@@ -9,6 +9,5 @@ const hasAtLeastOne = <SomeElement>(
 };
 
 export {
-  isEmpty,
   hasAtLeastOne,
 };

--- a/src/library/utilitiesByType/error/asError.ts
+++ b/src/library/utilitiesByType/error/asError.ts
@@ -17,6 +17,5 @@ const asError = (givenSubject: unknown): Error => {
 };
 
 export {
-  isError,
   asError,
 };

--- a/src/library/utilitiesByType/error/exports.ts
+++ b/src/library/utilitiesByType/error/exports.ts
@@ -1,1 +1,3 @@
+export * from './isError';
+
 export * from './asError';

--- a/src/library/utilitiesByType/string/character/droppingLastCharacter.ts
+++ b/src/library/utilitiesByType/string/character/droppingLastCharacter.ts
@@ -1,12 +1,7 @@
-import {
-  lastCharacterOf,
-} from './lastCharacterOf';
-
 const droppingLastCharacter = (givenCharacters: string): string => {
   return givenCharacters.substring(0, givenCharacters.length - 1);
 };
 
 export {
-  lastCharacterOf,
   droppingLastCharacter,
 };

--- a/src/library/utilitiesByType/string/character/exports.ts
+++ b/src/library/utilitiesByType/string/character/exports.ts
@@ -1,1 +1,3 @@
+export * from './lastCharacterOf';
+
 export * from './droppingLastCharacter';

--- a/src/library/utilitiesByType/string/concatenated.ts
+++ b/src/library/utilitiesByType/string/concatenated.ts
@@ -2,25 +2,6 @@ import type {
   StringLike,
 } from './StringLike';
 
-import {
-  asString,
-} from './asString';
-
-import {
-  lastCharacterOf,
-  droppingLastCharacter,
-} from './character';
-
-import {
-  emptyString,
-  type EmptyString,
-  isEmpty,
-} from './empty';
-
-import {
-  isString,
-} from './isString';
-
 const concatenated = (
   ...givenOperands: (StringLike | null)[]
 ): string => {
@@ -30,13 +11,5 @@ const concatenated = (
 };
 
 export {
-  isString,
-  asString,
-  emptyString,
-  type EmptyString,
-  isEmpty,
-  lastCharacterOf,
-  droppingLastCharacter,
-  type StringLike,
   concatenated,
 };

--- a/src/library/utilitiesByType/string/empty/exports.ts
+++ b/src/library/utilitiesByType/string/empty/exports.ts
@@ -1,1 +1,5 @@
+export * from './instance';
+
+export type * from './type';
+
 export * from './predicate';

--- a/src/library/utilitiesByType/string/empty/predicate.ts
+++ b/src/library/utilitiesByType/string/empty/predicate.ts
@@ -13,7 +13,5 @@ const isEmpty = (
 };
 
 export {
-  emptyString,
-  type EmptyString,
   isEmpty,
 };

--- a/src/library/utilitiesByType/string/exports.ts
+++ b/src/library/utilitiesByType/string/exports.ts
@@ -1,1 +1,11 @@
+export type * from './StringLike';
+
+export * from './isString';
+
+export * from './asString';
+
+export * from './empty';
+
+export * from './character';
+
 export * from './concatenated';


### PR DESCRIPTION
- modules that represent a single unit should not be responsible for exposing their peers.
- peers should be exposed through the "exports" file so they can be properly tested and regulated