### PR TITLE
refactor: highlights `default` interfaces for all submodules

### DIFF
--- a/src/features/TextToImage/Client/SDXL/index.ts
+++ b/src/features/TextToImage/Client/SDXL/index.ts
@@ -1,5 +1,5 @@
 import * as TextToImage_Client_SDXL from './exports.ts';
 
 export {
-  TextToImage_Client_SDXL as default,
+  TextToImage_Client_SDXL as _default,
 };

--- a/src/features/TextToImage/Client/exports.ts
+++ b/src/features/TextToImage/Client/exports.ts
@@ -1,3 +1,3 @@
 export {
-  default as SDXL,
+  _default as SDXL,
 } from './SDXL';

--- a/src/features/TextToImage/Config/Dynamic/Fetching/Error/Any.ts
+++ b/src/features/TextToImage/Config/Dynamic/Fetching/Error/Any.ts
@@ -1,9 +1,9 @@
 import type {
-  default as TextToImage_Config_Dynamic_Fetching_Error_Request,
+  _default as TextToImage_Config_Dynamic_Fetching_Error_Request,
 } from './Request';
 
 import type {
-  default as TextToImage_Config_Dynamic_Fetching_Error_Response,
+  _default as TextToImage_Config_Dynamic_Fetching_Error_Response,
 } from './Response';
 
 type TextToImage_Config_Dynamic_Fetching_Error_Any =

--- a/src/features/TextToImage/Config/Dynamic/Fetching/Error/Request.ts
+++ b/src/features/TextToImage/Config/Dynamic/Fetching/Error/Request.ts
@@ -18,5 +18,5 @@ class TextToImage_Config_Dynamic_Fetching_Error_Request
 }
 
 export {
-  TextToImage_Config_Dynamic_Fetching_Error_Request as default,
+  TextToImage_Config_Dynamic_Fetching_Error_Request as _default,
 };

--- a/src/features/TextToImage/Config/Dynamic/Fetching/Error/Response.ts
+++ b/src/features/TextToImage/Config/Dynamic/Fetching/Error/Response.ts
@@ -19,5 +19,5 @@ class TextToImage_Config_Dynamic_Fetching_Error_Response
 }
 
 export {
-  TextToImage_Config_Dynamic_Fetching_Error_Response as default,
+  TextToImage_Config_Dynamic_Fetching_Error_Response as _default,
 };

--- a/src/features/TextToImage/Config/Dynamic/Fetching/Error/exports.ts
+++ b/src/features/TextToImage/Config/Dynamic/Fetching/Error/exports.ts
@@ -1,9 +1,9 @@
 export {
-  default as Request,
+  _default as Request,
 } from './Request';
 
 export {
-  default as Response,
+  _default as Response,
 } from './Response';
 
 export type {

--- a/src/features/TextToImage/Config/Static/Reading/Error.ts
+++ b/src/features/TextToImage/Config/Static/Reading/Error.ts
@@ -19,5 +19,5 @@ class TextToImage_Config_Static_Reading_Error
 }
 
 export {
-  TextToImage_Config_Static_Reading_Error as default,
+  TextToImage_Config_Static_Reading_Error as _default,
 };

--- a/src/features/TextToImage/Config/Static/Reading/Outcome.ts
+++ b/src/features/TextToImage/Config/Static/Reading/Outcome.ts
@@ -5,7 +5,7 @@ import type {
 } from '../../definition.ts';
 
 import type {
-  default as TextToImage_Config_Static_Reading_Error,
+  _default as TextToImage_Config_Static_Reading_Error,
 } from './Error';
 
 type TextToImage_Config_Static_Reading_Outcome = Attempt.Outcome<

