### PR TITLE
refactor: transfers aliasing concerns from all units to peer "exports"

### DIFF
--- a/src/features/TextToImage/Client/SDXL/exports.ts
+++ b/src/features/TextToImage/Client/SDXL/exports.ts
@@ -1,3 +1,3 @@
 export {
-  generateOutputFrom,
+  TextToImage_Client_SDXL_generateOutputFrom as generateOutputFrom,
 } from './generateOutputFrom';

--- a/src/features/TextToImage/Client/SDXL/generateOutputFrom.ts
+++ b/src/features/TextToImage/Client/SDXL/generateOutputFrom.ts
@@ -74,5 +74,5 @@ const TextToImage_Client_SDXL_generateOutputFrom = async (
 };
 
 export {
-  TextToImage_Client_SDXL_generateOutputFrom as generateOutputFrom,
+  TextToImage_Client_SDXL_generateOutputFrom,
 };

--- a/src/features/TextToImage/Client/SDXL/index.ts
+++ b/src/features/TextToImage/Client/SDXL/index.ts
@@ -1,5 +1,5 @@
 import * as TextToImage_Client_SDXL from './exports.ts';
 
 export {
-  TextToImage_Client_SDXL as _default,
+  TextToImage_Client_SDXL,
 };

--- a/src/features/TextToImage/Client/exports.ts
+++ b/src/features/TextToImage/Client/exports.ts
@@ -1,3 +1,3 @@
 export {
-  _default as SDXL,
+  TextToImage_Client_SDXL as SDXL,
 } from './SDXL';

--- a/src/features/TextToImage/Config/Dynamic/Fetching/Error/Any.ts
+++ b/src/features/TextToImage/Config/Dynamic/Fetching/Error/Any.ts
@@ -1,9 +1,9 @@
 import type {
-  _default as TextToImage_Config_Dynamic_Fetching_Error_Request,
+  TextToImage_Config_Dynamic_Fetching_Error_Request,
 } from './Request';
 
 import type {
-  _default as TextToImage_Config_Dynamic_Fetching_Error_Response,
+  TextToImage_Config_Dynamic_Fetching_Error_Response,
 } from './Response';
 
 type TextToImage_Config_Dynamic_Fetching_Error_Any =

--- a/src/features/TextToImage/Config/Dynamic/Fetching/Error/Request.ts
+++ b/src/features/TextToImage/Config/Dynamic/Fetching/Error/Request.ts
@@ -18,5 +18,5 @@ class TextToImage_Config_Dynamic_Fetching_Error_Request
 }
 
 export {
-  TextToImage_Config_Dynamic_Fetching_Error_Request as _default,
+  TextToImage_Config_Dynamic_Fetching_Error_Request,
 };

--- a/src/features/TextToImage/Config/Dynamic/Fetching/Error/Response.ts
+++ b/src/features/TextToImage/Config/Dynamic/Fetching/Error/Response.ts
@@ -19,5 +19,5 @@ class TextToImage_Config_Dynamic_Fetching_Error_Response
 }
 
 export {
-  TextToImage_Config_Dynamic_Fetching_Error_Response as _default,
+  TextToImage_Config_Dynamic_Fetching_Error_Response,
 };

--- a/src/features/TextToImage/Config/Dynamic/Fetching/Error/exports.ts
+++ b/src/features/TextToImage/Config/Dynamic/Fetching/Error/exports.ts
@@ -1,9 +1,9 @@
 export {
-  _default as Request,
+  TextToImage_Config_Dynamic_Fetching_Error_Request as Request,
 } from './Request';
 
 export {
-  _default as Response,
+  TextToImage_Config_Dynamic_Fetching_Error_Response as Response,
 } from './Response';
 
 export type {

--- a/src/features/TextToImage/Config/Dynamic/exports.ts
+++ b/src/features/TextToImage/Config/Dynamic/exports.ts
@@ -3,7 +3,7 @@ export {
 } from './endpoint';
 
 export {
-  fetch,
+  TextToImage_Config_Dynamic_fetch as fetch,
 } from './fetch';
 
 export {

--- a/src/features/TextToImage/Config/Dynamic/fetch.ts
+++ b/src/features/TextToImage/Config/Dynamic/fetch.ts
@@ -38,5 +38,5 @@ const TextToImage_Config_Dynamic_fetch = (): Promise<
 });
 
 export {
-  TextToImage_Config_Dynamic_fetch as fetch,
+  TextToImage_Config_Dynamic_fetch,
 };

