### PR TITLE
refactor: ensures aliases for each member of every namespace

### DIFF
--- a/src/features/Reporting/namespaceMembers.ts
+++ b/src/features/Reporting/namespaceMembers.ts
@@ -1,3 +1,3 @@
 export {
-  Reporting_promptUserWith,
+  Reporting_promptUserWith as promptUserWith,
 } from './promptUserWith';

--- a/src/features/TextToImage/Client/SDXL/generateOutputFrom.ts
+++ b/src/features/TextToImage/Client/SDXL/generateOutputFrom.ts
@@ -16,7 +16,7 @@ import {
 } from './initialize';
 
 import {
-  toSharkUIOutput_first,
+  first as toSharkUIOutput_first,
 } from './toSharkUIOutput';
 
 const TextToImage_Client_SDXL_generateOutputFrom = async (

--- a/src/features/TextToImage/Client/SDXL/toSharkUIOutput/Image/Description/namespaceMembers.ts
+++ b/src/features/TextToImage/Client/SDXL/toSharkUIOutput/Image/Description/namespaceMembers.ts
@@ -1,7 +1,7 @@
 export {
-  toSharkUIOutput_Image_Description_singular,
+  toSharkUIOutput_Image_Description_singular as singular,
 } from './singular';
 
 export {
-  toSharkUIOutput_Image_Description_all,
+  toSharkUIOutput_Image_Description_all as all,
 } from './all';

--- a/src/features/TextToImage/Client/SDXL/toSharkUIOutput/Image/exports_objectOriented.ts
+++ b/src/features/TextToImage/Client/SDXL/toSharkUIOutput/Image/exports_objectOriented.ts
@@ -1,6 +1,6 @@
 export * from './definition.ts';
 
 export {
-  toSharkUIOutput_Image_Description_singular,
-  toSharkUIOutput_Image_Description_all,
+  singular as toSharkUIOutput_Image_Description_singular,
+  all as toSharkUIOutput_Image_Description_all,
 } from './Description';

--- a/src/features/TextToImage/Client/SDXL/toSharkUIOutput/namespaceMembers.ts
+++ b/src/features/TextToImage/Client/SDXL/toSharkUIOutput/namespaceMembers.ts
@@ -1,7 +1,7 @@
 export {
-  toSharkUIOutput_plural,
+  toSharkUIOutput_plural as plural,
 } from './plural';
 
 export {
-  toSharkUIOutput_first,
+  toSharkUIOutput_first as first,
 } from './first';

--- a/src/features/TextToImage/Config/Dynamic/Fetching/Error/Request.ts
+++ b/src/features/TextToImage/Config/Dynamic/Fetching/Error/Request.ts
@@ -1,7 +1,7 @@
 import Attempt from '@/library/Attempt';
 
 import type {
-  URLComponent_Path,
+  Path as URLComponent_Path,
 } from '@/library/URLComponent';
 
 class TextToImage_Config_Dynamic_Fetching_Error_Request

--- a/src/features/TextToImage/Config/Dynamic/Fetching/Error/Response.ts
+++ b/src/features/TextToImage/Config/Dynamic/Fetching/Error/Response.ts
@@ -1,7 +1,7 @@
 import Attempt from '@/library/Attempt';
 
 import type {
-  URLComponent_Path,
+  Path as URLComponent_Path,
 } from '@/library/URLComponent';
 
 class TextToImage_Config_Dynamic_Fetching_Error_Response

--- a/src/features/TextToImage/Config/Dynamic/endpoint.ts
+++ b/src/features/TextToImage/Config/Dynamic/endpoint.ts
@@ -1,5 +1,5 @@
 import {
-  URLComponent_Path,
+  Path as URLComponent_Path,
 } from '@/library/URLComponent';
 
 const TextToImage_Config_Dynamic_endpoint = URLComponent_Path.parsedFrom('/config/text-to-image').forciblyUnwrap();

--- a/src/features/TextToImage/Config/Static/Reading/Error.ts
+++ b/src/features/TextToImage/Config/Static/Reading/Error.ts
@@ -1,7 +1,7 @@
 import Attempt from '@/library/Attempt';
 
 import type {
-  URLComponent_Path,
+  Path as URLComponent_Path,
 } from '@/library/URLComponent';
 
 class TextToImage_Config_Static_Reading_Error

--- a/src/features/TextToImage/Config/Static/file.ts
+++ b/src/features/TextToImage/Config/Static/file.ts
@@ -1,5 +1,5 @@
 import {
-  URLComponent_Path,
+  Path as URLComponent_Path,
 } from '@/library/URLComponent';
 
 const TextToImage_Config_Static_file = URLComponent_Path.parsedFrom('/config/text-to-image.json').forciblyUnwrap();

--- a/src/features/TextToImage/Config/namespaceMembers.ts
+++ b/src/features/TextToImage/Config/namespaceMembers.ts
@@ -1,5 +1,5 @@
 export * as Dynamic from './Dynamic';
 export * as Static from './Static';
 export {
-  TextToImage_Config_empty,
+  TextToImage_Config_empty as empty,
 } from './empty';

--- a/src/features/TextToImage/Pipeline/Output/Nullable/namespaceMembers.ts
+++ b/src/features/TextToImage/Pipeline/Output/Nullable/namespaceMembers.ts
@@ -1,3 +1,3 @@
 export {
-  TextToImage_Pipeline_Output_Nullable_from,
+  TextToImage_Pipeline_Output_Nullable_from as from,
 } from './from';

--- a/src/features/TextToImage/Pipeline/Output/exports_objectOriented.ts
+++ b/src/features/TextToImage/Pipeline/Output/exports_objectOriented.ts
@@ -1,5 +1,5 @@
 export type * from './definition.ts';
 
 export {
-  TextToImage_Pipeline_Output_Nullable_from,
+  from as TextToImage_Pipeline_Output_Nullable_from,
 } from './Nullable';

--- a/src/features/TextToImage/Server/Current/namespaceMembers.ts
+++ b/src/features/TextToImage/Server/Current/namespaceMembers.ts
@@ -1,7 +1,7 @@
 export {
-  TextToImage_Server_Current_accordingToEnvironment as Current_accordingToEnvironment,
+  TextToImage_Server_Current_accordingToEnvironment as accordingToEnvironment,
 } from './accordingToEnvironment';
 
 export {
-  TextToImage_Server_Current_retrieve as Current_retrieve,
+  TextToImage_Server_Current_retrieve as retrieve,
 } from './retrieve';

--- a/src/features/TextToImage/Server/Current/retrieve.ts
+++ b/src/features/TextToImage/Server/Current/retrieve.ts
@@ -7,7 +7,7 @@ import type {
 import {
   Dynamic as TextToImage_Config_Dynamic,
   Static as TextToImage_Config_Static,
-  TextToImage_Config_empty,
+  empty as TextToImage_Config_empty,
 } from '../../Config';
 
 import {

--- a/src/features/TextToImage/Server/Error/Specification.ts
+++ b/src/features/TextToImage/Server/Error/Specification.ts
@@ -1,7 +1,7 @@
 import Attempt from '@/library/Attempt';
 
 import type {
-  URLComponent_Path,
+  Path as URLComponent_Path,
 } from '@/library/URLComponent';
 
 class TextToImage_Server_Error_Specification

--- a/src/features/TextToImage/Server/namespaceMembers.ts
+++ b/src/features/TextToImage/Server/namespaceMembers.ts
@@ -1,6 +1,6 @@
 export {
-  Current_accordingToEnvironment,
-  Current_retrieve,
+  accordingToEnvironment as Current_accordingToEnvironment,
+  retrieve as Current_retrieve,
 } from './Current';
 
 export {

--- a/src/library/Attempt/Adapted/Config.ts
+++ b/src/library/Attempt/Adapted/Config.ts
@@ -1,6 +1,6 @@
 import type {
-  Attempt_Error_Actionable,
-  Attempt_Error_Interpreter,
+  Actionable as Attempt_Error_Actionable,
+  Interpreter as Attempt_Error_Interpreter,
 } from '../Error';
 
 interface Attempt_Adapted_Config<

--- a/src/library/Attempt/Adapted/namespaceMembers.ts
+++ b/src/library/Attempt/Adapted/namespaceMembers.ts
@@ -1,15 +1,15 @@
 export {
-  Attempt_Adapted_to,
+  Attempt_Adapted_to as to,
 } from './to';
 
 export {
-  Attempt_Adapted_toEventually,
+  Attempt_Adapted_toEventually as toEventually,
 } from './toEventually';
 
 export {
-  Attempt_Adapted_toSettle,
+  Attempt_Adapted_toSettle as toSettle,
 } from './toSettle';
 
 export type {
-  Attempt_Adapted_Config,
+  Attempt_Adapted_Config as Config,
 } from './Config';

--- a/src/library/Attempt/Adapted/to.ts
+++ b/src/library/Attempt/Adapted/to.ts
@@ -1,6 +1,6 @@
 import {
-  type Attempt_Error_Actionable,
-  Attempt_Error_Actionable_from,
+  type Actionable as Attempt_Error_Actionable,
+  Actionable_from as Attempt_Error_Actionable_from,
 } from '../Error';
 
 import {

--- a/src/library/Attempt/Adapted/to.ts
+++ b/src/library/Attempt/Adapted/to.ts
@@ -4,7 +4,7 @@ import {
 } from '../Error';
 
 import {
-  Attempt_Fresh_that,
+  that as Attempt_Fresh_that,
 } from '../Fresh';
 
 import type {

--- a/src/library/Attempt/Adapted/toEventually.ts
+++ b/src/library/Attempt/Adapted/toEventually.ts
@@ -1,6 +1,6 @@
 import {
-  type Attempt_Error_Actionable,
-  Attempt_Error_Actionable_from,
+  type Actionable as Attempt_Error_Actionable,
+  Actionable_from as Attempt_Error_Actionable_from,
 } from '../Error';
 
 import {

--- a/src/library/Attempt/Adapted/toEventually.ts
+++ b/src/library/Attempt/Adapted/toEventually.ts
@@ -4,7 +4,7 @@ import {
 } from '../Error';
 
 import {
-  Attempt_Fresh_thatEventually,
+  thatEventually as Attempt_Fresh_thatEventually,
 } from '../Fresh';
 
 import type {

--- a/src/library/Attempt/Adapted/toSettle.ts
+++ b/src/library/Attempt/Adapted/toSettle.ts
@@ -1,5 +1,5 @@
 import type {
-  Attempt_Error_Actionable,
+  Actionable as Attempt_Error_Actionable,
 } from '../Error';
 
 import type {

--- a/src/library/Attempt/End/Getter.ts
+++ b/src/library/Attempt/End/Getter.ts
@@ -1,5 +1,5 @@
 import type {
-  Attempt_Error_Actionable,
+  Actionable as Attempt_Error_Actionable,
 } from '../Error';
 
 import type {

--- a/src/library/Attempt/End/Retriever.ts
+++ b/src/library/Attempt/End/Retriever.ts
@@ -1,5 +1,5 @@
 import type {
-  Attempt_Error_Actionable,
+  Actionable as Attempt_Error_Actionable,
 } from '../Error';
 
 import type {

--- a/src/library/Attempt/End/namespaceMembers.ts
+++ b/src/library/Attempt/End/namespaceMembers.ts
@@ -1,7 +1,7 @@
 export type {
-  Attempt_End_Getter,
+  Attempt_End_Getter as Getter,
 } from './Getter';
 
 export type {
-  Attempt_End_Retriever,
+  Attempt_End_Retriever as Retriever,
 } from './Retriever';

--- a/src/library/Attempt/Error/namespaceMembers.ts
+++ b/src/library/Attempt/Error/namespaceMembers.ts
@@ -1,19 +1,19 @@
 export {
-  Attempt_Error_NonActionable,
+  Attempt_Error_NonActionable as NonActionable,
 } from './NonActionable';
 
 export {
-  Attempt_Error_Creation,
+  Attempt_Error_Creation as Creation,
 } from './Creation';
 
 export {
-  Attempt_Error_Actionable,
+  Attempt_Error_Actionable as Actionable,
 } from './Actionable';
 
 export {
-  Attempt_Error_Actionable_from,
+  Attempt_Error_Actionable_from as Actionable_from,
 } from './assertActionable';
 
 export type {
-  Attempt_Error_Interpreter,
+  Attempt_Error_Interpreter as Interpreter,
 } from './Interpreter';

--- a/src/library/Attempt/Fresh/namespaceMembers.ts
+++ b/src/library/Attempt/Fresh/namespaceMembers.ts
@@ -1,6 +1,6 @@
 export {
-  Attempt_Fresh_that,
+  Attempt_Fresh_that as that,
 } from './that';
 export {
-  Attempt_Fresh_thatEventually,
+  Attempt_Fresh_thatEventually as thatEventually,
 } from './thatEventually';

--- a/src/library/Attempt/Fresh/that.ts
+++ b/src/library/Attempt/Fresh/that.ts
@@ -1,5 +1,5 @@
 import type {
-  Attempt_End_Getter,
+  Getter as Attempt_End_Getter,
 } from '../End';
 
 import {

--- a/src/library/Attempt/Fresh/that.ts
+++ b/src/library/Attempt/Fresh/that.ts
@@ -3,8 +3,8 @@ import type {
 } from '../End';
 
 import {
-  type Attempt_Error_Actionable,
-  Attempt_Error_Creation,
+  type Actionable as Attempt_Error_Actionable,
+  Creation as Attempt_Error_Creation,
 } from '../Error';
 
 import type {

--- a/src/library/Attempt/Fresh/thatEventually.ts
+++ b/src/library/Attempt/Fresh/thatEventually.ts
@@ -1,5 +1,5 @@
 import type {
-  Attempt_End_Retriever,
+  Retriever as Attempt_End_Retriever,
 } from '../End';
 
 import {

--- a/src/library/Attempt/Fresh/thatEventually.ts
+++ b/src/library/Attempt/Fresh/thatEventually.ts
@@ -3,8 +3,8 @@ import type {
 } from '../End';
 
 import {
-  type Attempt_Error_Actionable,
-  Attempt_Error_Creation,
+  type Actionable as Attempt_Error_Actionable,
+  Creation as Attempt_Error_Creation,
 } from '../Error';
 
 import type {

--- a/src/library/Attempt/Outcome/Discriminable/definition.ts
+++ b/src/library/Attempt/Outcome/Discriminable/definition.ts
@@ -5,7 +5,7 @@ import type {
 } from '@/library/typeUtilities';
 
 import type {
-  Attempt_Error_Actionable,
+  Actionable as Attempt_Error_Actionable,
 } from '../../Error';
 
 import type {

--- a/src/library/Attempt/Outcome/Failure/Cause/Transformer/definition.ts
+++ b/src/library/Attempt/Outcome/Failure/Cause/Transformer/definition.ts
@@ -1,5 +1,5 @@
 import type {
-  Attempt_Error_Actionable,
+  Actionable as Attempt_Error_Actionable,
 } from '@/library/Attempt/Error'; // eslint-disable-line import/no-internal-modules -- avoids lengthy relative paths
 
 type Attempt_Outcome_Failure_Cause_Transformer<

--- a/src/library/Attempt/Outcome/Failure/Cause/Transformer/identity.ts
+++ b/src/library/Attempt/Outcome/Failure/Cause/Transformer/identity.ts
@@ -1,5 +1,5 @@
 import type {
-  Attempt_Error_Actionable,
+  Actionable as Attempt_Error_Actionable,
 } from '@/library/Attempt/Error'; // eslint-disable-line import/no-internal-modules -- avoids lengthy relative paths
 
 const Attempt_Outcome_Failure_Cause_Transformer_identity = <

--- a/src/library/Attempt/Outcome/Failure/Cause/namespaceMembers.ts
+++ b/src/library/Attempt/Outcome/Failure/Cause/namespaceMembers.ts
@@ -1,4 +1,4 @@
 export {
-  type Attempt_Outcome_Failure_Cause_Transformer,
-  Attempt_Outcome_Failure_Cause_Transformer_identity,
+  type Attempt_Outcome_Failure_Cause_Transformer as Transformer,
+  Attempt_Outcome_Failure_Cause_Transformer_identity as Transformer_identity,
 } from './Transformer';

--- a/src/library/Attempt/Outcome/Failure/SemanticallySugarfree.ts
+++ b/src/library/Attempt/Outcome/Failure/SemanticallySugarfree.ts
@@ -1,5 +1,5 @@
 import type {
-  Attempt_Error_Actionable,
+  Actionable as Attempt_Error_Actionable,
 } from '../../Error';
 
 import type {

--- a/src/library/Attempt/Outcome/Failure/Transformer.ts
+++ b/src/library/Attempt/Outcome/Failure/Transformer.ts
@@ -3,7 +3,7 @@ import type {
 } from '../../Error';
 
 import type {
-  Attempt_Outcome_Failure_Cause_Transformer,
+  Transformer as Attempt_Outcome_Failure_Cause_Transformer,
 } from './Cause';
 
 interface Attempt_Outcome_Failure_Transformer<

--- a/src/library/Attempt/Outcome/Failure/Transformer.ts
+++ b/src/library/Attempt/Outcome/Failure/Transformer.ts
@@ -1,5 +1,5 @@
 import type {
-  Attempt_Error_Actionable,
+  Actionable as Attempt_Error_Actionable,
 } from '../../Error';
 
 import type {

--- a/src/library/Attempt/Outcome/Failure/definition.ts
+++ b/src/library/Attempt/Outcome/Failure/definition.ts
@@ -1,5 +1,5 @@
 import type {
-  Attempt_Error_Actionable,
+  Actionable as Attempt_Error_Actionable,
 } from '../../Error';
 
 import type {

--- a/src/library/Attempt/Outcome/Failure/dueTo.ts
+++ b/src/library/Attempt/Outcome/Failure/dueTo.ts
@@ -3,7 +3,7 @@ import type {
 } from '../../Error';
 
 import {
-  Attempt_Outcome_Failure_Cause_Transformer_identity,
+  Transformer_identity as Attempt_Outcome_Failure_Cause_Transformer_identity,
 } from './Cause';
 
 import type {

--- a/src/library/Attempt/Outcome/Failure/dueTo.ts
+++ b/src/library/Attempt/Outcome/Failure/dueTo.ts
@@ -1,5 +1,5 @@
 import type {
-  Attempt_Error_Actionable,
+  Actionable as Attempt_Error_Actionable,
 } from '../../Error';
 
 import {

--- a/src/library/Attempt/Outcome/Failure/exports_objectOriented.ts
+++ b/src/library/Attempt/Outcome/Failure/exports_objectOriented.ts
@@ -1,8 +1,8 @@
 export type * from './definition.ts';
 
 export {
-  type Attempt_Outcome_Failure_Cause_Transformer,
-  /**/ Attempt_Outcome_Failure_Cause_Transformer_identity,
+  type Transformer as Attempt_Outcome_Failure_Cause_Transformer,
+  /**/ Transformer_identity as Attempt_Outcome_Failure_Cause_Transformer_identity,
 } from './Cause';
 
 export type {

--- a/src/library/Attempt/Outcome/Success/Product/namespaceMembers.ts
+++ b/src/library/Attempt/Outcome/Success/Product/namespaceMembers.ts
@@ -1,4 +1,4 @@
 export {
-  type Attempt_Outcome_Success_Product_Transformer,
-  Attempt_Outcome_Success_Product_Transformer_identity,
+  type Attempt_Outcome_Success_Product_Transformer as Transformer,
+  Attempt_Outcome_Success_Product_Transformer_identity as Transformer_identity,
 } from './Transformer';

--- a/src/library/Attempt/Outcome/Success/Transformer.ts
+++ b/src/library/Attempt/Outcome/Success/Transformer.ts
@@ -1,5 +1,5 @@
 import type {
-  Attempt_Outcome_Success_Product_Transformer,
+  Transformer as Attempt_Outcome_Success_Product_Transformer,
 } from './Product';
 
 interface Attempt_Outcome_Success_Transformer<

--- a/src/library/Attempt/Outcome/Success/exports_objectOriented.ts
+++ b/src/library/Attempt/Outcome/Success/exports_objectOriented.ts
@@ -1,8 +1,8 @@
 export type * from './definition.ts';
 
 export {
-  type Attempt_Outcome_Success_Product_Transformer,
-  /**/ Attempt_Outcome_Success_Product_Transformer_identity,
+  type Transformer as Attempt_Outcome_Success_Product_Transformer,
+  /**/ Transformer_identity as Attempt_Outcome_Success_Product_Transformer_identity,
 } from './Product';
 
 export type {

--- a/src/library/Attempt/Outcome/Success/thatYielded.ts
+++ b/src/library/Attempt/Outcome/Success/thatYielded.ts
@@ -1,5 +1,5 @@
 import {
-  Attempt_Outcome_Success_Product_Transformer_identity,
+  Transformer_identity as Attempt_Outcome_Success_Product_Transformer_identity,
 } from './Product';
 
 import type {

--- a/src/library/Attempt/Outcome/Transformer.ts
+++ b/src/library/Attempt/Outcome/Transformer.ts
@@ -1,5 +1,5 @@
 import type {
-  Attempt_Error_Actionable,
+  Actionable as Attempt_Error_Actionable,
 } from '../Error';
 
 import type {

--- a/src/library/Attempt/Outcome/definition.ts
+++ b/src/library/Attempt/Outcome/definition.ts
@@ -1,5 +1,5 @@
 import type {
-  Attempt_Error_Actionable,
+  Actionable as Attempt_Error_Actionable,
 } from '../Error';
 
 import {

--- a/src/library/Attempt/Outcome/fromRewrapping.ts
+++ b/src/library/Attempt/Outcome/fromRewrapping.ts
@@ -1,5 +1,5 @@
 import type {
-  Attempt_Error_Actionable,
+  Actionable as Attempt_Error_Actionable,
 } from '../Error';
 
 import {

--- a/src/library/Attempt/Outcome/typeParameters/CauseOf.ts
+++ b/src/library/Attempt/Outcome/typeParameters/CauseOf.ts
@@ -1,5 +1,5 @@
 import type {
-  Attempt_Error_Actionable,
+  Actionable as Attempt_Error_Actionable,
 } from '../../Error';
 
 import type {

--- a/src/library/Attempt/Outcome/typeParameters/ProductOf.ts
+++ b/src/library/Attempt/Outcome/typeParameters/ProductOf.ts
@@ -1,5 +1,5 @@
 import type {
-  Attempt_Error_Actionable,
+  Actionable as Attempt_Error_Actionable,
 } from '../../Error';
 
 import type {

--- a/src/library/Attempt/Progressive.ts
+++ b/src/library/Attempt/Progressive.ts
@@ -1,5 +1,5 @@
 import type {
-  Attempt_Error_Actionable,
+  Actionable as Attempt_Error_Actionable,
 } from './Error';
 
 import type {

--- a/src/library/Attempt/ended.ts
+++ b/src/library/Attempt/ended.ts
@@ -1,5 +1,5 @@
 import {
-  Attempt_Error_NonActionable,
+  NonActionable as Attempt_Error_NonActionable,
 } from './Error';
 
 import {

--- a/src/library/Attempt/namespaceMembers.ts
+++ b/src/library/Attempt/namespaceMembers.ts
@@ -16,9 +16,9 @@ export {
 } from './Adapted';
 
 export {
-  Attempt_Error_NonActionable as Error_NonActionable,
-  Attempt_Error_Actionable as Error_Actionable,
-  type Attempt_Error_Interpreter as Error_Interpreter,
+  NonActionable as Error_NonActionable,
+  Actionable as Error_Actionable,
+  type Interpreter as Error_Interpreter,
 } from './Error';
 
 export {

--- a/src/library/Attempt/namespaceMembers.ts
+++ b/src/library/Attempt/namespaceMembers.ts
@@ -9,10 +9,10 @@ export {
 } from './Outcome';
 
 export {
-  Attempt_Adapted_to as Adapted_to,
-  Attempt_Adapted_toEventually as Adapted_toEventually,
-  Attempt_Adapted_toSettle as Adapted_toSettle,
-  type Attempt_Adapted_Config as Adapted_Config,
+  to as Adapted_to,
+  toEventually as Adapted_toEventually,
+  toSettle as Adapted_toSettle,
+  type Config as Adapted_Config,
 } from './Adapted';
 
 export {

--- a/src/library/Attempt/namespaceMembers.ts
+++ b/src/library/Attempt/namespaceMembers.ts
@@ -22,8 +22,8 @@ export {
 } from './Error';
 
 export {
-  Attempt_Fresh_that as Fresh_that,
-  Attempt_Fresh_thatEventually as Fresh_thatEventually,
+  that as Fresh_that,
+  thatEventually as Fresh_thatEventually,
 } from './Fresh';
 
 export type {
@@ -31,6 +31,6 @@ export type {
 } from './Progressive';
 
 export type {
-  Attempt_End_Getter as End_Getter,
-  Attempt_End_Retriever as End_Retriever,
+  Getter as End_Getter,
+  Retriever as End_Retriever,
 } from './End';

--- a/src/library/ContentDescriptor/TopLevel/Discrete/namespaceMembers.ts
+++ b/src/library/ContentDescriptor/TopLevel/Discrete/namespaceMembers.ts
@@ -1,5 +1,5 @@
 export {
-  ContentDescriptor_TopLevel_Discrete_all,
+  ContentDescriptor_TopLevel_Discrete_all as all,
 } from './all';
 
 export {

--- a/src/library/HTTP/Client.ts
+++ b/src/library/HTTP/Client.ts
@@ -1,8 +1,8 @@
 import Attempt from '@/library/Attempt';
 
 import type {
-  URLComponent_Origin,
-  URLComponent_Path,
+  Origin as URLComponent_Origin,
+  Path as URLComponent_Path,
 } from '@/library/URLComponent';
 
 import {

--- a/src/library/Schema/namespaceMembers.ts
+++ b/src/library/Schema/namespaceMembers.ts
@@ -1,1 +1,1 @@
-export * from './core';
+export * from './core'; // Uses the aliases as-is

--- a/src/library/ShimmedStabilityAIClient/SDXL/namespaceMembers.ts
+++ b/src/library/ShimmedStabilityAIClient/SDXL/namespaceMembers.ts
@@ -1,3 +1,3 @@
 export {
-  SDXL_DiffusionStepCount,
+  SDXL_DiffusionStepCount as DiffusionStepCount,
 } from './DiffusionStepCount';

--- a/src/library/ShimmedStabilityAIClient/definition.ts
+++ b/src/library/ShimmedStabilityAIClient/definition.ts
@@ -1,7 +1,7 @@
 import HTTP from '@/library/HTTP';
 
 import {
-  URLComponent_Origin,
+  Origin as URLComponent_Origin,
 } from '@/library/URLComponent';
 
 import {

--- a/src/library/ShimmedStabilityAIClient/exports_objectAdjacent.ts
+++ b/src/library/ShimmedStabilityAIClient/exports_objectAdjacent.ts
@@ -1,3 +1,3 @@
 export {
-  SDXL_DiffusionStepCount,
+  DiffusionStepCount as SDXL_DiffusionStepCount,
 } from './SDXL';

--- a/src/library/Shortfin/TextToImage/SDXL/Client/definition.ts
+++ b/src/library/Shortfin/TextToImage/SDXL/Client/definition.ts
@@ -2,7 +2,7 @@ import Attempt from '@/library/Attempt';
 import HTTP from '@/library/HTTP';
 
 import {
-  URLComponent_Path,
+  Path as URLComponent_Path,
 } from '@/library/URLComponent';
 
 import type {

--- a/src/library/URLComponent/namespaceMembers.ts
+++ b/src/library/URLComponent/namespaceMembers.ts
@@ -1,8 +1,8 @@
 export {
-  URLComponent_Origin,
-  URLComponent_Origin_ParsingError,
+  URLComponent_Origin as Origin,
+  URLComponent_Origin_ParsingError as Origin_ParsingError,
 } from './Origin';
 export {
-  URLComponent_Path,
-  URLComponent_Path_ParsingError,
+  URLComponent_Path as Path,
+  URLComponent_Path_ParsingError as Path_ParsingError,
 } from './Path';

--- a/src/main.ts
+++ b/src/main.ts
@@ -11,7 +11,7 @@ import vuetify from '@/plugins/vuetify.ts';
 import router from '@/router';
 
 import {
-  Reporting_promptUserWith,
+  promptUserWith as Reporting_promptUserWith,
 } from '@/features/Reporting';
 
 const app = createApp(App);


### PR DESCRIPTION
- for namespaces embodied as an assembled (rather than declared) object, each member of that namespace must have an alias that determines the key used to access that member.
- e.g. `Attempt_Error_Actionable` needs to be accessible via `Attempt_Error.Actionable`, so the alias needed in "Attempt/Error/namespaceMembers.ts" is `Actionable`
- this will, in a future PR, enable all assembled objects to be labeled such that all members can be accessed via a single namespace

Facilitates #953