--- a/src/features/TextToImage/Config/Static/Reading/exports.ts
+++ b/src/features/TextToImage/Config/Static/Reading/exports.ts
@@ -1,5 +1,5 @@
 export {
-  default as Error,
+  _default as Error,
 } from './Error';
 
 export type {

--- a/src/features/TextToImage/Pipeline/Output/Image.ts
+++ b/src/features/TextToImage/Pipeline/Output/Image.ts
@@ -8,5 +8,5 @@ interface TextToImage_Pipeline_Output_Image {
 }
 
 export type {
-  TextToImage_Pipeline_Output_Image as default,
+  TextToImage_Pipeline_Output_Image as _default,
 };

--- a/src/features/TextToImage/Pipeline/Output/definition.ts
+++ b/src/features/TextToImage/Pipeline/Output/definition.ts
@@ -1,5 +1,5 @@
 import type {
-  default as TextToImage_Pipeline_Output_Image,
+  _default as TextToImage_Pipeline_Output_Image,
 } from './Image';
 
 /** The resulting information after a text-to-image model has ingested some input with some configuration */

--- a/src/features/TextToImage/Server/Error/Any.ts
+++ b/src/features/TextToImage/Server/Error/Any.ts
@@ -1,9 +1,9 @@
 import type {
-  default as TextToImage_Server_Error_Connection,
+  _default as TextToImage_Server_Error_Connection,
 } from './Connection';
 
 import type {
-  default as TextToImage_Server_Error_Specification,
+  _default as TextToImage_Server_Error_Specification,
 } from './Specification';
 
 type TextToImage_Server_Error_Any =

--- a/src/features/TextToImage/Server/Error/Connection.ts
+++ b/src/features/TextToImage/Server/Error/Connection.ts
@@ -14,5 +14,5 @@ class TextToImage_Server_Error_Connection
 }
 
 export {
-  TextToImage_Server_Error_Connection as default,
+  TextToImage_Server_Error_Connection as _default,
 };

--- a/src/features/TextToImage/Server/Error/Specification.ts
+++ b/src/features/TextToImage/Server/Error/Specification.ts
@@ -20,5 +20,5 @@ class TextToImage_Server_Error_Specification
 }
 
 export {
-  TextToImage_Server_Error_Specification as default,
+  TextToImage_Server_Error_Specification as _default,
 };

--- a/src/features/TextToImage/Server/Error/exports.ts
+++ b/src/features/TextToImage/Server/Error/exports.ts
@@ -1,9 +1,9 @@
 export {
-  default as Specification,
+  _default as Specification,
 } from './Specification';
 
 export {
-  default as Connection,
+  _default as Connection,
 } from './Connection';
 
 export type {

--- a/src/library/Attempt/Adapted/Config.ts
+++ b/src/library/Attempt/Adapted/Config.ts
@@ -10,5 +10,5 @@ interface Attempt_Adapted_Config<
 }
 
 export type {
-  Attempt_Adapted_Config as default,
+  Attempt_Adapted_Config as _default,
 };

--- a/src/library/Attempt/Adapted/exports.ts
+++ b/src/library/Attempt/Adapted/exports.ts
@@ -11,5 +11,5 @@ export {
 } from './toSettle';
 
 export type {
-  default as Attempt_Adapted_Config,
+  _default as Attempt_Adapted_Config,
 } from './Config';

--- a/src/library/Attempt/Adapted/to.ts
+++ b/src/library/Attempt/Adapted/to.ts
@@ -16,7 +16,7 @@ import {
 } from '../tryCatchStatements';
 
 import type {
-  default as Attempt_Adapted_Config,
+  _default as Attempt_Adapted_Config,
 } from './Config';
 
 const Attempt_Adapted_to = <

--- a/src/library/Attempt/Adapted/toEventually.ts
+++ b/src/library/Attempt/Adapted/toEventually.ts
@@ -16,7 +16,7 @@ import {
 } from '../tryCatchStatements';
 
 import type {
-  default as Attempt_Adapted_Config,
+  _default as Attempt_Adapted_Config,
 } from './Config';
 
 const Attempt_Adapted_toEventually = async <

--- a/src/library/Attempt/Adapted/toSettle.ts
+++ b/src/library/Attempt/Adapted/toSettle.ts
@@ -7,7 +7,7 @@ import type {
 } from '../Outcome';
 
 import type {
-  default as Attempt_Adapted_Config,
+  _default as Attempt_Adapted_Config,
 } from './Config';
 
 import {

--- a/src/library/Attempt/Error/Actionable.ts
+++ b/src/library/Attempt/Error/Actionable.ts
@@ -3,7 +3,7 @@ import type {
 } from '@/library/typeUtilities';
 
 import {
-  default as Attempt_Error_NonActionable,
+  _default as Attempt_Error_NonActionable,
 } from './NonActionable';
 
 /** Extend this class to describe errors from which callers ought to recover */
@@ -26,5 +26,5 @@ abstract class Attempt_Error_Actionable<
 }
 
 export {
-  Attempt_Error_Actionable as default,
+  Attempt_Error_Actionable as _default,
 };

