### PR TITLE
refactor: converts all internal default imports to named equivalents

### DIFF
--- a/src/features/TextToImage/Pipeline/Output/definition.ts
+++ b/src/features/TextToImage/Pipeline/Output/definition.ts
@@ -1,4 +1,6 @@
-import type TextToImage_Pipeline_Output_Image from './Image';
+import type {
+  default as TextToImage_Pipeline_Output_Image,
+} from './Image';
 
 /** The resulting information after a text-to-image model has ingested some input with some configuration */
 interface TextToImage_Pipeline_Output {

--- a/src/library/Attempt/Adapted/to.ts
+++ b/src/library/Attempt/Adapted/to.ts
@@ -15,7 +15,9 @@ import {
   safe,
 } from '../tryCatchStatements';
 
-import type Attempt_Adapted_Config from './Config';
+import type {
+  default as Attempt_Adapted_Config,
+} from './Config';
 
 const Attempt_Adapted_to = <
   SomeProduct,

--- a/src/library/Attempt/Adapted/toSettle.ts
+++ b/src/library/Attempt/Adapted/toSettle.ts
@@ -6,7 +6,9 @@ import type {
   Attempt_Outcome,
 } from '../Outcome';
 
-import type Attempt_Adapted_Config from './Config';
+import type {
+  default as Attempt_Adapted_Config,
+} from './Config';
 
 import {
   Attempt_Adapted_toEventually,

--- a/src/library/Attempt/Error/Creation.ts
+++ b/src/library/Attempt/Error/Creation.ts
@@ -1,4 +1,6 @@
-import Attempt_Error_NonActionable from './NonActionable';
+import {
+  default as Attempt_Error_NonActionable,
+} from './NonActionable';
 
 class Attempt_Error_Creation
   extends Attempt_Error_NonActionable {

--- a/src/library/Attempt/Error/Interpreter.ts
+++ b/src/library/Attempt/Error/Interpreter.ts
@@ -1,4 +1,6 @@
-import type Attempt_Error_Actionable from './Actionable';
+import type {
+  default as Attempt_Error_Actionable,
+} from './Actionable';
 
 import type {
   PotentiallyActionable,

--- a/src/library/Attempt/Error/assertActionable.ts
+++ b/src/library/Attempt/Error/assertActionable.ts
@@ -2,13 +2,17 @@ import type {
   default as Attempt_Error_Actionable,
 } from './Actionable';
 
-import type Attempt_Error_Interpreter from './Interpreter';
+import type {
+  default as Attempt_Error_Interpreter,
+} from './Interpreter';
 
 import {
   default as Attempt_Error_NonActionable,
 } from './NonActionable';
 
-import NonActionableBuiltInError from './NonActionableBuiltInError';
+import {
+  default as NonActionableBuiltInError,
+} from './NonActionableBuiltInError';
 
 import {
   type AppropriatelyThrown,

--- a/src/library/Attempt/Error/modifier/AppropriatelyThrown/definition.ts
+++ b/src/library/Attempt/Error/modifier/AppropriatelyThrown/definition.ts
@@ -1,4 +1,6 @@
-import type Attempt_Error_Actionable from '../../Actionable';
+import type {
+  default as Attempt_Error_Actionable,
+} from '../../Actionable';
 
 type AppropriatelyThrown<
   SomeError extends Error,

--- a/src/library/Attempt/Error/modifier/PotentiallyActionable/assume.ts
+++ b/src/library/Attempt/Error/modifier/PotentiallyActionable/assume.ts
@@ -1,4 +1,6 @@
-import Attempt_Error_Creation from '../../Creation';
+import {
+  default as Attempt_Error_Creation,
+} from '../../Creation';
 
 import {
   default as Attempt_Error_NonActionable,

--- a/src/library/Attempt/Error/modifier/PotentiallyActionable/definition.ts
+++ b/src/library/Attempt/Error/modifier/PotentiallyActionable/definition.ts
@@ -1,4 +1,6 @@
-import type Attempt_Error_NonActionable from '../../NonActionable';
+import type {
+  default as Attempt_Error_NonActionable,
+} from '../../NonActionable';
 
 type PotentiallyActionable<
   SomeError extends Error,

--- a/src/library/NonTrivialString/definition.ts
+++ b/src/library/NonTrivialString/definition.ts
@@ -8,7 +8,9 @@ import {
   type StringLike,
 } from '@/library/utilitiesByType/string';
 
-import NonTrivialString_ParsingError from './ParsingError.ts';
+import {
+  default as NonTrivialString_ParsingError,
+} from './ParsingError.ts';
 
 class NonTrivialString
   extends StringSubset<

--- a/src/library/Sequence/Base64/Conformance/ensure.ts
+++ b/src/library/Sequence/Base64/Conformance/ensure.ts
@@ -4,7 +4,9 @@ import {
   Sequence_Base64_pattern,
 } from '../pattern';
 
-import Sequence_Base64_Conformance_Error from './Error';
+import {
+  default as Sequence_Base64_Conformance_Error,
+} from './Error';
 
 const Sequence_Base64_Conformance_ensure = (
   givenCharacterSequence: string,

--- a/src/library/Sequence/Byte/Encoded/Base64/definition.ts
+++ b/src/library/Sequence/Byte/Encoded/Base64/definition.ts
@@ -18,7 +18,9 @@ import {
   Sequence_Byte_Encoded_Compatibility,
 } from '../Compatibility';
 
-import Sequence_Byte_Encoded_Base64_ParsingError from './ParsingError.ts';
+import {
+  default as Sequence_Byte_Encoded_Base64_ParsingError,
+} from './ParsingError.ts';
 
 /** See [RFC 4648 Section 4](https://www.rfc-editor.org/rfc/rfc4648.html#section-4) for more information */
 class Sequence_Byte_Encoded_Base64

--- a/src/library/Sequence/Byte/Encoded/Compatibility/ensure.ts
+++ b/src/library/Sequence/Byte/Encoded/Compatibility/ensure.ts
@@ -1,7 +1,9 @@
 import Attempt from '@/library/Attempt';
 import Byte from '@/library/Byte';
 
-import Sequence_Byte_Encoded_Compatibility_Error from './Error';
+import {
+  default as Sequence_Byte_Encoded_Compatibility_Error,
+} from './Error';
 
 const Sequence_Byte_Encoded_Compatibility_ensure = (
   givenSequence: string,

--- a/src/library/ShimmedStabilityAIClient/Version1/Image.ts
+++ b/src/library/ShimmedStabilityAIClient/Version1/Image.ts
@@ -10,7 +10,9 @@ import type {
 import HTTP from '@/library/HTTP';
 import Shortfin from '@/library/Shortfin';
 
-import toShortfinRequestBody from '../toShortfinRequestBody';
+import {
+  default as toShortfinRequestBody,
+} from '../toShortfinRequestBody';
 
 class ShimmedStabilityAIClient_Version1_Image
   extends HTTP.Client {

--- a/src/library/WebAPI/exports.ts
+++ b/src/library/WebAPI/exports.ts
@@ -1,4 +1,6 @@
-import WebAPI_Server from './Server.ts';
+import {
+  default as WebAPI_Server,
+} from './Server.ts';
 
 export {
   WebAPI_Server as Server,

--- a/src/library/modifiersByType/error/Contextualized/assume.ts
+++ b/src/library/modifiersByType/error/Contextualized/assume.ts
@@ -4,7 +4,9 @@ import type {
   Instantiable,
 } from '@/library/typeUtilities';
 
-import type Contextualized from './definition.ts';
+import type {
+  default as Contextualized,
+} from './definition.ts';
 
 import {
   Contextualized_describes,

--- a/src/library/modifiersByType/error/Contextualized/cast.ts
+++ b/src/library/modifiersByType/error/Contextualized/cast.ts
@@ -6,7 +6,9 @@ import {
   Contextualized_assume,
 } from './assume';
 
-import type Contextualized from './definition.ts';
+import type {
+  default as Contextualized,
+} from './definition.ts';
 
 import {
   Contextualized_describes,

--- a/src/library/modifiersByType/error/Contextualized/describes.ts
+++ b/src/library/modifiersByType/error/Contextualized/describes.ts
@@ -2,7 +2,9 @@ import type {
   Instantiable,
 } from '@/library/typeUtilities';
 
-import type Contextualized from './definition.ts';
+import type {
+  default as Contextualized,
+} from './definition.ts';
 
 const Contextualized_describes = <
   SomeError extends Error,


### PR DESCRIPTION
- preps sites to switch to non-default named exports only