### PR TITLE
refactor(text-to-image): ensures all aliases align with namespace depth

### DIFF
--- a/src/features/TextToImage/Config/namespaceMembers.ts
+++ b/src/features/TextToImage/Config/namespaceMembers.ts
@@ -1,5 +1,5 @@
-export * as Config_Dynamic from './Dynamic';
-export * as Config_Static from './Static';
+export * as Dynamic from './Dynamic';
+export * as Static from './Static';
 export {
   TextToImage_Config_empty,
 } from './empty';

--- a/src/features/TextToImage/Server/Current/retrieve.ts
+++ b/src/features/TextToImage/Server/Current/retrieve.ts
@@ -5,8 +5,8 @@ import type {
 } from '@/library/WebAPI';
 
 import {
-  Config_Dynamic as TextToImage_Config_Dynamic,
-  Config_Static as TextToImage_Config_Static,
+  Dynamic as TextToImage_Config_Dynamic,
+  Static as TextToImage_Config_Static,
   TextToImage_Config_empty,
 } from '../../Config';
 


### PR DESCRIPTION
- e.g. if the member access for "/TextToImage/Config/Dynamic" should be `TextToImage.Config.Dynamic` rather than `TextToImage.Config.Config_Dynamic`
- all aliases were checked, but there was only one offender