--- a/src/features/TextToImage/Config/Static/Reading/Error.ts
+++ b/src/features/TextToImage/Config/Static/Reading/Error.ts
@@ -19,5 +19,5 @@ class TextToImage_Config_Static_Reading_Error
 }
 
 export {
-  TextToImage_Config_Static_Reading_Error as _default,
+  TextToImage_Config_Static_Reading_Error,
 };

--- a/src/features/TextToImage/Config/Static/Reading/Outcome.ts
+++ b/src/features/TextToImage/Config/Static/Reading/Outcome.ts
@@ -5,7 +5,7 @@ import type {
 } from '../../definition.ts';
 
 import type {
-  _default as TextToImage_Config_Static_Reading_Error,
+  TextToImage_Config_Static_Reading_Error,
 } from './Error';
 
 type TextToImage_Config_Static_Reading_Outcome = Attempt.Outcome<

--- a/src/features/TextToImage/Config/Static/Reading/exports.ts
+++ b/src/features/TextToImage/Config/Static/Reading/exports.ts
@@ -1,5 +1,5 @@
 export {
-  _default as Error,
+  TextToImage_Config_Static_Reading_Error as Error,
 } from './Error';
 
 export type {

--- a/src/features/TextToImage/Config/Static/exports.ts
+++ b/src/features/TextToImage/Config/Static/exports.ts
@@ -3,7 +3,7 @@ export {
 } from './file';
 
 export {
-  read,
+  TextToImage_Config_Static_read as read,
 } from './read';
 
 export {

--- a/src/features/TextToImage/Config/Static/read.ts
+++ b/src/features/TextToImage/Config/Static/read.ts
@@ -27,5 +27,5 @@ const TextToImage_Config_Static_read = (): Promise<
 });
 
 export {
-  TextToImage_Config_Static_read as read,
+  TextToImage_Config_Static_read,
 };

--- a/src/features/TextToImage/Pipeline/Output/Image.ts
+++ b/src/features/TextToImage/Pipeline/Output/Image.ts
@@ -8,5 +8,5 @@ interface TextToImage_Pipeline_Output_Image {
 }
 
 export type {
-  TextToImage_Pipeline_Output_Image as _default,
+  TextToImage_Pipeline_Output_Image,
 };

--- a/src/features/TextToImage/Pipeline/Output/definition.ts
+++ b/src/features/TextToImage/Pipeline/Output/definition.ts
@@ -1,5 +1,5 @@
 import type {
-  _default as TextToImage_Pipeline_Output_Image,
+  TextToImage_Pipeline_Output_Image,
 } from './Image';
 
 /** The resulting information after a text-to-image model has ingested some input with some configuration */

--- a/src/features/TextToImage/Server/Current/exports.ts
+++ b/src/features/TextToImage/Server/Current/exports.ts
@@ -3,5 +3,5 @@ export {
 } from './accordingToEnvironment';
 
 export {
-  Current_retrieve,
+  TextToImage_Server_Current_retrieve as Current_retrieve,
 } from './retrieve';

--- a/src/features/TextToImage/Server/Current/retrieve.ts
+++ b/src/features/TextToImage/Server/Current/retrieve.ts
@@ -54,5 +54,5 @@ const TextToImage_Server_Current_retrieve = (): Promise<
 });
 
 export {
-  TextToImage_Server_Current_retrieve as Current_retrieve,
+  TextToImage_Server_Current_retrieve,
 };

--- a/src/features/TextToImage/Server/Error/Any.ts
+++ b/src/features/TextToImage/Server/Error/Any.ts
@@ -1,9 +1,9 @@
 import type {
-  _default as TextToImage_Server_Error_Connection,
+  TextToImage_Server_Error_Connection,
 } from './Connection';
 
 import type {
-  _default as TextToImage_Server_Error_Specification,
+  TextToImage_Server_Error_Specification,
 } from './Specification';
 
 type TextToImage_Server_Error_Any =

