### PR TITLE
refactor: reveals named re-exports for all object-oriented exports

### DIFF
--- a/src/features/Reporting/exports.ts
+++ b/src/features/Reporting/exports.ts
@@ -1,1 +1,3 @@
-export * from './promptUserWith';
+export {
+  Reporting_promptUserWith,
+} from './promptUserWith';

--- a/src/features/TextToImage/Client/SDXL/exports.ts
+++ b/src/features/TextToImage/Client/SDXL/exports.ts
@@ -1,1 +1,3 @@
-export * from './generateOutputFrom';
+export {
+  generateOutputFrom,
+} from './generateOutputFrom';

--- a/src/features/TextToImage/Client/SDXL/toSharkUIOutput/Image/Description/exports.ts
+++ b/src/features/TextToImage/Client/SDXL/toSharkUIOutput/Image/Description/exports.ts
@@ -1,3 +1,7 @@
-export * from './singular';
+export {
+  toSharkUIOutput_Image_Description_singular,
+} from './singular';
 
-export * from './all';
+export {
+  toSharkUIOutput_Image_Description_all,
+} from './all';

--- a/src/features/TextToImage/Client/SDXL/toSharkUIOutput/exports.ts
+++ b/src/features/TextToImage/Client/SDXL/toSharkUIOutput/exports.ts
@@ -1,3 +1,7 @@
-export * from './plural';
+export {
+  toSharkUIOutput_plural,
+} from './plural';
 
-export * from './first';
+export {
+  toSharkUIOutput_first,
+} from './first';

--- a/src/features/TextToImage/Config/Dynamic/exports.ts
+++ b/src/features/TextToImage/Config/Dynamic/exports.ts
@@ -2,7 +2,9 @@ export {
   TextToImage_Config_Dynamic_endpoint as endpoint,
 } from './endpoint';
 
-export * from './fetch';
+export {
+  fetch,
+} from './fetch';
 
 export {
   TextToImage_Config_Dynamic_Fetching as Fetching,

--- a/src/features/TextToImage/Config/Static/exports.ts
+++ b/src/features/TextToImage/Config/Static/exports.ts
@@ -2,7 +2,9 @@ export {
   TextToImage_Config_Static_file as file,
 } from './file';
 
-export * from './read';
+export {
+  read,
+} from './read';
 
 export {
   TextToImage_Config_Static_Reading as Reading,

--- a/src/features/TextToImage/Config/exports.ts
+++ b/src/features/TextToImage/Config/exports.ts
@@ -1,3 +1,5 @@
 export * as Config_Dynamic from './Dynamic';
 export * as Config_Static from './Static';
-export * from './empty';
+export {
+  TextToImage_Config_empty,
+} from './empty';

--- a/src/features/TextToImage/Pipeline/Output/Nullable/exports.ts
+++ b/src/features/TextToImage/Pipeline/Output/Nullable/exports.ts
@@ -1,1 +1,3 @@
-export * from './from';
+export {
+  TextToImage_Pipeline_Output_Nullable_from,
+} from './from';

--- a/src/features/TextToImage/Server/Current/exports.ts
+++ b/src/features/TextToImage/Server/Current/exports.ts
@@ -2,4 +2,6 @@ export {
   TextToImage_Server_Current_accordingToEnvironment as Current_accordingToEnvironment,
 } from './accordingToEnvironment';
 
-export * from './retrieve';
+export {
+  Current_retrieve,
+} from './retrieve';

--- a/src/features/TextToImage/Server/exports.ts
+++ b/src/features/TextToImage/Server/exports.ts
@@ -1,4 +1,7 @@
-export * from './Current';
+export {
+  Current_accordingToEnvironment,
+  Current_retrieve,
+} from './Current';
 
 export {
   TextToImage_Server_Error as Error,

--- a/src/features/TextToImage/exports.ts
+++ b/src/features/TextToImage/exports.ts
@@ -2,4 +2,8 @@ export * as Client from './Client';
 
 export * as Server from './Server';
 
-export type * from './Pipeline';
+export type {
+  Input,
+  Output,
+  Output_Nullable_from,
+} from './Pipeline';

--- a/src/library/Attempt/Adapted/exports.ts
+++ b/src/library/Attempt/Adapted/exports.ts
@@ -2,7 +2,9 @@ export {
   Attempt_Adapted_to,
 } from './to';
 
-export * from './toEventually';
+export {
+  Attempt_Adapted_toEventually,
+} from './toEventually';
 
 export {
   Attempt_Adapted_toSettle,

--- a/src/library/Attempt/End/exports.ts
+++ b/src/library/Attempt/End/exports.ts
@@ -1,3 +1,7 @@
-export type * from './Getter';
+export type {
+  Attempt_End_Getter,
+} from './Getter';
 
-export type * from './Retriever';
+export type {
+  Attempt_End_Retriever,
+} from './Retriever';

--- a/src/library/Attempt/Fresh/exports.ts
+++ b/src/library/Attempt/Fresh/exports.ts
@@ -1,2 +1,6 @@
-export * from './that';
-export * from './thatEventually';
+export {
+  Attempt_Fresh_that,
+} from './that';
+export {
+  Attempt_Fresh_thatEventually,
+} from './thatEventually';

--- a/src/library/Attempt/Outcome/Failure/Cause/exports.ts
+++ b/src/library/Attempt/Outcome/Failure/Cause/exports.ts
@@ -1,1 +1,4 @@
-export * from './Transformer';
+export {
+  type Attempt_Outcome_Failure_Cause_Transformer,
+  Attempt_Outcome_Failure_Cause_Transformer_identity,
+} from './Transformer';

--- a/src/library/Attempt/Outcome/Success/Product/exports.ts
+++ b/src/library/Attempt/Outcome/Success/Product/exports.ts
@@ -1,1 +1,4 @@
-export * from './Transformer';
+export {
+  type Attempt_Outcome_Success_Product_Transformer,
+  Attempt_Outcome_Success_Product_Transformer_identity,
+} from './Transformer';

--- a/src/library/Sequence/Base64/Conformance/exports.ts
+++ b/src/library/Sequence/Base64/Conformance/exports.ts
@@ -1,4 +1,6 @@
-export * from './ensure';
+export {
+  ensure,
+} from './ensure';
 
 export {
   default as Error,

--- a/src/library/Sequence/Byte/Encoded/Compatibility/exports.ts
+++ b/src/library/Sequence/Byte/Encoded/Compatibility/exports.ts
@@ -1,4 +1,6 @@
-export * from './ensure';
+export {
+  ensure,
+} from './ensure';
 
 export {
   default as Error,

--- a/src/library/URLComponent/exports.ts
+++ b/src/library/URLComponent/exports.ts
@@ -1,2 +1,8 @@
-export * from './Origin';
-export * from './Path';
+export {
+  URLComponent_Origin,
+  URLComponent_Origin_ParsingError,
+} from './Origin';
+export {
+  URLComponent_Path,
+  URLComponent_Path_ParsingError,
+} from './Path';


### PR DESCRIPTION
- ensures all the sites are prepped for alias standardization