### PR TITLE
types: ensures `type` exports for type-only units

### DIFF
--- a/src/library/Attempt/Outcome/Transformer.ts
+++ b/src/library/Attempt/Outcome/Transformer.ts
@@ -46,6 +46,6 @@ type Attempt_Outcome_Transformer<
   )
 ;
 
-export {
-  type Attempt_Outcome_Transformer,
+export type {
+  Attempt_Outcome_Transformer,
 };


### PR DESCRIPTION
- `type` dictates whether an export should be revealed to the runtime as well, rather than just the compiler
- by hiding these type-only units from the runtime at the module level, we can guarantee that the bundler will ignore the module all together during a build 