### PR TITLE
refactor: avoids pibling re-exports in "exports" files

### DIFF
--- a/src/features/TextToImage/Server/Current/exports.ts
+++ b/src/features/TextToImage/Server/Current/exports.ts
@@ -1,8 +1,4 @@
 export {
-  TextToImage_Server_Error as Error,
-} from '../Error';
-
-export {
   TextToImage_Server_Current_accordingToEnvironment as Current_accordingToEnvironment,
 } from './accordingToEnvironment';
 

--- a/src/features/TextToImage/Server/exports.ts
+++ b/src/features/TextToImage/Server/exports.ts
@@ -1,1 +1,5 @@
 export * from './Current';
+
+export {
+  TextToImage_Server_Error as Error,
+} from './Error';

--- a/src/library/Attempt/Fresh/exports.ts
+++ b/src/library/Attempt/Fresh/exports.ts
@@ -1,4 +1,2 @@
-export type * from '../End';
-
 export * from './that';
 export * from './thatEventually';

--- a/src/library/Attempt/exports.ts
+++ b/src/library/Attempt/exports.ts
@@ -24,10 +24,13 @@ export {
 export {
   Attempt_Fresh_that as Fresh_that,
   Attempt_Fresh_thatEventually as Fresh_thatEventually,
-  type Attempt_End_Getter as End_Getter,
-  type Attempt_End_Retriever as End_Retriever,
 } from './Fresh';
 
 export type {
   Attempt_Progressive as Progressive,
 } from './Progressive';
+
+export type {
+  Attempt_End_Getter as End_Getter,
+  Attempt_End_Retriever as End_Retriever,
+} from './End';

--- a/src/library/math/operator/constructive/absoluteValueOf/aliases/exports.ts
+++ b/src/library/math/operator/constructive/absoluteValueOf/aliases/exports.ts
@@ -1,5 +1,3 @@
-export * from '../definition.ts';
-
 export * from './unsigned';
 
 export * from './modulusOf';

--- a/src/library/math/operator/constructive/absoluteValueOf/definition.test.ts
+++ b/src/library/math/operator/constructive/absoluteValueOf/definition.test.ts
@@ -12,7 +12,7 @@ import {
 
 import {
   absoluteValueOf,
-} from './aliases';
+} from './definition.ts';
 
 describe(absoluteValueOf, () => {
   const {

--- a/src/library/math/operator/constructive/absoluteValueOf/exports.ts
+++ b/src/library/math/operator/constructive/absoluteValueOf/exports.ts
@@ -1,1 +1,3 @@
+export * from './definition.ts';
+
 export * from './aliases';

--- a/src/library/math/operator/constructive/greatestCommonDivisor/abbreviations/exports.ts
+++ b/src/library/math/operator/constructive/greatestCommonDivisor/abbreviations/exports.ts
@@ -1,9 +1,3 @@
-export {
-  greatestCommonDivisor,
-} from '../definition.ts';
-
-export * from '../aliases';
-
 export * from './gcd';
 
 export * from './gcf';

--- a/src/library/math/operator/constructive/greatestCommonDivisor/exports.ts
+++ b/src/library/math/operator/constructive/greatestCommonDivisor/exports.ts
@@ -1,1 +1,5 @@
+export * from './definition.ts';
+
+export * from './aliases';
+
 export * from './abbreviations';

--- a/src/library/math/operator/predicate/isWhole/aliases/exports.ts
+++ b/src/library/math/operator/predicate/isWhole/aliases/exports.ts
@@ -1,3 +1,1 @@
-export * from '../definition.ts';
-
 export * from './isInteger';

--- a/src/library/math/operator/predicate/isWhole/definition.test.ts
+++ b/src/library/math/operator/predicate/isWhole/definition.test.ts
@@ -12,7 +12,7 @@ import {
 
 import {
   isWhole,
-} from './aliases';
+} from './definition.ts';
 
 describe(isWhole, () => {
   describe('the sad outcomes', () => {

--- a/src/library/math/operator/predicate/isWhole/exports.ts
+++ b/src/library/math/operator/predicate/isWhole/exports.ts
@@ -1,1 +1,3 @@
+export * from './definition.ts';
+
 export * from './aliases';


### PR DESCRIPTION
- "exports" files are only supposed to define exposure for their peers
- parent- or child-adjacent files should be managed by the "exports" file at that same level in the file hierarchy