### PR TITLE
refactor: highlights all nestable re-exports

### DIFF
--- a/src/features/TextToImage/Client/SDXL/toSharkUIOutput/Image/exports_objectOriented.ts
+++ b/src/features/TextToImage/Client/SDXL/toSharkUIOutput/Image/exports_objectOriented.ts
@@ -1,3 +1,6 @@
 export * from './definition.ts';
 
-export * from './Description';
+export {
+  toSharkUIOutput_Image_Description_singular,
+  toSharkUIOutput_Image_Description_all,
+} from './Description';

--- a/src/features/TextToImage/Pipeline/Output/exports_objectOriented.ts
+++ b/src/features/TextToImage/Pipeline/Output/exports_objectOriented.ts
@@ -1,3 +1,5 @@
 export type * from './definition.ts';
 
-export * from './Nullable';
+export {
+  TextToImage_Pipeline_Output_Nullable_from,
+} from './Nullable';

--- a/src/library/Attempt/Outcome/Failure/Cause/Transformer/exports_objectOriented.ts
+++ b/src/library/Attempt/Outcome/Failure/Cause/Transformer/exports_objectOriented.ts
@@ -1,3 +1,5 @@
 export type * from './definition.ts';
 
-export * from './identity';
+export {
+  Attempt_Outcome_Failure_Cause_Transformer_identity,
+} from './identity';

--- a/src/library/Attempt/Outcome/Failure/exports_objectOriented.ts
+++ b/src/library/Attempt/Outcome/Failure/exports_objectOriented.ts
@@ -1,7 +1,14 @@
 export type * from './definition.ts';
 
-export * from './Cause';
+export {
+  type Attempt_Outcome_Failure_Cause_Transformer,
+  /**/ Attempt_Outcome_Failure_Cause_Transformer_identity,
+} from './Cause';
 
-export type * from './Transformer';
+export type {
+  Attempt_Outcome_Failure_Transformer,
+} from './Transformer';
 
-export * from './dueTo';
+export {
+  Attempt_Outcome_Failure_dueTo,
+} from './dueTo';

--- a/src/library/Attempt/Outcome/Success/Product/Transformer/exports_objectOriented.ts
+++ b/src/library/Attempt/Outcome/Success/Product/Transformer/exports_objectOriented.ts
@@ -1,3 +1,5 @@
 export type * from './definition.ts';
 
-export * from './identity';
+export {
+  Attempt_Outcome_Success_Product_Transformer_identity,
+} from './identity';

--- a/src/library/Attempt/Outcome/Success/exports_objectOriented.ts
+++ b/src/library/Attempt/Outcome/Success/exports_objectOriented.ts
@@ -1,7 +1,14 @@
 export type * from './definition.ts';
 
-export * from './Product';
+export {
+  type Attempt_Outcome_Success_Product_Transformer,
+  /**/ Attempt_Outcome_Success_Product_Transformer_identity,
+} from './Product';
 
-export type * from './Transformer';
+export type {
+  Attempt_Outcome_Success_Transformer,
+} from './Transformer';
 
-export * from './thatYielded';
+export {
+  Attempt_Outcome_Success_thatYielded,
+} from './thatYielded';

--- a/src/library/Attempt/Outcome/exports_objectOriented.ts
+++ b/src/library/Attempt/Outcome/exports_objectOriented.ts
@@ -1,5 +1,17 @@
 export * from './definition.ts';
 
-export * from './Success';
+export {
+  type Attempt_Outcome_Success,
+  type Attempt_Outcome_Success_Product_Transformer,
+  /**/ Attempt_Outcome_Success_Product_Transformer_identity,
+  type Attempt_Outcome_Success_Transformer,
+  /**/ Attempt_Outcome_Success_thatYielded,
+} from './Success';
 
-export * from './Failure';
+export {
+  type Attempt_Outcome_Failure,
+  type Attempt_Outcome_Failure_Cause_Transformer,
+  /**/ Attempt_Outcome_Failure_Cause_Transformer_identity,
+  type Attempt_Outcome_Failure_Transformer,
+  /**/ Attempt_Outcome_Failure_dueTo,
+} from './Failure';

--- a/src/library/ShimmedStabilityAIClient/exports_objectAdjacent.ts
+++ b/src/library/ShimmedStabilityAIClient/exports_objectAdjacent.ts
@@ -1,1 +1,3 @@
-export * from './SDXL';
+export {
+  SDXL_DiffusionStepCount,
+} from './SDXL';

--- a/src/library/URLComponent/Origin/exports_objectOriented.ts
+++ b/src/library/URLComponent/Origin/exports_objectOriented.ts
@@ -1,3 +1,5 @@
 export * from './definition.ts';
 
-export * from './ParsingError';
+export {
+  URLComponent_Origin_ParsingError,
+} from './ParsingError';

--- a/src/library/URLComponent/Path/exports_objectOriented.ts
+++ b/src/library/URLComponent/Path/exports_objectOriented.ts
@@ -1,3 +1,5 @@
 export * from './definition.ts';
 
-export * from './ParsingError';
+export {
+  URLComponent_Path_ParsingError,
+} from './ParsingError';


### PR DESCRIPTION
- the goal for each of these namespaces is to access them via dot syntax on their parent namespace rather than directly
- this is ideal because it neatly bundles each concept into a discoverable hierarchy
- the job will be considered done once future commits dissolve away each for these re-exports