--- a/src/features/TextToImage/Server/Error/Connection.ts
+++ b/src/features/TextToImage/Server/Error/Connection.ts
@@ -14,5 +14,5 @@ class TextToImage_Server_Error_Connection
 }
 
 export {
-  TextToImage_Server_Error_Connection as _default,
+  TextToImage_Server_Error_Connection,
 };

--- a/src/features/TextToImage/Server/Error/Specification.ts
+++ b/src/features/TextToImage/Server/Error/Specification.ts
@@ -20,5 +20,5 @@ class TextToImage_Server_Error_Specification
 }
 
 export {
-  TextToImage_Server_Error_Specification as _default,
+  TextToImage_Server_Error_Specification,
 };

--- a/src/features/TextToImage/Server/Error/exports.ts
+++ b/src/features/TextToImage/Server/Error/exports.ts
@@ -1,9 +1,9 @@
 export {
-  _default as Specification,
+  TextToImage_Server_Error_Specification as Specification,
 } from './Specification';
 
 export {
-  _default as Connection,
+  TextToImage_Server_Error_Connection as Connection,
 } from './Connection';
 
 export type {

--- a/src/library/Attempt/Adapted/Config.ts
+++ b/src/library/Attempt/Adapted/Config.ts
@@ -10,5 +10,5 @@ interface Attempt_Adapted_Config<
 }
 
 export type {
-  Attempt_Adapted_Config as _default,
+  Attempt_Adapted_Config,
 };

--- a/src/library/Attempt/Adapted/exports.ts
+++ b/src/library/Attempt/Adapted/exports.ts
@@ -11,5 +11,5 @@ export {
 } from './toSettle';
 
 export type {
-  _default as Attempt_Adapted_Config,
+  Attempt_Adapted_Config,
 } from './Config';

--- a/src/library/Attempt/Adapted/to.ts
+++ b/src/library/Attempt/Adapted/to.ts
@@ -16,7 +16,7 @@ import {
 } from '../tryCatchStatements';
 
 import type {
-  _default as Attempt_Adapted_Config,
+  Attempt_Adapted_Config,
 } from './Config';
 
 const Attempt_Adapted_to = <

--- a/src/library/Attempt/Adapted/toEventually.ts
+++ b/src/library/Attempt/Adapted/toEventually.ts
@@ -16,7 +16,7 @@ import {
 } from '../tryCatchStatements';
 
 import type {
-  _default as Attempt_Adapted_Config,
+  Attempt_Adapted_Config,
 } from './Config';
 
 const Attempt_Adapted_toEventually = async <

--- a/src/library/Attempt/Adapted/toSettle.ts
+++ b/src/library/Attempt/Adapted/toSettle.ts
@@ -7,7 +7,7 @@ import type {
 } from '../Outcome';
 
 import type {
-  _default as Attempt_Adapted_Config,
+  Attempt_Adapted_Config,
 } from './Config';
 
 import {

--- a/src/library/Attempt/Error/Actionable.ts
+++ b/src/library/Attempt/Error/Actionable.ts
@@ -3,7 +3,7 @@ import type {
 } from '@/library/typeUtilities';
 
 import {
-  _default as Attempt_Error_NonActionable,
+  Attempt_Error_NonActionable,
 } from './NonActionable';
 
 /** Extend this class to describe errors from which callers ought to recover */
@@ -26,5 +26,5 @@ abstract class Attempt_Error_Actionable<
 }
 
 export {
-  Attempt_Error_Actionable as _default,
+  Attempt_Error_Actionable,
 };

--- a/src/library/Attempt/Error/Creation.ts
+++ b/src/library/Attempt/Error/Creation.ts
@@ -1,5 +1,5 @@
 import {
-  _default as Attempt_Error_NonActionable,
+  Attempt_Error_NonActionable,
 } from './NonActionable';
 
 class Attempt_Error_Creation
@@ -32,5 +32,5 @@ class Attempt_Error_Creation
 }
 
 export {
-  Attempt_Error_Creation as _default,
+  Attempt_Error_Creation,
 };

--- a/src/library/Attempt/Error/Interpreter.ts
+++ b/src/library/Attempt/Error/Interpreter.ts
@@ -1,5 +1,5 @@
 import type {
-  _default as Attempt_Error_Actionable,
+  Attempt_Error_Actionable,
 } from './Actionable';
 
 import type {
@@ -13,5 +13,5 @@ type Attempt_Error_Interpreter<
 ) => SomeActionableError | null;
 
 export type {
-  Attempt_Error_Interpreter as _default,
+  Attempt_Error_Interpreter,
 };