--- a/src/library/Attempt/Error/Creation.ts
+++ b/src/library/Attempt/Error/Creation.ts
@@ -1,5 +1,5 @@
 import {
-  default as Attempt_Error_NonActionable,
+  _default as Attempt_Error_NonActionable,
 } from './NonActionable';
 
 class Attempt_Error_Creation
@@ -32,5 +32,5 @@ class Attempt_Error_Creation
 }
 
 export {
-  Attempt_Error_Creation as default,
+  Attempt_Error_Creation as _default,
 };

--- a/src/library/Attempt/Error/Interpreter.ts
+++ b/src/library/Attempt/Error/Interpreter.ts
@@ -1,5 +1,5 @@
 import type {
-  default as Attempt_Error_Actionable,
+  _default as Attempt_Error_Actionable,
 } from './Actionable';
 
 import type {
@@ -13,5 +13,5 @@ type Attempt_Error_Interpreter<
 ) => SomeActionableError | null;
 
 export type {
-  Attempt_Error_Interpreter as default,
+  Attempt_Error_Interpreter as _default,
 };

--- a/src/library/Attempt/Error/NonActionable/definition.ts
+++ b/src/library/Attempt/Error/NonActionable/definition.ts
@@ -73,5 +73,5 @@ class Attempt_Error_NonActionable
 }
 
 export {
-  Attempt_Error_NonActionable as default,
+  Attempt_Error_NonActionable as _default,
 };

--- a/src/library/Attempt/Error/NonActionable/exports.ts
+++ b/src/library/Attempt/Error/NonActionable/exports.ts
@@ -1,3 +1,3 @@
 export {
-  default as Attempt_Error_NonActionable,
+  _default as Attempt_Error_NonActionable,
 } from './definition.ts';

--- a/src/library/Attempt/Error/NonActionable/index.ts
+++ b/src/library/Attempt/Error/NonActionable/index.ts
@@ -1,3 +1,3 @@
 export {
-  Attempt_Error_NonActionable as default,
+  Attempt_Error_NonActionable as _default,
 } from './exports.ts';

--- a/src/library/Attempt/Error/NonActionableBuiltInError/definition.ts
+++ b/src/library/Attempt/Error/NonActionableBuiltInError/definition.ts
@@ -23,5 +23,5 @@ const NonActionableBuiltInError = {
 };
 
 export {
-  NonActionableBuiltInError as default,
+  NonActionableBuiltInError as _default,
 };

