### PR TITLE
refactor: ensures namespace labels can be isolated

### DIFF
--- a/src/features/Reporting/exports_objectOriented.ts
+++ b/src/features/Reporting/exports_objectOriented.ts
@@ -1,0 +1,1 @@
+export * from './namespace.ts';

--- a/src/features/Reporting/index.ts
+++ b/src/features/Reporting/index.ts
@@ -1,1 +1,1 @@
-export * from './namespaceMembers.ts';
+export * from './exports_objectOriented.ts';

--- a/src/features/Reporting/namespace.ts
+++ b/src/features/Reporting/namespace.ts
@@ -1,0 +1,1 @@
+export * from './namespaceMembers.ts';

--- a/src/features/TextToImage/Client/Generation/exports_objectOriented.ts
+++ b/src/features/TextToImage/Client/Generation/exports_objectOriented.ts
@@ -1,0 +1,1 @@
+export type * from './namespace.ts';

--- a/src/features/TextToImage/Client/Generation/index.ts
+++ b/src/features/TextToImage/Client/Generation/index.ts
@@ -1,1 +1,1 @@
-export type * as TextToImage_Client_Generation from './namespaceMembers.ts';
+export type * as TextToImage_Client_Generation from './exports_objectOriented.ts';

--- a/src/features/TextToImage/Client/Generation/namespace.ts
+++ b/src/features/TextToImage/Client/Generation/namespace.ts
@@ -1,0 +1,1 @@
+export type * from './namespaceMembers.ts';

--- a/src/features/TextToImage/Client/SDXL/exports_objectOriented.ts
+++ b/src/features/TextToImage/Client/SDXL/exports_objectOriented.ts
@@ -1,0 +1,1 @@
+export * from './namespace.ts';

