### PR TITLE
refactor: ensures named interfaces for all submodules

### DIFF
--- a/src/library/Attempt/Error/NonActionableBuiltInError/exports.ts
+++ b/src/library/Attempt/Error/NonActionableBuiltInError/exports.ts
@@ -1,3 +1,3 @@
 export {
-  NonActionableBuiltInError as _default,
+  NonActionableBuiltInError,
 } from './definition.ts';

--- a/src/library/Attempt/Error/NonActionableBuiltInError/index.ts
+++ b/src/library/Attempt/Error/NonActionableBuiltInError/index.ts
@@ -1,3 +1,3 @@
 export {
-  _default,
+  NonActionableBuiltInError,
 } from './exports.ts';

--- a/src/library/Attempt/Error/assertActionable.ts
+++ b/src/library/Attempt/Error/assertActionable.ts
@@ -11,7 +11,7 @@ import {
 } from './NonActionable';
 
 import {
-  _default as NonActionableBuiltInError,
+  NonActionableBuiltInError,
 } from './NonActionableBuiltInError';
 
 import {

--- a/src/library/Attempt/Error/modifier/AppropriatelyThrown/exports.ts
+++ b/src/library/Attempt/Error/modifier/AppropriatelyThrown/exports.ts
@@ -1,5 +1,5 @@
 export type {
-  AppropriatelyThrown as _default,
+  AppropriatelyThrown,
 } from './definition.ts';
 
 export {

--- a/src/library/Attempt/Error/modifier/AppropriatelyThrown/index.ts
+++ b/src/library/Attempt/Error/modifier/AppropriatelyThrown/index.ts
@@ -1,4 +1,4 @@
 export {
-  type _default,
+  type AppropriatelyThrown,
   AppropriatelyThrown_assume,
 } from './exports.ts';

--- a/src/library/Attempt/Error/modifier/PotentiallyActionable/exports.ts
+++ b/src/library/Attempt/Error/modifier/PotentiallyActionable/exports.ts
@@ -1,5 +1,5 @@
 export type {
-  PotentiallyActionable as _default,
+  PotentiallyActionable,
 } from './definition.ts';
 
 export {

--- a/src/library/Attempt/Error/modifier/PotentiallyActionable/index.ts
+++ b/src/library/Attempt/Error/modifier/PotentiallyActionable/index.ts
@@ -1,4 +1,4 @@
 export {
-  type _default,
+  type PotentiallyActionable,
   PotentiallyActionable_assume,
 } from './exports.ts';

--- a/src/library/Attempt/Error/modifier/exports.ts
+++ b/src/library/Attempt/Error/modifier/exports.ts
@@ -1,9 +1,9 @@
 export {
-  type _default as AppropriatelyThrown,
+  type AppropriatelyThrown,
   AppropriatelyThrown_assume,
 } from './AppropriatelyThrown';
 
 export {
-  type _default as PotentiallyActionable,
+  type PotentiallyActionable,
   PotentiallyActionable_assume,
 } from './PotentiallyActionable';

--- a/src/library/ShimmedStabilityAIClient/Version1/Image.ts
+++ b/src/library/ShimmedStabilityAIClient/Version1/Image.ts
@@ -11,7 +11,7 @@ import HTTP from '@/library/HTTP';
 import Shortfin from '@/library/Shortfin';
 
 import {
-  _default as toShortfinRequestBody,
+  toShortfinRequestBody,
 } from '../toShortfinRequestBody';
 
 class ShimmedStabilityAIClient_Version1_Image

--- a/src/library/ShimmedStabilityAIClient/toShortfinRequestBody/index.ts
+++ b/src/library/ShimmedStabilityAIClient/toShortfinRequestBody/index.ts
@@ -1,3 +1,3 @@
 export {
-  toShortfinRequestBody as _default,
+  toShortfinRequestBody,
 } from './exports.ts';

--- a/src/library/UniformResourceIdentifier/Image/index.ts
+++ b/src/library/UniformResourceIdentifier/Image/index.ts
@@ -1,3 +1,3 @@
 export {
-  URI_Image as _default,
+  URI_Image,
 } from './exports.ts';

--- a/src/library/UniformResourceIdentifier/exports.ts
+++ b/src/library/UniformResourceIdentifier/exports.ts
@@ -1,3 +1,3 @@
 export {
-  _default as URI_Image,
+  URI_Image,
 } from './Image';

--- a/src/library/modifiersByType/error/Contextualized/exports.ts
+++ b/src/library/modifiersByType/error/Contextualized/exports.ts
@@ -1,3 +1,3 @@
 export {
-  Contextualized as _default,
+  Contextualized,
 } from './definition.ts';

--- a/src/library/modifiersByType/error/Contextualized/index.ts
+++ b/src/library/modifiersByType/error/Contextualized/index.ts
@@ -1,3 +1,3 @@
 export {
-  _default,
+  Contextualized,
 } from './exports.ts';

--- a/src/library/modifiersByType/error/exports.ts
+++ b/src/library/modifiersByType/error/exports.ts
@@ -1,3 +1,3 @@
 export {
-  _default as Contextualized,
+  Contextualized,
 } from './Contextualized';

--- a/src/utilities/Repository/exports.ts
+++ b/src/utilities/Repository/exports.ts
@@ -1,3 +1,3 @@
 export {
-  Repository as _default,
+  Repository,
 } from './definition.ts';

--- a/src/utilities/Repository/index.ts
+++ b/src/utilities/Repository/index.ts
@@ -1,3 +1,3 @@
 export {
-  _default as default,
+  Repository as default,
 } from './exports.ts';


### PR DESCRIPTION
- internal modules are named such that they communicate either:
  - where they sit in the namespace hierarchy (in the case of an object-oriented library)
  - the exact nature of what they do when used (in the case of a functional toolbox)
- these modules are only ever renamed for better clarity, so it's preferrable that all their import sites change, too (or at least make it explicit that the previous name was kept as a downstream alias)