--- a/src/library/Attempt/Error/NonActionableBuiltInError/describes.ts
+++ b/src/library/Attempt/Error/NonActionableBuiltInError/describes.ts
@@ -1,5 +1,5 @@
 import type {
-  default as NonActionableBuiltInError,
+  _default as NonActionableBuiltInError,
 } from './definition.ts';
 
 const NonActionableBuiltInError_describes = (

--- a/src/library/Attempt/Error/NonActionableBuiltInError/exports.ts
+++ b/src/library/Attempt/Error/NonActionableBuiltInError/exports.ts
@@ -1,3 +1,3 @@
 export {
-  default,
+  _default,
 } from './definition.ts';

--- a/src/library/Attempt/Error/NonActionableBuiltInError/index.ts
+++ b/src/library/Attempt/Error/NonActionableBuiltInError/index.ts
@@ -1,3 +1,3 @@
 export {
-  default,
+  _default,
 } from './exports.ts';

--- a/src/library/Attempt/Error/assertActionable.ts
+++ b/src/library/Attempt/Error/assertActionable.ts
@@ -1,17 +1,17 @@
 import type {
-  default as Attempt_Error_Actionable,
+  _default as Attempt_Error_Actionable,
 } from './Actionable';
 
 import type {
-  default as Attempt_Error_Interpreter,
+  _default as Attempt_Error_Interpreter,
 } from './Interpreter';
 
 import {
-  default as Attempt_Error_NonActionable,
+  _default as Attempt_Error_NonActionable,
 } from './NonActionable';
 
 import {
-  default as NonActionableBuiltInError,
+  _default as NonActionableBuiltInError,
 } from './NonActionableBuiltInError';
 
 import {

--- a/src/library/Attempt/Error/exports.ts
+++ b/src/library/Attempt/Error/exports.ts
@@ -1,13 +1,13 @@
 export {
-  default as Attempt_Error_NonActionable,
+  _default as Attempt_Error_NonActionable,
 } from './NonActionable';
 
 export {
-  default as Attempt_Error_Creation,
+  _default as Attempt_Error_Creation,
 } from './Creation';
 
 export {
-  default as Attempt_Error_Actionable,
+  _default as Attempt_Error_Actionable,
 } from './Actionable';
 
 export {
@@ -15,7 +15,7 @@ export {
 } from './assertActionable';
 
 export type {
-  default as Attempt_Error_Interpreter,
+  _default as Attempt_Error_Interpreter,
 } from './Interpreter';
 
 export * from './modifier';

--- a/src/library/Attempt/Error/modifier/AppropriatelyThrown/assume.ts
+++ b/src/library/Attempt/Error/modifier/AppropriatelyThrown/assume.ts
@@ -1,9 +1,9 @@
 import {
-  default as Attempt_Error_Actionable,
+  _default as Attempt_Error_Actionable,
 } from '../../Actionable';
 
 import type {
-  default as AppropriatelyThrown,
+  _default as AppropriatelyThrown,
 } from './definition.ts';
 
 /**

--- a/src/library/Attempt/Error/modifier/AppropriatelyThrown/definition.ts
+++ b/src/library/Attempt/Error/modifier/AppropriatelyThrown/definition.ts
@@ -1,5 +1,5 @@
 import type {
-  default as Attempt_Error_Actionable,
+  _default as Attempt_Error_Actionable,
 } from '../../Actionable';
 
 type AppropriatelyThrown<
@@ -10,5 +10,5 @@ type AppropriatelyThrown<
 >;
 
 export type {
-  AppropriatelyThrown as default,
+  AppropriatelyThrown as _default,
 };

--- a/src/library/Attempt/Error/modifier/AppropriatelyThrown/exports.ts
+++ b/src/library/Attempt/Error/modifier/AppropriatelyThrown/exports.ts
@@ -1,5 +1,5 @@
 export type {
-  default,
+  _default,
 } from './definition.ts';
 
 export {

--- a/src/library/Attempt/Error/modifier/AppropriatelyThrown/index.ts
+++ b/src/library/Attempt/Error/modifier/AppropriatelyThrown/index.ts
@@ -1,4 +1,4 @@
 export {
-  type default,
+  type _default,
   AppropriatelyThrown_assume,
 } from './exports.ts';

--- a/src/library/Attempt/Error/modifier/PotentiallyActionable/assume.ts
+++ b/src/library/Attempt/Error/modifier/PotentiallyActionable/assume.ts
@@ -1,13 +1,13 @@
 import {
-  default as Attempt_Error_Creation,
+  _default as Attempt_Error_Creation,
 } from '../../Creation';
 
 import {
-  default as Attempt_Error_NonActionable,
+  _default as Attempt_Error_NonActionable,
 } from '../../NonActionable';
 
 import type {
-  default as PotentiallyActionable,
+  _default as PotentiallyActionable,
 } from './definition.ts';
 
 const PotentiallyActionable_assume = <

--- a/src/library/Attempt/Error/modifier/PotentiallyActionable/definition.ts
+++ b/src/library/Attempt/Error/modifier/PotentiallyActionable/definition.ts
@@ -1,5 +1,5 @@
 import type {
-  default as Attempt_Error_NonActionable,
+  _default as Attempt_Error_NonActionable,
 } from '../../NonActionable';
 
 type PotentiallyActionable<
@@ -7,5 +7,5 @@ type PotentiallyActionable<
 > = Exclude<SomeError, Attempt_Error_NonActionable>;
 
 export type {
-  PotentiallyActionable as default,
+  PotentiallyActionable as _default,
 };

--- a/src/library/Attempt/Error/modifier/PotentiallyActionable/exports.ts
+++ b/src/library/Attempt/Error/modifier/PotentiallyActionable/exports.ts
@@ -1,5 +1,5 @@
 export type {
-  default,
+  _default,
 } from './definition.ts';
 
 export {

--- a/src/library/Attempt/Error/modifier/PotentiallyActionable/index.ts
+++ b/src/library/Attempt/Error/modifier/PotentiallyActionable/index.ts
@@ -1,4 +1,4 @@
 export {
-  type default,
+  type _default,
   PotentiallyActionable_assume,
 } from './exports.ts';

--- a/src/library/Attempt/Error/modifier/exports.ts
+++ b/src/library/Attempt/Error/modifier/exports.ts
@@ -1,9 +1,9 @@
 export {
-  type default as AppropriatelyThrown,
+  type _default as AppropriatelyThrown,
   AppropriatelyThrown_assume,
 } from './AppropriatelyThrown';
 
 export {
-  type default as PotentiallyActionable,
+  type _default as PotentiallyActionable,
   PotentiallyActionable_assume,
 } from './PotentiallyActionable';

--- a/src/library/NonTrivialString/ParsingError.ts
+++ b/src/library/NonTrivialString/ParsingError.ts
@@ -14,5 +14,5 @@ class NonTrivialString_ParsingError
 }
 
 export {
-  NonTrivialString_ParsingError as default,
+  NonTrivialString_ParsingError as _default,
 };

--- a/src/library/NonTrivialString/definition.ts
+++ b/src/library/NonTrivialString/definition.ts
@@ -9,7 +9,7 @@ import {
 } from '@/library/utilitiesByType/string';
 
 import {
-  default as NonTrivialString_ParsingError,
+  _default as NonTrivialString_ParsingError,
 } from './ParsingError.ts';
 
 class NonTrivialString

--- a/src/library/Range/Discrete.ts
+++ b/src/library/Range/Discrete.ts
@@ -94,5 +94,5 @@ class Range_Discrete
 }
 
 export {
-  Range_Discrete as default,
+  Range_Discrete as _default,
 };

--- a/src/library/Range/exports.ts
+++ b/src/library/Range/exports.ts
@@ -3,5 +3,5 @@ export {
 } from './definitionWithAugmentation.ts';
 
 export {
-  default as Range_Discrete,
+  _default as Range_Discrete,
 } from './Discrete';

--- a/src/library/Sequence/Base64/Conformance/Error.ts
+++ b/src/library/Sequence/Base64/Conformance/Error.ts
@@ -13,5 +13,5 @@ class Sequence_Base64_Conformance_Error
 }
 
 export {
-  Sequence_Base64_Conformance_Error as default,
+  Sequence_Base64_Conformance_Error as _default,
 };

--- a/src/library/Sequence/Base64/Conformance/ensure.ts
+++ b/src/library/Sequence/Base64/Conformance/ensure.ts
@@ -5,7 +5,7 @@ import {
 } from '../pattern';
 
 import {
-  default as Sequence_Base64_Conformance_Error,
+  _default as Sequence_Base64_Conformance_Error,
 } from './Error';
 
 const Sequence_Base64_Conformance_ensure = (

--- a/src/library/Sequence/Base64/Conformance/exports.ts
+++ b/src/library/Sequence/Base64/Conformance/exports.ts
@@ -3,5 +3,5 @@ export {
 } from './ensure';
 
 export {
-  default as Error,
+  _default as Error,
 } from './Error';

--- a/src/library/Sequence/Byte/Encoded/Base64/ParsingError.ts
+++ b/src/library/Sequence/Byte/Encoded/Base64/ParsingError.ts
@@ -48,5 +48,5 @@ class Sequence_Byte_Encoded_Base64_ParsingError
 }
 
 export {
-  Sequence_Byte_Encoded_Base64_ParsingError as default,
+  Sequence_Byte_Encoded_Base64_ParsingError as _default,
 };

--- a/src/library/Sequence/Byte/Encoded/Base64/definition.ts
+++ b/src/library/Sequence/Byte/Encoded/Base64/definition.ts
@@ -19,7 +19,7 @@ import {
 } from '../Compatibility';
 
 import {
-  default as Sequence_Byte_Encoded_Base64_ParsingError,
+  _default as Sequence_Byte_Encoded_Base64_ParsingError,
 } from './ParsingError.ts';
 
 /** See [RFC 4648 Section 4](https://www.rfc-editor.org/rfc/rfc4648.html#section-4) for more information */

--- a/src/library/Sequence/Byte/Encoded/Compatibility/Error.ts
+++ b/src/library/Sequence/Byte/Encoded/Compatibility/Error.ts
@@ -16,5 +16,5 @@ class Sequence_Byte_Encoded_Compatibility_Error
 }
 
 export {
-  Sequence_Byte_Encoded_Compatibility_Error as default,
+  Sequence_Byte_Encoded_Compatibility_Error as _default,
 };

--- a/src/library/Sequence/Byte/Encoded/Compatibility/ensure.ts
+++ b/src/library/Sequence/Byte/Encoded/Compatibility/ensure.ts
@@ -2,7 +2,7 @@ import Attempt from '@/library/Attempt';
 import Byte from '@/library/Byte';
 
 import {
-  default as Sequence_Byte_Encoded_Compatibility_Error,
+  _default as Sequence_Byte_Encoded_Compatibility_Error,
 } from './Error';
 
 const Sequence_Byte_Encoded_Compatibility_ensure = (

--- a/src/library/Sequence/Byte/Encoded/Compatibility/exports.ts
+++ b/src/library/Sequence/Byte/Encoded/Compatibility/exports.ts
@@ -3,5 +3,5 @@ export {
 } from './ensure';
 
 export {
-  default as Error,
+  _default as Error,
 } from './Error';

--- a/src/library/ShimmedStabilityAIClient/SDXL/DiffusionStepCount.ts
+++ b/src/library/ShimmedStabilityAIClient/SDXL/DiffusionStepCount.ts
@@ -16,5 +16,5 @@ abstract class SDXL_DiffusionStepCount { // eslint-disable-line @typescript-esli
 }
 
 export {
-  SDXL_DiffusionStepCount as default,
+  SDXL_DiffusionStepCount as _default,
 };

--- a/src/library/ShimmedStabilityAIClient/SDXL/exports.ts
+++ b/src/library/ShimmedStabilityAIClient/SDXL/exports.ts
@@ -1,3 +1,3 @@
 export {
-  default as SDXL_DiffusionStepCount,
+  _default as SDXL_DiffusionStepCount,
 } from './DiffusionStepCount';

--- a/src/library/ShimmedStabilityAIClient/Version1/Image.ts
+++ b/src/library/ShimmedStabilityAIClient/Version1/Image.ts
@@ -11,7 +11,7 @@ import HTTP from '@/library/HTTP';
 import Shortfin from '@/library/Shortfin';
 
 import {
-  default as toShortfinRequestBody,
+  _default as toShortfinRequestBody,
 } from '../toShortfinRequestBody';
 
 class ShimmedStabilityAIClient_Version1_Image

--- a/src/library/ShimmedStabilityAIClient/toShortfinRequestBody/index.ts
+++ b/src/library/ShimmedStabilityAIClient/toShortfinRequestBody/index.ts
@@ -1,3 +1,3 @@
 export {
-  toShortfinRequestBody as default,
+  toShortfinRequestBody as _default,
 } from './exports.ts';

--- a/src/library/UniformResourceIdentifier/Image/index.ts
+++ b/src/library/UniformResourceIdentifier/Image/index.ts
@@ -1,3 +1,3 @@
 export {
-  URI_Image as default,
+  URI_Image as _default,
 } from './exports.ts';

--- a/src/library/UniformResourceIdentifier/exports.ts
+++ b/src/library/UniformResourceIdentifier/exports.ts
@@ -1,3 +1,3 @@
 export {
-  default as URI_Image,
+  _default as URI_Image,
 } from './Image';

--- a/src/library/WebAPI/Server.ts
+++ b/src/library/WebAPI/Server.ts
@@ -30,5 +30,5 @@ class WebAPI_Server {
 }
 
 export {
-  WebAPI_Server as default,
+  WebAPI_Server as _default,
 };

--- a/src/library/WebAPI/exports.ts
+++ b/src/library/WebAPI/exports.ts
@@ -1,5 +1,5 @@
 import {
-  default as WebAPI_Server,
+  _default as WebAPI_Server,
 } from './Server.ts';
 
 export {

--- a/src/library/modifiersByType/error/Contextualized/assume.ts
+++ b/src/library/modifiersByType/error/Contextualized/assume.ts
@@ -5,7 +5,7 @@ import type {
 } from '@/library/typeUtilities';
 
 import type {
-  default as Contextualized,
+  _default as Contextualized,
 } from './definition.ts';
 
 import {

--- a/src/library/modifiersByType/error/Contextualized/cast.ts
+++ b/src/library/modifiersByType/error/Contextualized/cast.ts
@@ -7,7 +7,7 @@ import {
 } from './assume';
 
 import type {
-  default as Contextualized,
+  _default as Contextualized,
 } from './definition.ts';
 
 import {

--- a/src/library/modifiersByType/error/Contextualized/definition.ts
+++ b/src/library/modifiersByType/error/Contextualized/definition.ts
@@ -28,5 +28,5 @@ const Contextualized = {
 };
 
 export {
-  Contextualized as default,
+  Contextualized as _default,
 };

--- a/src/library/modifiersByType/error/Contextualized/describes.ts
+++ b/src/library/modifiersByType/error/Contextualized/describes.ts
@@ -3,7 +3,7 @@ import type {
 } from '@/library/typeUtilities';
 
 import type {
-  default as Contextualized,
+  _default as Contextualized,
 } from './definition.ts';
 
 const Contextualized_describes = <

--- a/src/library/modifiersByType/error/Contextualized/exports.ts
+++ b/src/library/modifiersByType/error/Contextualized/exports.ts
@@ -1,3 +1,3 @@
 export {
-  default,
+  _default,
 } from './definition.ts';

--- a/src/library/modifiersByType/error/Contextualized/index.ts
+++ b/src/library/modifiersByType/error/Contextualized/index.ts
@@ -1,3 +1,3 @@
 export {
-  default,
+  _default,
 } from './exports.ts';

--- a/src/library/modifiersByType/error/exports.ts
+++ b/src/library/modifiersByType/error/exports.ts
@@ -1,3 +1,3 @@
 export {
-  default as Contextualized,
+  _default as Contextualized,
 } from './Contextualized';

--- a/src/library/typeUtilities/Static.ts
+++ b/src/library/typeUtilities/Static.ts
@@ -6,5 +6,5 @@ interface Static<
 }
 
 export type {
-  Static as default,
+  Static as _default,
 };

--- a/src/library/typeUtilities/exports.ts
+++ b/src/library/typeUtilities/exports.ts
@@ -5,7 +5,7 @@ export type * from './Instantiable';
 export type * from './Batched';
 
 export type {
-  default as Static,
+  _default as Static,
 } from './Static';
 
 export type * from './Branded';

--- a/src/utilities/Repository/definition.ts
+++ b/src/utilities/Repository/definition.ts
@@ -24,5 +24,5 @@ const Repository = {
 };
 
 export {
-  Repository as default,
+  Repository as _default,
 };

--- a/src/utilities/Repository/exports.ts
+++ b/src/utilities/Repository/exports.ts
@@ -1,3 +1,3 @@
 export {
-  default,
+  _default,
 } from './definition.ts';

--- a/src/utilities/Repository/index.ts
+++ b/src/utilities/Repository/index.ts
@@ -1,3 +1,3 @@
 export {
-  default,
+  _default as default,
 } from './exports.ts';


### PR DESCRIPTION
- VSCode is unable to "rename" the `default` alias
- It was easier to identify the ones that need to change and then prepend them with `_`, making them an actual `export` alias with which VSCode could operate

Facilitates #934