### PR TITLE
refactor: avoids destructuring nestable namespaces

### DIFF
--- a/src/features/TextToImage/Client/SDXL/toSharkUIOutput/Image/exports_objectOriented.ts
+++ b/src/features/TextToImage/Client/SDXL/toSharkUIOutput/Image/exports_objectOriented.ts
@@ -1,6 +1,3 @@
 export * from './definition.ts';
 
-export {
-  singular as toSharkUIOutput_Image_Description_singular,
-  all as toSharkUIOutput_Image_Description_all,
-} from './Description';
+export * as toSharkUIOutput_Image_Description from './Description';

--- a/src/features/TextToImage/Client/SDXL/toSharkUIOutput/plural.ts
+++ b/src/features/TextToImage/Client/SDXL/toSharkUIOutput/plural.ts
@@ -7,12 +7,12 @@ import Attempt from '@/library/Attempt';
 import {
   type Input as TextToImage_Pipeline_Input,
   type Output as TextToImage_Pipeline_Output,
-  Output_Nullable_from as TextToImage_Pipeline_Output_Nullable_from,
+  Output_Nullable as TextToImage_Pipeline_Output_Nullable,
 } from '@/features/TextToImage/Pipeline'; // eslint-disable-line import/no-internal-modules -- more concise than relative import
 
 import {
   toSharkUIOutput_Image,
-  toSharkUIOutput_Image_Description_all,
+  toSharkUIOutput_Image_Description,
 } from './Image';
 
 const toSharkUIOutput_plural = (
@@ -36,9 +36,9 @@ const toSharkUIOutput_plural = (
 
   const inferredOutputs = inferredRawImages
     .map($0 => toSharkUIOutput_Image($0, {
-      description: toSharkUIOutput_Image_Description_all(givenInputText),
+      description: toSharkUIOutput_Image_Description.all(givenInputText),
     }))
-    .map($0 => TextToImage_Pipeline_Output_Nullable_from($0));
+    .map($0 => TextToImage_Pipeline_Output_Nullable.from($0));
 
   return inferredOutputs;
 };

--- a/src/features/TextToImage/Pipeline/Output/exports_objectOriented.ts
+++ b/src/features/TextToImage/Pipeline/Output/exports_objectOriented.ts
@@ -1,5 +1,3 @@
 export type * from './definition.ts';
 
-export {
-  from as TextToImage_Pipeline_Output_Nullable_from,
-} from './Nullable';
+export * as TextToImage_Pipeline_Output_Nullable from './Nullable';

--- a/src/features/TextToImage/Pipeline/namespaceMembers.ts
+++ b/src/features/TextToImage/Pipeline/namespaceMembers.ts
@@ -3,5 +3,5 @@ export type {
 } from './Input';
 export {
   type TextToImage_Pipeline_Output as Output,
-  /**/ TextToImage_Pipeline_Output_Nullable_from as Output_Nullable_from,
+  /**/ TextToImage_Pipeline_Output_Nullable as Output_Nullable,
 } from './Output';

--- a/src/library/Attempt/Outcome/Failure/exports_objectOriented.ts
+++ b/src/library/Attempt/Outcome/Failure/exports_objectOriented.ts
@@ -1,9 +1,6 @@
 export type * from './definition.ts';
 
-export {
-  type Transformer as Attempt_Outcome_Failure_Cause_Transformer,
-  /**/ Transformer_identity as Attempt_Outcome_Failure_Cause_Transformer_identity,
-} from './Cause';
+export * as Attempt_Outcome_Failure_Cause from './Cause';
 
 export type {
   Attempt_Outcome_Failure_Transformer,

--- a/src/library/Attempt/Outcome/Success/exports_objectOriented.ts
+++ b/src/library/Attempt/Outcome/Success/exports_objectOriented.ts
@@ -1,9 +1,6 @@
 export type * from './definition.ts';
 
-export {
-  type Transformer as Attempt_Outcome_Success_Product_Transformer,
-  /**/ Transformer_identity as Attempt_Outcome_Success_Product_Transformer_identity,
-} from './Product';
+export * as Attempt_Outcome_Success_Product from './Product';
 
 export type {
   Attempt_Outcome_Success_Transformer,

--- a/src/library/Attempt/Outcome/exports_objectOriented.ts
+++ b/src/library/Attempt/Outcome/exports_objectOriented.ts
@@ -2,16 +2,14 @@ export * from './definition.ts';
 
 export {
   type Attempt_Outcome_Success,
-  type Attempt_Outcome_Success_Product_Transformer,
-  /**/ Attempt_Outcome_Success_Product_Transformer_identity,
+  /**/ Attempt_Outcome_Success_Product,
   type Attempt_Outcome_Success_Transformer,
   /**/ Attempt_Outcome_Success_thatYielded,
 } from './Success';
 
 export {
   type Attempt_Outcome_Failure,
-  type Attempt_Outcome_Failure_Cause_Transformer,
-  /**/ Attempt_Outcome_Failure_Cause_Transformer_identity,
+  /**/ Attempt_Outcome_Failure_Cause,
   type Attempt_Outcome_Failure_Transformer,
   /**/ Attempt_Outcome_Failure_dueTo,
 } from './Failure';

--- a/src/library/Attempt/Outcome/fromRewrapping.ts
+++ b/src/library/Attempt/Outcome/fromRewrapping.ts
@@ -5,13 +5,13 @@ import type {
 import {
   type Attempt_Outcome_Failure,
   type Attempt_Outcome_Failure_Transformer,
-  Attempt_Outcome_Failure_Cause_Transformer_identity,
+  Attempt_Outcome_Failure_Cause,
 } from './Failure';
 
 import {
   type Attempt_Outcome_Success,
   type Attempt_Outcome_Success_Transformer,
-  Attempt_Outcome_Success_Product_Transformer_identity,
+  Attempt_Outcome_Success_Product,
 } from './Success';
 
 import type {
@@ -84,11 +84,11 @@ function Attempt_Outcome_fromRewrapping<
     SomeTransformableActionableError
   >,
   {
-    product: toTransformedProduct = Attempt_Outcome_Success_Product_Transformer_identity<
+    product: toTransformedProduct = Attempt_Outcome_Success_Product.Transformer_identity<
       SomeTransformableProduct,
       SomeTransformedProduct
     >,
-    cause: toTransformedCause = Attempt_Outcome_Failure_Cause_Transformer_identity<
+    cause: toTransformedCause = Attempt_Outcome_Failure_Cause.Transformer_identity<
       SomeTransformableActionableError,
       SomeTransformedActionableError
     >,
@@ -98,11 +98,11 @@ function Attempt_Outcome_fromRewrapping<
     SomeTransformedProduct,
     SomeTransformedActionableError
   > = {
-    product: Attempt_Outcome_Success_Product_Transformer_identity<
+    product: Attempt_Outcome_Success_Product.Transformer_identity<
       SomeTransformableProduct,
       SomeTransformedProduct
     >,
-    cause: Attempt_Outcome_Failure_Cause_Transformer_identity<
+    cause: Attempt_Outcome_Failure_Cause.Transformer_identity<
       SomeTransformableActionableError,
       SomeTransformedActionableError
     >,

--- a/src/library/ShimmedStabilityAIClient/exports_objectAdjacent.ts
+++ b/src/library/ShimmedStabilityAIClient/exports_objectAdjacent.ts
@@ -1,3 +1,1 @@
-export {
-  DiffusionStepCount as SDXL_DiffusionStepCount,
-} from './SDXL';
+export * as SDXL from './SDXL';

--- a/src/pages/TextToImagePage.vue
+++ b/src/pages/TextToImagePage.vue
@@ -27,7 +27,7 @@ import {
 } from 'vuetify/components/VSkeletonLoader';
 
 import {
-  SDXL_DiffusionStepCount,
+  SDXL,
 } from '@/library/ShimmedStabilityAIClient';
 
 import DiscreteSlider from '@/components/DiscreteSlider.vue';
@@ -42,7 +42,7 @@ const currentPrompt: Ref<TextToImage.Pipeline.Input['text'] | null> = ref(null);
 
 const {
   range,
-} = SDXL_DiffusionStepCount;
+} = SDXL.DiffusionStepCount;
 
 const currentNumberOfDiffusionSteps = ref<number>(range.midpoint);
 


### PR DESCRIPTION
- sub-namespaces must be presented as a whole rather than in pieces.
- this makes them nestable, and as a result, easier to test at the interface level and accessible via dot syntax