### PR TITLE
refactor: ensures no aliases are missing any intermediate namespaces

### DIFF
--- a/src/features/TextToImage/components/TextToImageOutputImg.vue
+++ b/src/features/TextToImage/components/TextToImageOutputImg.vue
@@ -6,7 +6,7 @@ import {
 import type * as TextToImage from '@/features/TextToImage';
 
 defineProps<{
-  modelValue: TextToImage.Output['image'];
+  modelValue: TextToImage.Pipeline_Output['image'];
 }>();
 </script>
 

--- a/src/features/TextToImage/namespaceMembers.ts
+++ b/src/features/TextToImage/namespaceMembers.ts
@@ -3,7 +3,7 @@ export * as Client from './Client';
 export * as Server from './Server';
 
 export type {
-  Input,
-  Output,
-  Output_Nullable_from,
+  Input as Pipeline_Input,
+  Output as Pipeline_Output,
+  Output_Nullable_from as Pipeline_Output_Nullable_from,
 } from './Pipeline';

--- a/src/pages/TextToImagePage.vue
+++ b/src/pages/TextToImagePage.vue
@@ -38,7 +38,7 @@ import TextToImageInputSection from '@/features/TextToImage/components/TextToIma
 import TextToImageOutputAlert from '@/features/TextToImage/components/TextToImageOutputAlert.vue';
 import TextToImageOutputImg from '@/features/TextToImage/components/TextToImageOutputImg.vue';
 
-const currentPrompt: Ref<TextToImage.Input['text'] | null> = ref(null);
+const currentPrompt: Ref<TextToImage.Pipeline_Input['text'] | null> = ref(null);
 
 const {
   range,


### PR DESCRIPTION
- overlooked in #950 because it had too few namespaces instead of too many