### PR TITLE
refactor: decouples mixtures of paradigms

### DIFF
--- a/src/library/Attempt/Error/exports.ts
+++ b/src/library/Attempt/Error/exports.ts
@@ -17,5 +17,3 @@ export {
 export type {
   Attempt_Error_Interpreter,
 } from './Interpreter';
-
-export * from './exports_objectAdjacent.ts';

--- a/src/library/Attempt/Error/exports.ts
+++ b/src/library/Attempt/Error/exports.ts
@@ -18,4 +18,4 @@ export type {
   Attempt_Error_Interpreter,
 } from './Interpreter';
 
-export * from './modifier';
+export * from './exports_objectAdjacent.ts';

--- a/src/library/Attempt/Error/exports_objectAdjacent.ts
+++ b/src/library/Attempt/Error/exports_objectAdjacent.ts
@@ -1,0 +1,1 @@
+export * from './modifier';

--- a/src/library/Attempt/Error/index.ts
+++ b/src/library/Attempt/Error/index.ts
@@ -1,1 +1,3 @@
 export * from './exports.ts';
+
+export * from './exports_objectAdjacent.ts';

--- a/src/library/Attempt/Outcome/exports.ts
+++ b/src/library/Attempt/Outcome/exports.ts
@@ -3,5 +3,3 @@ export * from './definition.ts';
 export * from './Success';
 
 export * from './Failure';
-
-export type * from './exports_toolbox.ts';

--- a/src/library/Attempt/Outcome/exports.ts
+++ b/src/library/Attempt/Outcome/exports.ts
@@ -4,4 +4,4 @@ export * from './Success';
 
 export * from './Failure';
 
-export type * from './typeParameters';
+export type * from './exports_toolbox.ts';

--- a/src/library/Attempt/Outcome/exports_toolbox.ts
+++ b/src/library/Attempt/Outcome/exports_toolbox.ts
@@ -1,0 +1,1 @@
+export type * from './typeParameters';

--- a/src/library/Attempt/Outcome/index.ts
+++ b/src/library/Attempt/Outcome/index.ts
@@ -1,1 +1,3 @@
 export * from './exports.ts';
+
+export type * from './exports_toolbox.ts';

--- a/src/library/ContentDescriptor/exports.ts
+++ b/src/library/ContentDescriptor/exports.ts
@@ -2,4 +2,4 @@ export {
   ContentDescriptor,
 } from './definition.ts';
 
-export * from './misnomers';
+export * from './exports_objectAdjacent.ts';

--- a/src/library/ContentDescriptor/exports.ts
+++ b/src/library/ContentDescriptor/exports.ts
@@ -1,5 +1,3 @@
 export {
   ContentDescriptor,
 } from './definition.ts';
-
-export * from './exports_objectAdjacent.ts';

--- a/src/library/ContentDescriptor/exports_objectAdjacent.ts
+++ b/src/library/ContentDescriptor/exports_objectAdjacent.ts
@@ -1,0 +1,1 @@
+export * from './misnomers';

--- a/src/library/ContentDescriptor/index.ts
+++ b/src/library/ContentDescriptor/index.ts
@@ -1,6 +1,5 @@
 export {
   ContentDescriptor as default,
-  ContentType,
-  MediaType,
-  MIMEType,
 } from './exports.ts';
+
+export * from './exports_objectAdjacent.ts';

--- a/src/library/ShimmedStabilityAIClient/exports.ts
+++ b/src/library/ShimmedStabilityAIClient/exports.ts
@@ -2,4 +2,4 @@ export {
   ShimmedStabilityAIClient,
 } from './definition.ts';
 
-export * from './SDXL';
+export * from './exports_objectAdjacent.ts';

--- a/src/library/ShimmedStabilityAIClient/exports.ts
+++ b/src/library/ShimmedStabilityAIClient/exports.ts
@@ -1,5 +1,3 @@
 export {
   ShimmedStabilityAIClient,
 } from './definition.ts';
-
-export * from './exports_objectAdjacent.ts';

--- a/src/library/ShimmedStabilityAIClient/exports_objectAdjacent.ts
+++ b/src/library/ShimmedStabilityAIClient/exports_objectAdjacent.ts
@@ -1,0 +1,1 @@
+export * from './SDXL';

--- a/src/library/ShimmedStabilityAIClient/index.ts
+++ b/src/library/ShimmedStabilityAIClient/index.ts
@@ -1,4 +1,5 @@
 export {
   ShimmedStabilityAIClient as default,
-  SDXL_DiffusionStepCount,
 } from './exports.ts';
+
+export * from './exports_objectAdjacent.ts';

--- a/src/library/math/operator/constructive/absoluteValueOf/exports.ts
+++ b/src/library/math/operator/constructive/absoluteValueOf/exports.ts
@@ -1,3 +1,1 @@
 export * from './definition.ts';
-
-export * from './exports_objectAdjacent.ts';

--- a/src/library/math/operator/constructive/absoluteValueOf/exports.ts
+++ b/src/library/math/operator/constructive/absoluteValueOf/exports.ts
@@ -1,3 +1,3 @@
 export * from './definition.ts';
 
-export * from './aliases';
+export * from './exports_objectAdjacent.ts';

--- a/src/library/math/operator/constructive/absoluteValueOf/exports_objectAdjacent.ts
+++ b/src/library/math/operator/constructive/absoluteValueOf/exports_objectAdjacent.ts
@@ -1,0 +1,1 @@
+export * from './aliases';

--- a/src/library/math/operator/constructive/absoluteValueOf/index.ts
+++ b/src/library/math/operator/constructive/absoluteValueOf/index.ts
@@ -1,1 +1,3 @@
 export * from './exports.ts';
+
+export * from './exports_objectAdjacent.ts';

--- a/src/library/math/operator/constructive/greatestCommonDivisor/exports.ts
+++ b/src/library/math/operator/constructive/greatestCommonDivisor/exports.ts
@@ -1,3 +1,1 @@
 export * from './definition.ts';
-
-export * from './exports_objectAdjacent.ts';

--- a/src/library/math/operator/constructive/greatestCommonDivisor/exports.ts
+++ b/src/library/math/operator/constructive/greatestCommonDivisor/exports.ts
@@ -1,5 +1,3 @@
 export * from './definition.ts';
 
-export * from './aliases';
-
-export * from './abbreviations';
+export * from './exports_objectAdjacent.ts';

--- a/src/library/math/operator/constructive/greatestCommonDivisor/exports_objectAdjacent.ts
+++ b/src/library/math/operator/constructive/greatestCommonDivisor/exports_objectAdjacent.ts
@@ -1,0 +1,3 @@
+export * from './aliases';
+
+export * from './abbreviations';

--- a/src/library/math/operator/constructive/greatestCommonDivisor/index.ts
+++ b/src/library/math/operator/constructive/greatestCommonDivisor/index.ts
@@ -1,1 +1,3 @@
 export * from './exports.ts';
+
+export * from './exports_objectAdjacent.ts';

--- a/src/library/math/operator/predicate/isWhole/exports.ts
+++ b/src/library/math/operator/predicate/isWhole/exports.ts
@@ -1,3 +1,1 @@
 export * from './definition.ts';
-
-export * from './exports_objectAdjacent.ts';

--- a/src/library/math/operator/predicate/isWhole/exports.ts
+++ b/src/library/math/operator/predicate/isWhole/exports.ts
@@ -1,3 +1,3 @@
 export * from './definition.ts';
 
-export * from './aliases';
+export * from './exports_objectAdjacent.ts';

--- a/src/library/math/operator/predicate/isWhole/exports_objectAdjacent.ts
+++ b/src/library/math/operator/predicate/isWhole/exports_objectAdjacent.ts
@@ -1,0 +1,1 @@
+export * from './aliases';

--- a/src/library/math/operator/predicate/isWhole/index.ts
+++ b/src/library/math/operator/predicate/isWhole/index.ts
@@ -1,1 +1,3 @@
 export * from './exports.ts';
+
+export * from './exports_objectAdjacent.ts';


### PR DESCRIPTION
- Some top-level modules have both object-oriented and functional exports, depending on the idea or concept represented by the module.
- Some modules provide common aliases, misnomers, and/or abbreviations to aid discoverability.
- Those aliases and such are usually exposed as named exports, with the top-level "primary" namespace/object exposed as the `default` export
- This doesn't expand automatically when aliases and the like are added to a module's exports because of limitations in TypeScript's syntax
- It also required modifying the index when more aliases were added to the list.
- The solution was to avoid mixing them anywhere except for the index files, allowing for leveraging of the `*` syntax for imports