--- a/src/features/TextToImage/Client/SDXL/index.ts
+++ b/src/features/TextToImage/Client/SDXL/index.ts
@@ -1,4 +1,4 @@
-import * as TextToImage_Client_SDXL from './namespaceMembers.ts';
+import * as TextToImage_Client_SDXL from './exports_objectOriented.ts';
 
 export {
   TextToImage_Client_SDXL,

--- a/src/features/TextToImage/Client/SDXL/namespace.ts
+++ b/src/features/TextToImage/Client/SDXL/namespace.ts
@@ -1,0 +1,1 @@
+export * from './namespaceMembers.ts';

--- a/src/features/TextToImage/Client/SDXL/toSharkUIOutput/Image/Description/exports_objectOriented.ts
+++ b/src/features/TextToImage/Client/SDXL/toSharkUIOutput/Image/Description/exports_objectOriented.ts
@@ -1,0 +1,1 @@
+export * from './namespace.ts';

--- a/src/features/TextToImage/Client/SDXL/toSharkUIOutput/Image/Description/index.ts
+++ b/src/features/TextToImage/Client/SDXL/toSharkUIOutput/Image/Description/index.ts
@@ -1,1 +1,1 @@
-export * from './namespaceMembers.ts';
+export * from './exports_objectOriented.ts';

--- a/src/features/TextToImage/Client/SDXL/toSharkUIOutput/Image/Description/namespace.ts
+++ b/src/features/TextToImage/Client/SDXL/toSharkUIOutput/Image/Description/namespace.ts
@@ -1,0 +1,1 @@
+export * from './namespaceMembers.ts';

--- a/src/features/TextToImage/Client/SDXL/toSharkUIOutput/exports_objectOriented.ts
+++ b/src/features/TextToImage/Client/SDXL/toSharkUIOutput/exports_objectOriented.ts
@@ -1,0 +1,1 @@
+export * from './namespace.ts';

--- a/src/features/TextToImage/Client/SDXL/toSharkUIOutput/index.ts
+++ b/src/features/TextToImage/Client/SDXL/toSharkUIOutput/index.ts
@@ -1,1 +1,1 @@
-export * from './namespaceMembers.ts';
+export * from './exports_objectOriented.ts';

--- a/src/features/TextToImage/Client/SDXL/toSharkUIOutput/namespace.ts
+++ b/src/features/TextToImage/Client/SDXL/toSharkUIOutput/namespace.ts
@@ -1,0 +1,1 @@
+export * from './namespaceMembers.ts';

--- a/src/features/TextToImage/Client/exports_objectOriented.ts
+++ b/src/features/TextToImage/Client/exports_objectOriented.ts
@@ -1,0 +1,1 @@
+export * from './namespace.ts';

--- a/src/features/TextToImage/Client/index.ts
+++ b/src/features/TextToImage/Client/index.ts
@@ -1,1 +1,1 @@
-export * from './namespaceMembers.ts';
+export * from './exports_objectOriented.ts';

--- a/src/features/TextToImage/Client/namespace.ts
+++ b/src/features/TextToImage/Client/namespace.ts
@@ -1,0 +1,1 @@
+export * from './namespaceMembers.ts';

--- a/src/features/TextToImage/Config/Dynamic/Fetching/Error/exports_objectOriented.ts
+++ b/src/features/TextToImage/Config/Dynamic/Fetching/Error/exports_objectOriented.ts
@@ -1,0 +1,1 @@
+export * from './namespace.ts';

--- a/src/features/TextToImage/Config/Dynamic/Fetching/Error/index.ts
+++ b/src/features/TextToImage/Config/Dynamic/Fetching/Error/index.ts
@@ -1,1 +1,1 @@
-export * as TextToImage_Config_Dynamic_Fetching_Error from './namespaceMembers.ts';
+export * as TextToImage_Config_Dynamic_Fetching_Error from './exports_objectOriented.ts';

--- a/src/features/TextToImage/Config/Dynamic/Fetching/Error/namespace.ts
+++ b/src/features/TextToImage/Config/Dynamic/Fetching/Error/namespace.ts
@@ -1,0 +1,1 @@
+export * from './namespaceMembers.ts';

--- a/src/features/TextToImage/Config/Dynamic/Fetching/exports_objectOriented.ts
+++ b/src/features/TextToImage/Config/Dynamic/Fetching/exports_objectOriented.ts
@@ -1,0 +1,1 @@
+export * from './namespace.ts';

--- a/src/features/TextToImage/Config/Dynamic/Fetching/index.ts
+++ b/src/features/TextToImage/Config/Dynamic/Fetching/index.ts
@@ -1,1 +1,1 @@
-export * as TextToImage_Config_Dynamic_Fetching from './namespaceMembers.ts';
+export * as TextToImage_Config_Dynamic_Fetching from './exports_objectOriented.ts';

--- a/src/features/TextToImage/Config/Dynamic/Fetching/namespace.ts
+++ b/src/features/TextToImage/Config/Dynamic/Fetching/namespace.ts
@@ -1,0 +1,1 @@
+export * from './namespaceMembers.ts';

--- a/src/features/TextToImage/Config/Dynamic/exports_objectOriented.ts
+++ b/src/features/TextToImage/Config/Dynamic/exports_objectOriented.ts
@@ -1,0 +1,1 @@
+export * from './namespace.ts';

--- a/src/features/TextToImage/Config/Dynamic/index.ts
+++ b/src/features/TextToImage/Config/Dynamic/index.ts
@@ -1,1 +1,1 @@
-export * from './namespaceMembers.ts';
+export * from './exports_objectOriented.ts';

--- a/src/features/TextToImage/Config/Dynamic/namespace.ts
+++ b/src/features/TextToImage/Config/Dynamic/namespace.ts
@@ -1,0 +1,1 @@
+export * from './namespaceMembers.ts';

--- a/src/features/TextToImage/Config/Static/Reading/exports_objectOriented.ts
+++ b/src/features/TextToImage/Config/Static/Reading/exports_objectOriented.ts
@@ -1,0 +1,1 @@
+export * from './namespace.ts';

--- a/src/features/TextToImage/Config/Static/Reading/index.ts
+++ b/src/features/TextToImage/Config/Static/Reading/index.ts
@@ -1,1 +1,1 @@
-export * as TextToImage_Config_Static_Reading from './namespaceMembers.ts';
+export * as TextToImage_Config_Static_Reading from './exports_objectOriented.ts';

--- a/src/features/TextToImage/Config/Static/Reading/namespace.ts
+++ b/src/features/TextToImage/Config/Static/Reading/namespace.ts
@@ -1,0 +1,1 @@
+export * from './namespaceMembers.ts';

--- a/src/features/TextToImage/Config/Static/exports_objectOriented.ts
+++ b/src/features/TextToImage/Config/Static/exports_objectOriented.ts
@@ -1,0 +1,1 @@
+export * from './namespace.ts';

--- a/src/features/TextToImage/Config/Static/index.ts
+++ b/src/features/TextToImage/Config/Static/index.ts
@@ -1,1 +1,1 @@
-export * from './namespaceMembers.ts';
+export * from './exports_objectOriented.ts';

--- a/src/features/TextToImage/Config/Static/namespace.ts
+++ b/src/features/TextToImage/Config/Static/namespace.ts
@@ -1,0 +1,1 @@
+export * from './namespaceMembers.ts';

--- a/src/features/TextToImage/Config/exports_objectOriented.ts
+++ b/src/features/TextToImage/Config/exports_objectOriented.ts
@@ -1,0 +1,1 @@
+export * from './namespace.ts';

--- a/src/features/TextToImage/Config/index.ts
+++ b/src/features/TextToImage/Config/index.ts
@@ -1,1 +1,1 @@
-export * from './namespaceMembers.ts';
+export * from './exports_objectOriented.ts';

--- a/src/features/TextToImage/Config/namespace.ts
+++ b/src/features/TextToImage/Config/namespace.ts
@@ -1,0 +1,1 @@
+export * from './namespaceMembers.ts';

--- a/src/features/TextToImage/Pipeline/Output/Nullable/exports_objectOriented.ts
+++ b/src/features/TextToImage/Pipeline/Output/Nullable/exports_objectOriented.ts
@@ -1,0 +1,1 @@
+export * from './namespace.ts';

--- a/src/features/TextToImage/Pipeline/Output/Nullable/index.ts
+++ b/src/features/TextToImage/Pipeline/Output/Nullable/index.ts
@@ -1,1 +1,1 @@
-export * from './namespaceMembers.ts';
+export * from './exports_objectOriented.ts';

--- a/src/features/TextToImage/Pipeline/Output/Nullable/namespace.ts
+++ b/src/features/TextToImage/Pipeline/Output/Nullable/namespace.ts
@@ -1,0 +1,1 @@
+export * from './namespaceMembers.ts';

--- a/src/features/TextToImage/Pipeline/exports_objectOriented.ts
+++ b/src/features/TextToImage/Pipeline/exports_objectOriented.ts
@@ -1,0 +1,1 @@
+export * from './namespace.ts';

--- a/src/features/TextToImage/Pipeline/index.ts
+++ b/src/features/TextToImage/Pipeline/index.ts
@@ -1,1 +1,1 @@
-export * from './namespaceMembers.ts';
+export * from './exports_objectOriented.ts';

--- a/src/features/TextToImage/Pipeline/namespace.ts
+++ b/src/features/TextToImage/Pipeline/namespace.ts
@@ -1,0 +1,1 @@
+export * from './namespaceMembers.ts';

--- a/src/features/TextToImage/Server/Current/exports_objectOriented.ts
+++ b/src/features/TextToImage/Server/Current/exports_objectOriented.ts
@@ -1,0 +1,1 @@
+export * from './namespace.ts';

--- a/src/features/TextToImage/Server/Current/index.ts
+++ b/src/features/TextToImage/Server/Current/index.ts
@@ -1,1 +1,1 @@
-export * from './namespaceMembers.ts';
+export * from './exports_objectOriented.ts';

--- a/src/features/TextToImage/Server/Current/namespace.ts
+++ b/src/features/TextToImage/Server/Current/namespace.ts
@@ -1,0 +1,1 @@
+export * from './namespaceMembers.ts';

--- a/src/features/TextToImage/Server/Error/exports_objectOriented.ts
+++ b/src/features/TextToImage/Server/Error/exports_objectOriented.ts
@@ -1,0 +1,1 @@
+export * from './namespace.ts';

--- a/src/features/TextToImage/Server/Error/index.ts
+++ b/src/features/TextToImage/Server/Error/index.ts
@@ -1,1 +1,1 @@
-export * as TextToImage_Server_Error from './namespaceMembers.ts';
+export * as TextToImage_Server_Error from './exports_objectOriented.ts';

--- a/src/features/TextToImage/Server/Error/namespace.ts
+++ b/src/features/TextToImage/Server/Error/namespace.ts
@@ -1,0 +1,1 @@
+export * from './namespaceMembers.ts';

--- a/src/features/TextToImage/Server/Origin/exports_objectOriented.ts
+++ b/src/features/TextToImage/Server/Origin/exports_objectOriented.ts
@@ -1,0 +1,1 @@
+export * from './namespace.ts';

--- a/src/features/TextToImage/Server/Origin/index.ts
+++ b/src/features/TextToImage/Server/Origin/index.ts
@@ -1,1 +1,1 @@
-export * as TextToImage_Server_Origin from './namespaceMembers.ts';
+export * as TextToImage_Server_Origin from './exports_objectOriented.ts';

--- a/src/features/TextToImage/Server/Origin/namespace.ts
+++ b/src/features/TextToImage/Server/Origin/namespace.ts
@@ -1,0 +1,1 @@
+export * from './namespaceMembers.ts';

--- a/src/features/TextToImage/Server/exports_objectOriented.ts
+++ b/src/features/TextToImage/Server/exports_objectOriented.ts
@@ -1,0 +1,1 @@
+export * from './namespace.ts';

--- a/src/features/TextToImage/Server/index.ts
+++ b/src/features/TextToImage/Server/index.ts
@@ -1,1 +1,1 @@
-export * from './namespaceMembers.ts';
+export * from './exports_objectOriented.ts';

--- a/src/features/TextToImage/Server/namespace.ts
+++ b/src/features/TextToImage/Server/namespace.ts
@@ -1,0 +1,1 @@
+export * from './namespaceMembers.ts';

--- a/src/features/TextToImage/exports_objectOriented.ts
+++ b/src/features/TextToImage/exports_objectOriented.ts
@@ -1,0 +1,1 @@
+export * from './namespace.ts';

--- a/src/features/TextToImage/index.ts
+++ b/src/features/TextToImage/index.ts
@@ -1,1 +1,1 @@
-export * from './namespaceMembers.ts';
+export * from './exports_objectOriented.ts';

--- a/src/features/TextToImage/namespace.ts
+++ b/src/features/TextToImage/namespace.ts
@@ -1,0 +1,1 @@
+export * from './namespaceMembers.ts';

--- a/src/library/Attempt/Adapted/exports_objectOriented.ts
+++ b/src/library/Attempt/Adapted/exports_objectOriented.ts
@@ -1,0 +1,1 @@
+export * from './namespace.ts';

--- a/src/library/Attempt/Adapted/index.ts
+++ b/src/library/Attempt/Adapted/index.ts
@@ -1,1 +1,1 @@
-export * from './namespaceMembers.ts';
+export * from './exports_objectOriented.ts';

--- a/src/library/Attempt/Adapted/namespace.ts
+++ b/src/library/Attempt/Adapted/namespace.ts
@@ -1,0 +1,1 @@
+export * from './namespaceMembers.ts';

--- a/src/library/Attempt/End/exports_objectOriented.ts
+++ b/src/library/Attempt/End/exports_objectOriented.ts
@@ -1,0 +1,1 @@
+export type * from './namespace.ts';

--- a/src/library/Attempt/End/index.ts
+++ b/src/library/Attempt/End/index.ts
@@ -1,1 +1,1 @@
-export type * from './namespaceMembers.ts';
+export type * from './exports_objectOriented.ts';

--- a/src/library/Attempt/End/namespace.ts
+++ b/src/library/Attempt/End/namespace.ts
@@ -1,0 +1,1 @@
+export type * from './namespaceMembers.ts';

--- a/src/library/Attempt/Error/exports_objectOriented.ts
+++ b/src/library/Attempt/Error/exports_objectOriented.ts
@@ -1,0 +1,1 @@
+export * from './namespace.ts';

--- a/src/library/Attempt/Error/index.ts
+++ b/src/library/Attempt/Error/index.ts
@@ -1,3 +1,3 @@
-export * from './namespaceMembers.ts';
+export * from './exports_objectOriented.ts';
 
 export * from './exports_objectAdjacent.ts';

--- a/src/library/Attempt/Error/namespace.ts
+++ b/src/library/Attempt/Error/namespace.ts
@@ -1,0 +1,1 @@
+export * from './namespaceMembers.ts';

--- a/src/library/Attempt/Fresh/exports_objectOriented.ts
+++ b/src/library/Attempt/Fresh/exports_objectOriented.ts
@@ -1,0 +1,1 @@
+export * from './namespace.ts';

--- a/src/library/Attempt/Fresh/index.ts
+++ b/src/library/Attempt/Fresh/index.ts
@@ -1,1 +1,1 @@
-export * from './namespaceMembers.ts';
+export * from './exports_objectOriented.ts';

--- a/src/library/Attempt/Fresh/namespace.ts
+++ b/src/library/Attempt/Fresh/namespace.ts
@@ -1,0 +1,1 @@
+export * from './namespaceMembers.ts';

--- a/src/library/Attempt/Outcome/Failure/Cause/exports_objectOriented.ts
+++ b/src/library/Attempt/Outcome/Failure/Cause/exports_objectOriented.ts
@@ -1,0 +1,1 @@
+export * from './namespace.ts';

--- a/src/library/Attempt/Outcome/Failure/Cause/index.ts
+++ b/src/library/Attempt/Outcome/Failure/Cause/index.ts
@@ -1,1 +1,1 @@
-export * from './namespaceMembers.ts';
+export * from './exports_objectOriented.ts';

--- a/src/library/Attempt/Outcome/Failure/Cause/namespace.ts
+++ b/src/library/Attempt/Outcome/Failure/Cause/namespace.ts
@@ -1,0 +1,1 @@
+export * from './namespaceMembers.ts';

--- a/src/library/Attempt/Outcome/Success/Product/exports_objectOriented.ts
+++ b/src/library/Attempt/Outcome/Success/Product/exports_objectOriented.ts
@@ -1,0 +1,1 @@
+export * from './namespace.ts';

--- a/src/library/Attempt/Outcome/Success/Product/index.ts
+++ b/src/library/Attempt/Outcome/Success/Product/index.ts
@@ -1,1 +1,1 @@
-export * from './namespaceMembers.ts';
+export * from './exports_objectOriented.ts';

--- a/src/library/Attempt/Outcome/Success/Product/namespace.ts
+++ b/src/library/Attempt/Outcome/Success/Product/namespace.ts
@@ -1,0 +1,1 @@
+export * from './namespaceMembers.ts';

--- a/src/library/Attempt/exports_objectOriented.ts
+++ b/src/library/Attempt/exports_objectOriented.ts
@@ -1,0 +1,1 @@
+export * from './namespace.ts';

--- a/src/library/Attempt/index.ts
+++ b/src/library/Attempt/index.ts
@@ -1,4 +1,4 @@
-import * as Attempt from './namespaceMembers.ts';
+import * as Attempt from './exports_objectOriented.ts';
 
 export {
   Attempt as default,

--- a/src/library/Attempt/namespace.ts
+++ b/src/library/Attempt/namespace.ts
@@ -1,0 +1,1 @@
+export * from './namespaceMembers.ts';

--- a/src/library/ContentDescriptor/StructuredSyntaxNameSuffix/exports_objectOriented.ts
+++ b/src/library/ContentDescriptor/StructuredSyntaxNameSuffix/exports_objectOriented.ts
@@ -1,0 +1,1 @@
+export * from './namespace.ts';

--- a/src/library/ContentDescriptor/StructuredSyntaxNameSuffix/index.ts
+++ b/src/library/ContentDescriptor/StructuredSyntaxNameSuffix/index.ts
@@ -1,1 +1,1 @@
-export * as ContentDescriptor_StructuredSyntaxNameSuffix from './namespaceMembers.ts';
+export * as ContentDescriptor_StructuredSyntaxNameSuffix from './exports_objectOriented.ts';

--- a/src/library/ContentDescriptor/StructuredSyntaxNameSuffix/namespace.ts
+++ b/src/library/ContentDescriptor/StructuredSyntaxNameSuffix/namespace.ts
@@ -1,0 +1,1 @@
+export * from './namespaceMembers.ts';

--- a/src/library/ContentDescriptor/TopLevel/Composite/exports_objectOriented.ts
+++ b/src/library/ContentDescriptor/TopLevel/Composite/exports_objectOriented.ts
@@ -1,0 +1,1 @@
+export * from './namespace.ts';

--- a/src/library/ContentDescriptor/TopLevel/Composite/index.ts
+++ b/src/library/ContentDescriptor/TopLevel/Composite/index.ts
@@ -1,1 +1,1 @@
-export * as ContentDescriptor_TopLevel_Composite from './namespaceMembers.ts';
+export * as ContentDescriptor_TopLevel_Composite from './exports_objectOriented.ts';

--- a/src/library/ContentDescriptor/TopLevel/Composite/namespace.ts
+++ b/src/library/ContentDescriptor/TopLevel/Composite/namespace.ts
@@ -1,0 +1,1 @@
+export * from './namespaceMembers.ts';

--- a/src/library/ContentDescriptor/TopLevel/Discrete/exports_objectOriented.ts
+++ b/src/library/ContentDescriptor/TopLevel/Discrete/exports_objectOriented.ts
@@ -1,0 +1,1 @@
+export * from './namespace.ts';

--- a/src/library/ContentDescriptor/TopLevel/Discrete/index.ts
+++ b/src/library/ContentDescriptor/TopLevel/Discrete/index.ts
@@ -1,1 +1,1 @@
-export * as ContentDescriptor_TopLevel_Discrete from './namespaceMembers.ts';
+export * as ContentDescriptor_TopLevel_Discrete from './exports_objectOriented.ts';

--- a/src/library/ContentDescriptor/TopLevel/Discrete/namespace.ts
+++ b/src/library/ContentDescriptor/TopLevel/Discrete/namespace.ts
@@ -1,0 +1,1 @@
+export * from './namespaceMembers.ts';

--- a/src/library/ContentDescriptor/TopLevel/exports_objectOriented.ts
+++ b/src/library/ContentDescriptor/TopLevel/exports_objectOriented.ts
@@ -1,0 +1,1 @@
+export * from './namespace.ts';

--- a/src/library/ContentDescriptor/TopLevel/index.ts
+++ b/src/library/ContentDescriptor/TopLevel/index.ts
@@ -1,1 +1,1 @@
-export * as ContentDescriptor_TopLevel from './namespaceMembers.ts';
+export * as ContentDescriptor_TopLevel from './exports_objectOriented.ts';

--- a/src/library/ContentDescriptor/TopLevel/namespace.ts
+++ b/src/library/ContentDescriptor/TopLevel/namespace.ts
@@ -1,0 +1,1 @@
+export * from './namespaceMembers.ts';

--- a/src/library/HTTP/Endpoint/Error/exports_objectOriented.ts
+++ b/src/library/HTTP/Endpoint/Error/exports_objectOriented.ts
@@ -1,0 +1,1 @@
+export * from './namespace.ts';

--- a/src/library/HTTP/Endpoint/Error/index.ts
+++ b/src/library/HTTP/Endpoint/Error/index.ts
@@ -1,1 +1,1 @@
-export * as HTTP_Endpoint_Error from './namespaceMembers.ts';
+export * as HTTP_Endpoint_Error from './exports_objectOriented.ts';

--- a/src/library/HTTP/Endpoint/Error/namespace.ts
+++ b/src/library/HTTP/Endpoint/Error/namespace.ts
@@ -1,0 +1,1 @@
+export * from './namespaceMembers.ts';

--- a/src/library/HTTP/Endpoint/exports_objectOriented.ts
+++ b/src/library/HTTP/Endpoint/exports_objectOriented.ts
@@ -1,0 +1,1 @@
+export * from './namespace.ts';

--- a/src/library/HTTP/Endpoint/index.ts
+++ b/src/library/HTTP/Endpoint/index.ts
@@ -1,1 +1,1 @@
-export * as HTTP_Endpoint from './namespaceMembers.ts';
+export * as HTTP_Endpoint from './exports_objectOriented.ts';

--- a/src/library/HTTP/Endpoint/namespace.ts
+++ b/src/library/HTTP/Endpoint/namespace.ts
@@ -1,0 +1,1 @@
+export * from './namespaceMembers.ts';

--- a/src/library/HTTP/Request/exports_objectOriented.ts
+++ b/src/library/HTTP/Request/exports_objectOriented.ts
@@ -1,0 +1,1 @@
+export * from './namespace.ts';

--- a/src/library/HTTP/Request/index.ts
+++ b/src/library/HTTP/Request/index.ts
@@ -1,1 +1,1 @@
-export * as HTTP_Request from './namespaceMembers.ts';
+export * as HTTP_Request from './exports_objectOriented.ts';

--- a/src/library/HTTP/Request/namespace.ts
+++ b/src/library/HTTP/Request/namespace.ts
@@ -1,0 +1,1 @@
+export * from './namespaceMembers.ts';

--- a/src/library/HTTP/Response/StatusCode/Error/exports_objectOriented.ts
+++ b/src/library/HTTP/Response/StatusCode/Error/exports_objectOriented.ts
@@ -1,0 +1,1 @@
+export * from './namespace.ts';

--- a/src/library/HTTP/Response/StatusCode/Error/index.ts
+++ b/src/library/HTTP/Response/StatusCode/Error/index.ts
@@ -1,1 +1,1 @@
-export * as HTTP_Response_StatusCode_Error from './namespaceMembers.ts';
+export * as HTTP_Response_StatusCode_Error from './exports_objectOriented.ts';

--- a/src/library/HTTP/Response/StatusCode/Error/namespace.ts
+++ b/src/library/HTTP/Response/StatusCode/Error/namespace.ts
@@ -1,0 +1,1 @@
+export * from './namespaceMembers.ts';

--- a/src/library/HTTP/Response/StatusCode/exports_objectOriented.ts
+++ b/src/library/HTTP/Response/StatusCode/exports_objectOriented.ts
@@ -1,0 +1,1 @@
+export * from './namespace.ts';

--- a/src/library/HTTP/Response/StatusCode/index.ts
+++ b/src/library/HTTP/Response/StatusCode/index.ts
@@ -1,1 +1,1 @@
-export * as HTTP_Response_StatusCode from './namespaceMembers.ts';
+export * as HTTP_Response_StatusCode from './exports_objectOriented.ts';

--- a/src/library/HTTP/Response/StatusCode/namespace.ts
+++ b/src/library/HTTP/Response/StatusCode/namespace.ts
@@ -1,0 +1,1 @@
+export * from './namespaceMembers.ts';

--- a/src/library/HTTP/Response/exports_objectOriented.ts
+++ b/src/library/HTTP/Response/exports_objectOriented.ts
@@ -1,0 +1,1 @@
+export * from './namespace.ts';

--- a/src/library/HTTP/Response/index.ts
+++ b/src/library/HTTP/Response/index.ts
@@ -1,1 +1,1 @@
-export * as HTTP_Response from './namespaceMembers.ts';
+export * as HTTP_Response from './exports_objectOriented.ts';

--- a/src/library/HTTP/Response/namespace.ts
+++ b/src/library/HTTP/Response/namespace.ts
@@ -1,0 +1,1 @@
+export * from './namespaceMembers.ts';

--- a/src/library/HTTP/exports_objectOriented.ts
+++ b/src/library/HTTP/exports_objectOriented.ts
@@ -1,0 +1,1 @@
+export * from './namespace.ts';

--- a/src/library/HTTP/index.ts
+++ b/src/library/HTTP/index.ts
@@ -1,4 +1,4 @@
-import * as HTTP from './namespaceMembers.ts';
+import * as HTTP from './exports_objectOriented.ts';
 
 export {
   HTTP as default,

--- a/src/library/HTTP/namespace.ts
+++ b/src/library/HTTP/namespace.ts
@@ -1,0 +1,1 @@
+export * from './namespaceMembers.ts';

--- a/src/library/Parse/exports_objectOriented.ts
+++ b/src/library/Parse/exports_objectOriented.ts
@@ -1,0 +1,1 @@
+export * from './namespace.ts';

--- a/src/library/Parse/index.ts
+++ b/src/library/Parse/index.ts
@@ -1,4 +1,4 @@
-import * as Parse from './namespaceMembers.ts';
+import * as Parse from './exports_objectOriented.ts';
 
 export {
   Parse as default,

--- a/src/library/Parse/namespace.ts
+++ b/src/library/Parse/namespace.ts
@@ -1,0 +1,1 @@
+export * from './namespaceMembers.ts';

--- a/src/library/Schema/exports_objectOriented.ts
+++ b/src/library/Schema/exports_objectOriented.ts
@@ -1,0 +1,1 @@
+export * from './namespace.ts';

--- a/src/library/Schema/index.ts
+++ b/src/library/Schema/index.ts
@@ -1,4 +1,4 @@
-import * as Schema from './namespaceMembers.ts';
+import * as Schema from './exports_objectOriented.ts';
 
 export {
   Schema as default,

--- a/src/library/Schema/namespace.ts
+++ b/src/library/Schema/namespace.ts
@@ -1,0 +1,1 @@
+export * from './namespaceMembers.ts';

--- a/src/library/Sequence/Base64/Conformance/exports_objectOriented.ts
+++ b/src/library/Sequence/Base64/Conformance/exports_objectOriented.ts
@@ -1,0 +1,1 @@
+export * from './namespace.ts';

--- a/src/library/Sequence/Base64/Conformance/index.ts
+++ b/src/library/Sequence/Base64/Conformance/index.ts
@@ -1,1 +1,1 @@
-export * as Sequence_Base64_Conformance from './namespaceMembers.ts';
+export * as Sequence_Base64_Conformance from './exports_objectOriented.ts';

--- a/src/library/Sequence/Base64/Conformance/namespace.ts
+++ b/src/library/Sequence/Base64/Conformance/namespace.ts
@@ -1,0 +1,1 @@
+export * from './namespaceMembers.ts';

--- a/src/library/Sequence/Base64/exports_objectOriented.ts
+++ b/src/library/Sequence/Base64/exports_objectOriented.ts
@@ -1,0 +1,1 @@
+export * from './namespace.ts';

--- a/src/library/Sequence/Base64/index.ts
+++ b/src/library/Sequence/Base64/index.ts
@@ -1,1 +1,1 @@
-export * as Sequence_Base64 from './namespaceMembers.ts';
+export * as Sequence_Base64 from './exports_objectOriented.ts';

--- a/src/library/Sequence/Base64/namespace.ts
+++ b/src/library/Sequence/Base64/namespace.ts
@@ -1,0 +1,1 @@
+export * from './namespaceMembers.ts';

--- a/src/library/Sequence/Byte/Encoded/Compatibility/exports_objectOriented.ts
+++ b/src/library/Sequence/Byte/Encoded/Compatibility/exports_objectOriented.ts
@@ -1,0 +1,1 @@
+export * from './namespace.ts';

--- a/src/library/Sequence/Byte/Encoded/Compatibility/index.ts
+++ b/src/library/Sequence/Byte/Encoded/Compatibility/index.ts
@@ -1,1 +1,1 @@
-export * as Sequence_Byte_Encoded_Compatibility from './namespaceMembers.ts';
+export * as Sequence_Byte_Encoded_Compatibility from './exports_objectOriented.ts';

--- a/src/library/Sequence/Byte/Encoded/Compatibility/namespace.ts
+++ b/src/library/Sequence/Byte/Encoded/Compatibility/namespace.ts
@@ -1,0 +1,1 @@
+export * from './namespaceMembers.ts';

--- a/src/library/Sequence/Byte/Encoded/exports_objectOriented.ts
+++ b/src/library/Sequence/Byte/Encoded/exports_objectOriented.ts
@@ -1,0 +1,1 @@
+export * from './namespace.ts';

--- a/src/library/Sequence/Byte/Encoded/index.ts
+++ b/src/library/Sequence/Byte/Encoded/index.ts
@@ -1,1 +1,1 @@
-export * as Sequence_Byte_Encoded from './namespaceMembers.ts';
+export * as Sequence_Byte_Encoded from './exports_objectOriented.ts';

--- a/src/library/Sequence/Byte/Encoded/namespace.ts
+++ b/src/library/Sequence/Byte/Encoded/namespace.ts
@@ -1,0 +1,1 @@
+export * from './namespaceMembers.ts';

--- a/src/library/Sequence/Byte/exports_objectOriented.ts
+++ b/src/library/Sequence/Byte/exports_objectOriented.ts
@@ -1,0 +1,1 @@
+export * from './namespace.ts';

--- a/src/library/Sequence/Byte/index.ts
+++ b/src/library/Sequence/Byte/index.ts
@@ -1,1 +1,1 @@
-export * as Sequence_Byte from './namespaceMembers.ts';
+export * as Sequence_Byte from './exports_objectOriented.ts';

--- a/src/library/Sequence/Byte/namespace.ts
+++ b/src/library/Sequence/Byte/namespace.ts
@@ -1,0 +1,1 @@
+export * from './namespaceMembers.ts';

--- a/src/library/Sequence/exports_objectOriented.ts
+++ b/src/library/Sequence/exports_objectOriented.ts
@@ -1,0 +1,1 @@
+export * from './namespace.ts';

--- a/src/library/Sequence/index.ts
+++ b/src/library/Sequence/index.ts
@@ -1,4 +1,4 @@
-import * as Sequence from './namespaceMembers.ts';
+import * as Sequence from './exports_objectOriented.ts';
 
 export {
   Sequence as default,

--- a/src/library/Sequence/namespace.ts
+++ b/src/library/Sequence/namespace.ts
@@ -1,0 +1,1 @@
+export * from './namespaceMembers.ts';

--- a/src/library/ShimmedStabilityAIClient/SDXL/exports_objectOriented.ts
+++ b/src/library/ShimmedStabilityAIClient/SDXL/exports_objectOriented.ts
@@ -1,0 +1,1 @@
+export * from './namespace.ts';

--- a/src/library/ShimmedStabilityAIClient/SDXL/index.ts
+++ b/src/library/ShimmedStabilityAIClient/SDXL/index.ts
@@ -1,1 +1,1 @@
-export * from './namespaceMembers.ts';
+export * from './exports_objectOriented.ts';

--- a/src/library/ShimmedStabilityAIClient/SDXL/namespace.ts
+++ b/src/library/ShimmedStabilityAIClient/SDXL/namespace.ts
@@ -1,0 +1,1 @@
+export * from './namespaceMembers.ts';

--- a/src/library/Shortfin/TextToImage/SDXL/Client/Request/exports_objectOriented.ts
+++ b/src/library/Shortfin/TextToImage/SDXL/Client/Request/exports_objectOriented.ts
@@ -1,0 +1,1 @@
+export * from './namespace.ts';

--- a/src/library/Shortfin/TextToImage/SDXL/Client/Request/index.ts
+++ b/src/library/Shortfin/TextToImage/SDXL/Client/Request/index.ts
@@ -1,1 +1,1 @@
-export * as Shortfin_TextToImage_SDXL_Client_Request from './namespaceMembers.ts';
+export * as Shortfin_TextToImage_SDXL_Client_Request from './exports_objectOriented.ts';

--- a/src/library/Shortfin/TextToImage/SDXL/Client/Request/namespace.ts
+++ b/src/library/Shortfin/TextToImage/SDXL/Client/Request/namespace.ts
@@ -1,0 +1,1 @@
+export * from './namespaceMembers.ts';

--- a/src/library/Shortfin/TextToImage/SDXL/Client/Response/exports_objectOriented.ts
+++ b/src/library/Shortfin/TextToImage/SDXL/Client/Response/exports_objectOriented.ts
@@ -1,0 +1,1 @@
+export * from './namespace.ts';

--- a/src/library/Shortfin/TextToImage/SDXL/Client/Response/index.ts
+++ b/src/library/Shortfin/TextToImage/SDXL/Client/Response/index.ts
@@ -1,1 +1,1 @@
-export * as Shortfin_TextToImage_SDXL_Client_Response from './namespaceMembers.ts';
+export * as Shortfin_TextToImage_SDXL_Client_Response from './exports_objectOriented.ts';

--- a/src/library/Shortfin/TextToImage/SDXL/Client/Response/namespace.ts
+++ b/src/library/Shortfin/TextToImage/SDXL/Client/Response/namespace.ts
@@ -1,0 +1,1 @@
+export * from './namespaceMembers.ts';

--- a/src/library/Shortfin/TextToImage/SDXL/Pipeline/Input/Text/exports_objectOriented.ts
+++ b/src/library/Shortfin/TextToImage/SDXL/Pipeline/Input/Text/exports_objectOriented.ts
@@ -1,0 +1,1 @@
+export type * from './namespace.ts';

--- a/src/library/Shortfin/TextToImage/SDXL/Pipeline/Input/Text/index.ts
+++ b/src/library/Shortfin/TextToImage/SDXL/Pipeline/Input/Text/index.ts
@@ -1,1 +1,1 @@
-export type * as Shortfin_TextToImage_SDXL_Pipeline_Input_Text from './namespaceMembers.ts';
+export type * as Shortfin_TextToImage_SDXL_Pipeline_Input_Text from './exports_objectOriented.ts';

--- a/src/library/Shortfin/TextToImage/SDXL/Pipeline/Input/Text/namespace.ts
+++ b/src/library/Shortfin/TextToImage/SDXL/Pipeline/Input/Text/namespace.ts
@@ -1,0 +1,1 @@
+export type * from './namespaceMembers.ts';

--- a/src/library/Shortfin/TextToImage/SDXL/Pipeline/Input/exports_objectOriented.ts
+++ b/src/library/Shortfin/TextToImage/SDXL/Pipeline/Input/exports_objectOriented.ts
@@ -1,0 +1,1 @@
+export type * from './namespace.ts';

--- a/src/library/Shortfin/TextToImage/SDXL/Pipeline/Input/index.ts
+++ b/src/library/Shortfin/TextToImage/SDXL/Pipeline/Input/index.ts
@@ -1,1 +1,1 @@
-export type * as Shortfin_TextToImage_SDXL_Pipeline_Input from './namespaceMembers.ts';
+export type * as Shortfin_TextToImage_SDXL_Pipeline_Input from './exports_objectOriented.ts';

--- a/src/library/Shortfin/TextToImage/SDXL/Pipeline/Input/namespace.ts
+++ b/src/library/Shortfin/TextToImage/SDXL/Pipeline/Input/namespace.ts
@@ -1,0 +1,1 @@
+export type * from './namespaceMembers.ts';

--- a/src/library/Shortfin/TextToImage/SDXL/Pipeline/exports_objectOriented.ts
+++ b/src/library/Shortfin/TextToImage/SDXL/Pipeline/exports_objectOriented.ts
@@ -1,0 +1,1 @@
+export type * from './namespace.ts';

--- a/src/library/Shortfin/TextToImage/SDXL/Pipeline/index.ts
+++ b/src/library/Shortfin/TextToImage/SDXL/Pipeline/index.ts
@@ -1,1 +1,1 @@
-export type * as Shortfin_TextToImage_SDXL_Pipeline from './namespaceMembers.ts';
+export type * as Shortfin_TextToImage_SDXL_Pipeline from './exports_objectOriented.ts';

--- a/src/library/Shortfin/TextToImage/SDXL/Pipeline/namespace.ts
+++ b/src/library/Shortfin/TextToImage/SDXL/Pipeline/namespace.ts
@@ -1,0 +1,1 @@
+export type * from './namespaceMembers.ts';

--- a/src/library/Shortfin/TextToImage/SDXL/exports_objectOriented.ts
+++ b/src/library/Shortfin/TextToImage/SDXL/exports_objectOriented.ts
@@ -1,0 +1,1 @@
+export * from './namespace.ts';

--- a/src/library/Shortfin/TextToImage/SDXL/index.ts
+++ b/src/library/Shortfin/TextToImage/SDXL/index.ts
@@ -1,1 +1,1 @@
-export * as Shortfin_TextToImage_SDXL from './namespaceMembers.ts';
+export * as Shortfin_TextToImage_SDXL from './exports_objectOriented.ts';

--- a/src/library/Shortfin/TextToImage/SDXL/namespace.ts
+++ b/src/library/Shortfin/TextToImage/SDXL/namespace.ts
@@ -1,0 +1,1 @@
+export * from './namespaceMembers.ts';

--- a/src/library/Shortfin/TextToImage/exports_objectOriented.ts
+++ b/src/library/Shortfin/TextToImage/exports_objectOriented.ts
@@ -1,0 +1,1 @@
+export * from './namespace.ts';

--- a/src/library/Shortfin/TextToImage/index.ts
+++ b/src/library/Shortfin/TextToImage/index.ts
@@ -1,1 +1,1 @@
-export * as Shortfin_TextToImage from './namespaceMembers.ts';
+export * as Shortfin_TextToImage from './exports_objectOriented.ts';

--- a/src/library/Shortfin/TextToImage/namespace.ts
+++ b/src/library/Shortfin/TextToImage/namespace.ts
@@ -1,0 +1,1 @@
+export * from './namespaceMembers.ts';

--- a/src/library/Shortfin/exports_objectOriented.ts
+++ b/src/library/Shortfin/exports_objectOriented.ts
@@ -1,0 +1,1 @@
+export * from './namespace.ts';

--- a/src/library/Shortfin/index.ts
+++ b/src/library/Shortfin/index.ts
@@ -1,4 +1,4 @@
-import * as Shortfin from './namespaceMembers.ts';
+import * as Shortfin from './exports_objectOriented.ts';
 
 export {
   Shortfin as default,

--- a/src/library/Shortfin/namespace.ts
+++ b/src/library/Shortfin/namespace.ts
@@ -1,0 +1,1 @@
+export * from './namespaceMembers.ts';

--- a/src/library/URLComponent/exports_objectOriented.ts
+++ b/src/library/URLComponent/exports_objectOriented.ts
@@ -1,0 +1,1 @@
+export * from './namespace.ts';

--- a/src/library/URLComponent/index.ts
+++ b/src/library/URLComponent/index.ts
@@ -1,1 +1,1 @@
-export * from './namespaceMembers.ts';
+export * from './exports_objectOriented.ts';

--- a/src/library/URLComponent/namespace.ts
+++ b/src/library/URLComponent/namespace.ts
@@ -1,0 +1,1 @@
+export * from './namespaceMembers.ts';

--- a/src/library/UniformResourceIdentifier/Data/EncodingIdentifier/exports_objectOriented.ts
+++ b/src/library/UniformResourceIdentifier/Data/EncodingIdentifier/exports_objectOriented.ts
@@ -1,0 +1,1 @@
+export * from './namespace.ts';

--- a/src/library/UniformResourceIdentifier/Data/EncodingIdentifier/index.ts
+++ b/src/library/UniformResourceIdentifier/Data/EncodingIdentifier/index.ts
@@ -1,1 +1,1 @@
-export * as URI_Data_EncodingIdentifier from './namespaceMembers.ts';
+export * as URI_Data_EncodingIdentifier from './exports_objectOriented.ts';

--- a/src/library/UniformResourceIdentifier/Data/EncodingIdentifier/namespace.ts
+++ b/src/library/UniformResourceIdentifier/Data/EncodingIdentifier/namespace.ts
@@ -1,0 +1,1 @@
+export * from './namespaceMembers.ts';

--- a/src/library/UniformResourceIdentifier/Image/Format/exports_objectOriented.ts
+++ b/src/library/UniformResourceIdentifier/Image/Format/exports_objectOriented.ts
@@ -1,0 +1,1 @@
+export * from './namespace.ts';

--- a/src/library/UniformResourceIdentifier/Image/Format/index.ts
+++ b/src/library/UniformResourceIdentifier/Image/Format/index.ts
@@ -1,1 +1,1 @@
-export * as URI_Image_Format from './namespaceMembers.ts';
+export * as URI_Image_Format from './exports_objectOriented.ts';

--- a/src/library/UniformResourceIdentifier/Image/Format/namespace.ts
+++ b/src/library/UniformResourceIdentifier/Image/Format/namespace.ts
@@ -1,0 +1,1 @@
+export * from './namespaceMembers.ts';

--- a/src/library/WebAPI/exports_objectOriented.ts
+++ b/src/library/WebAPI/exports_objectOriented.ts
@@ -1,0 +1,1 @@
+export * from './namespace.ts';

--- a/src/library/WebAPI/index.ts
+++ b/src/library/WebAPI/index.ts
@@ -1,1 +1,1 @@
-export * from './namespaceMembers.ts';
+export * from './exports_objectOriented.ts';

--- a/src/library/WebAPI/namespace.ts
+++ b/src/library/WebAPI/namespace.ts
@@ -1,0 +1,1 @@
+export * from './namespaceMembers.ts';


### PR DESCRIPTION
- "index.ts" files are currently doing double+ duty for some modules:
  - constructing the central object from the list of namespace members: `import * as SomeNamespace...`
  - determining how that central object should be presented to external modules:
    - `export { SomeNamespace };`
    - `export { SomeNamespace as default };`
- this conflation makes it much harder to determine which way an index file should be tested
- the solution was to provision the files that make up the connective tissue, each re-exporting the one prior:
  - "/namespaceMembers.ts": calls out the members for the namespace-to-be
  - "/namespace.ts": nests the members under a single label for the namespace
  - "/exports_objectOriented.ts": acknowledges that the central object for this module was constructed rather than declared (via "/definition.ts") and can be exposed
  - "/index.ts": exposes the central object, making it `default` in the case of a top-level module
- this design makes it easier to validate whether the module is shaped in a way that's intuitive for consumers