--- a/src/library/Attempt/Error/NonActionable/definition.ts
+++ b/src/library/Attempt/Error/NonActionable/definition.ts
@@ -73,5 +73,5 @@ class Attempt_Error_NonActionable
 }
 
 export {
-  Attempt_Error_NonActionable as _default,
+  Attempt_Error_NonActionable,
 };

--- a/src/library/Attempt/Error/NonActionable/exports.ts
+++ b/src/library/Attempt/Error/NonActionable/exports.ts
@@ -1,3 +1,3 @@
 export {
-  _default as Attempt_Error_NonActionable,
+  Attempt_Error_NonActionable,
 } from './definition.ts';

--- a/src/library/Attempt/Error/NonActionable/index.ts
+++ b/src/library/Attempt/Error/NonActionable/index.ts
@@ -1,3 +1,3 @@
 export {
-  Attempt_Error_NonActionable as _default,
+  Attempt_Error_NonActionable,
 } from './exports.ts';

--- a/src/library/Attempt/Error/NonActionableBuiltInError/definition.ts
+++ b/src/library/Attempt/Error/NonActionableBuiltInError/definition.ts
@@ -23,5 +23,5 @@ const NonActionableBuiltInError = {
 };
 
 export {
-  NonActionableBuiltInError as _default,
+  NonActionableBuiltInError,
 };

--- a/src/library/Attempt/Error/NonActionableBuiltInError/describes.ts
+++ b/src/library/Attempt/Error/NonActionableBuiltInError/describes.ts
@@ -1,5 +1,5 @@
 import type {
-  _default as NonActionableBuiltInError,
+  NonActionableBuiltInError,
 } from './definition.ts';
 
 const NonActionableBuiltInError_describes = (

--- a/src/library/Attempt/Error/NonActionableBuiltInError/exports.ts
+++ b/src/library/Attempt/Error/NonActionableBuiltInError/exports.ts
@@ -1,3 +1,3 @@
 export {
-  _default,
+  NonActionableBuiltInError as _default,
 } from './definition.ts';

--- a/src/library/Attempt/Error/assertActionable.ts
+++ b/src/library/Attempt/Error/assertActionable.ts
@@ -1,13 +1,13 @@
 import type {
-  _default as Attempt_Error_Actionable,
+  Attempt_Error_Actionable,
 } from './Actionable';
 
 import type {
-  _default as Attempt_Error_Interpreter,
+  Attempt_Error_Interpreter,
 } from './Interpreter';
 
 import {
-  _default as Attempt_Error_NonActionable,
+  Attempt_Error_NonActionable,
 } from './NonActionable';
 
 import {

--- a/src/library/Attempt/Error/exports.ts
+++ b/src/library/Attempt/Error/exports.ts
@@ -1,13 +1,13 @@
 export {
-  _default as Attempt_Error_NonActionable,
+  Attempt_Error_NonActionable,
 } from './NonActionable';
 
 export {
-  _default as Attempt_Error_Creation,
+  Attempt_Error_Creation,
 } from './Creation';
 
 export {
-  _default as Attempt_Error_Actionable,
+  Attempt_Error_Actionable,
 } from './Actionable';
 
 export {
@@ -15,7 +15,7 @@ export {
 } from './assertActionable';
 
 export type {
-  _default as Attempt_Error_Interpreter,
+  Attempt_Error_Interpreter,
 } from './Interpreter';
 
 export * from './modifier';

--- a/src/library/Attempt/Error/modifier/AppropriatelyThrown/assume.ts
+++ b/src/library/Attempt/Error/modifier/AppropriatelyThrown/assume.ts
@@ -1,9 +1,9 @@
 import {
-  _default as Attempt_Error_Actionable,
+  Attempt_Error_Actionable,
 } from '../../Actionable';
 
 import type {
-  _default as AppropriatelyThrown,
+  AppropriatelyThrown,
 } from './definition.ts';
 
 /**

--- a/src/library/Attempt/Error/modifier/AppropriatelyThrown/definition.ts
+++ b/src/library/Attempt/Error/modifier/AppropriatelyThrown/definition.ts
@@ -1,5 +1,5 @@
 import type {
-  _default as Attempt_Error_Actionable,
+  Attempt_Error_Actionable,
 } from '../../Actionable';
 
 type AppropriatelyThrown<
@@ -10,5 +10,5 @@ type AppropriatelyThrown<
 >;
 
 export type {
-  AppropriatelyThrown as _default,
+  AppropriatelyThrown,
 };

--- a/src/library/Attempt/Error/modifier/AppropriatelyThrown/exports.ts
+++ b/src/library/Attempt/Error/modifier/AppropriatelyThrown/exports.ts
@@ -1,5 +1,5 @@
 export type {
-  _default,
+  AppropriatelyThrown as _default,
 } from './definition.ts';
 
 export {

--- a/src/library/Attempt/Error/modifier/PotentiallyActionable/assume.ts
+++ b/src/library/Attempt/Error/modifier/PotentiallyActionable/assume.ts
@@ -1,13 +1,13 @@
 import {
-  _default as Attempt_Error_Creation,
+  Attempt_Error_Creation,
 } from '../../Creation';
 
 import {
-  _default as Attempt_Error_NonActionable,
+  Attempt_Error_NonActionable,
 } from '../../NonActionable';
 
 import type {
-  _default as PotentiallyActionable,
+  PotentiallyActionable,
 } from './definition.ts';
 
 const PotentiallyActionable_assume = <

--- a/src/library/Attempt/Error/modifier/PotentiallyActionable/definition.ts
+++ b/src/library/Attempt/Error/modifier/PotentiallyActionable/definition.ts
@@ -1,5 +1,5 @@
 import type {
-  _default as Attempt_Error_NonActionable,
+  Attempt_Error_NonActionable,
 } from '../../NonActionable';
 
 type PotentiallyActionable<
@@ -7,5 +7,5 @@ type PotentiallyActionable<
 > = Exclude<SomeError, Attempt_Error_NonActionable>;
 
 export type {
-  PotentiallyActionable as _default,
+  PotentiallyActionable,
 };

--- a/src/library/Attempt/Error/modifier/PotentiallyActionable/exports.ts
+++ b/src/library/Attempt/Error/modifier/PotentiallyActionable/exports.ts
@@ -1,5 +1,5 @@
 export type {
-  _default,
+  PotentiallyActionable as _default,
 } from './definition.ts';
 
 export {

--- a/src/library/NonTrivialString/ParsingError.ts
+++ b/src/library/NonTrivialString/ParsingError.ts
@@ -14,5 +14,5 @@ class NonTrivialString_ParsingError
 }
 
 export {
-  NonTrivialString_ParsingError as _default,
+  NonTrivialString_ParsingError,
 };

--- a/src/library/NonTrivialString/definition.ts
+++ b/src/library/NonTrivialString/definition.ts
@@ -9,7 +9,7 @@ import {
 } from '@/library/utilitiesByType/string';
 
 import {
-  _default as NonTrivialString_ParsingError,
+  NonTrivialString_ParsingError,
 } from './ParsingError.ts';
 
 class NonTrivialString

--- a/src/library/Range/Discrete.ts
+++ b/src/library/Range/Discrete.ts
@@ -94,5 +94,5 @@ class Range_Discrete
 }
 
 export {
-  Range_Discrete as _default,
+  Range_Discrete,
 };

--- a/src/library/Range/exports.ts
+++ b/src/library/Range/exports.ts
@@ -3,5 +3,5 @@ export {
 } from './definitionWithAugmentation.ts';
 
 export {
-  _default as Range_Discrete,
+  Range_Discrete,
 } from './Discrete';

--- a/src/library/Sequence/Base64/Conformance/Error.ts
+++ b/src/library/Sequence/Base64/Conformance/Error.ts
@@ -13,5 +13,5 @@ class Sequence_Base64_Conformance_Error
 }
 
 export {
-  Sequence_Base64_Conformance_Error as _default,
+  Sequence_Base64_Conformance_Error,
 };

--- a/src/library/Sequence/Base64/Conformance/ensure.ts
+++ b/src/library/Sequence/Base64/Conformance/ensure.ts
@@ -5,7 +5,7 @@ import {
 } from '../pattern';
 
 import {
-  _default as Sequence_Base64_Conformance_Error,
+  Sequence_Base64_Conformance_Error,
 } from './Error';
 
 const Sequence_Base64_Conformance_ensure = (

--- a/src/library/Sequence/Base64/Conformance/ensure.ts
+++ b/src/library/Sequence/Base64/Conformance/ensure.ts
@@ -22,5 +22,5 @@ const Sequence_Base64_Conformance_ensure = (
 });
 
 export {
-  Sequence_Base64_Conformance_ensure as ensure,
+  Sequence_Base64_Conformance_ensure,
 };

--- a/src/library/Sequence/Base64/Conformance/exports.ts
+++ b/src/library/Sequence/Base64/Conformance/exports.ts
@@ -1,5 +1,5 @@
 export {
-  ensure,
+  Sequence_Base64_Conformance_ensure as ensure,
 } from './ensure';
 
 export {

--- a/src/library/Sequence/Base64/Conformance/exports.ts
+++ b/src/library/Sequence/Base64/Conformance/exports.ts
@@ -3,5 +3,5 @@ export {
 } from './ensure';
 
 export {
-  _default as Error,
+  Sequence_Base64_Conformance_Error as Error,
 } from './Error';

--- a/src/library/Sequence/Byte/Encoded/Base64/ParsingError.ts
+++ b/src/library/Sequence/Byte/Encoded/Base64/ParsingError.ts
@@ -48,5 +48,5 @@ class Sequence_Byte_Encoded_Base64_ParsingError
 }
 
 export {
-  Sequence_Byte_Encoded_Base64_ParsingError as _default,
+  Sequence_Byte_Encoded_Base64_ParsingError,
 };

--- a/src/library/Sequence/Byte/Encoded/Base64/definition.ts
+++ b/src/library/Sequence/Byte/Encoded/Base64/definition.ts
@@ -19,7 +19,7 @@ import {
 } from '../Compatibility';
 
 import {
-  _default as Sequence_Byte_Encoded_Base64_ParsingError,
+  Sequence_Byte_Encoded_Base64_ParsingError,
 } from './ParsingError.ts';
 
 /** See [RFC 4648 Section 4](https://www.rfc-editor.org/rfc/rfc4648.html#section-4) for more information */

--- a/src/library/Sequence/Byte/Encoded/Compatibility/Error.ts
+++ b/src/library/Sequence/Byte/Encoded/Compatibility/Error.ts
@@ -16,5 +16,5 @@ class Sequence_Byte_Encoded_Compatibility_Error
 }
 
 export {
-  Sequence_Byte_Encoded_Compatibility_Error as _default,
+  Sequence_Byte_Encoded_Compatibility_Error,
 };

--- a/src/library/Sequence/Byte/Encoded/Compatibility/ensure.ts
+++ b/src/library/Sequence/Byte/Encoded/Compatibility/ensure.ts
@@ -26,5 +26,5 @@ const Sequence_Byte_Encoded_Compatibility_ensure = (
 });
 
 export {
-  Sequence_Byte_Encoded_Compatibility_ensure as ensure,
+  Sequence_Byte_Encoded_Compatibility_ensure,
 };

--- a/src/library/Sequence/Byte/Encoded/Compatibility/ensure.ts
+++ b/src/library/Sequence/Byte/Encoded/Compatibility/ensure.ts
@@ -2,7 +2,7 @@ import Attempt from '@/library/Attempt';
 import Byte from '@/library/Byte';
 
 import {
-  _default as Sequence_Byte_Encoded_Compatibility_Error,
+  Sequence_Byte_Encoded_Compatibility_Error,
 } from './Error';
 
 const Sequence_Byte_Encoded_Compatibility_ensure = (

--- a/src/library/Sequence/Byte/Encoded/Compatibility/exports.ts
+++ b/src/library/Sequence/Byte/Encoded/Compatibility/exports.ts
@@ -1,5 +1,5 @@
 export {
-  ensure,
+  Sequence_Byte_Encoded_Compatibility_ensure as ensure,
 } from './ensure';
 
 export {

--- a/src/library/Sequence/Byte/Encoded/Compatibility/exports.ts
+++ b/src/library/Sequence/Byte/Encoded/Compatibility/exports.ts
@@ -3,5 +3,5 @@ export {
 } from './ensure';
 
 export {
-  _default as Error,
+  Sequence_Byte_Encoded_Compatibility_Error as Error,
 } from './Error';

--- a/src/library/ShimmedStabilityAIClient/SDXL/DiffusionStepCount.ts
+++ b/src/library/ShimmedStabilityAIClient/SDXL/DiffusionStepCount.ts
@@ -16,5 +16,5 @@ abstract class SDXL_DiffusionStepCount { // eslint-disable-line @typescript-esli
 }
 
 export {
-  SDXL_DiffusionStepCount as _default,
+  SDXL_DiffusionStepCount,
 };

--- a/src/library/ShimmedStabilityAIClient/SDXL/exports.ts
+++ b/src/library/ShimmedStabilityAIClient/SDXL/exports.ts
@@ -1,3 +1,3 @@
 export {
-  _default as SDXL_DiffusionStepCount,
+  SDXL_DiffusionStepCount,
 } from './DiffusionStepCount';

--- a/src/library/WebAPI/Server.ts
+++ b/src/library/WebAPI/Server.ts
@@ -30,5 +30,5 @@ class WebAPI_Server {
 }
 
 export {
-  WebAPI_Server as _default,
+  WebAPI_Server,
 };

--- a/src/library/WebAPI/exports.ts
+++ b/src/library/WebAPI/exports.ts
@@ -1,5 +1,5 @@
 import {
-  _default as WebAPI_Server,
+  WebAPI_Server,
 } from './Server.ts';
 
 export {

--- a/src/library/modifiersByType/error/Contextualized/assume.ts
+++ b/src/library/modifiersByType/error/Contextualized/assume.ts
@@ -5,7 +5,7 @@ import type {
 } from '@/library/typeUtilities';
 
 import type {
-  _default as Contextualized,
+  Contextualized,
 } from './definition.ts';
 
 import {

--- a/src/library/modifiersByType/error/Contextualized/cast.ts
+++ b/src/library/modifiersByType/error/Contextualized/cast.ts
@@ -7,7 +7,7 @@ import {
 } from './assume';
 
 import type {
-  _default as Contextualized,
+  Contextualized,
 } from './definition.ts';
 
 import {

--- a/src/library/modifiersByType/error/Contextualized/definition.ts
+++ b/src/library/modifiersByType/error/Contextualized/definition.ts
@@ -28,5 +28,5 @@ const Contextualized = {
 };
 
 export {
-  Contextualized as _default,
+  Contextualized,
 };

--- a/src/library/modifiersByType/error/Contextualized/describes.ts
+++ b/src/library/modifiersByType/error/Contextualized/describes.ts
@@ -3,7 +3,7 @@ import type {
 } from '@/library/typeUtilities';
 
 import type {
-  _default as Contextualized,
+  Contextualized,
 } from './definition.ts';
 
 const Contextualized_describes = <

--- a/src/library/modifiersByType/error/Contextualized/exports.ts
+++ b/src/library/modifiersByType/error/Contextualized/exports.ts
@@ -1,3 +1,3 @@
 export {
-  _default,
+  Contextualized as _default,
 } from './definition.ts';

--- a/src/library/typeUtilities/Static.ts
+++ b/src/library/typeUtilities/Static.ts
@@ -6,5 +6,5 @@ interface Static<
 }
 
 export type {
-  Static as _default,
+  Static,
 };

--- a/src/library/typeUtilities/exports.ts
+++ b/src/library/typeUtilities/exports.ts
@@ -5,7 +5,7 @@ export type * from './Instantiable';
 export type * from './Batched';
 
 export type {
-  _default as Static,
+  Static,
 } from './Static';
 
 export type * from './Branded';

--- a/src/utilities/Repository/definition.ts
+++ b/src/utilities/Repository/definition.ts
@@ -24,5 +24,5 @@ const Repository = {
 };
 
 export {
-  Repository as _default,
+  Repository,
 };

--- a/src/utilities/Repository/exports.ts
+++ b/src/utilities/Repository/exports.ts
@@ -1,3 +1,3 @@
 export {
-  _default,
+  Repository as _default,
 } from './definition.ts';


### PR DESCRIPTION
- a unit module should name itself
- placing a unit in a hierarchy is delegated to "exports" files