### PR TITLE
refactor: avoids destructuring namespaces members

### DIFF
--- a/src/features/TextToImage/Client/SDXL/generateOutputFrom.ts
+++ b/src/features/TextToImage/Client/SDXL/generateOutputFrom.ts
@@ -53,7 +53,7 @@ const TextToImage_Client_SDXL_generateOutputFrom = async (
     },
   });
 
-  const outcomeOfSettlingTextToImageResponse = await Attempt.Adapted_toSettle(promisedTextToImageResponse, {
+  const outcomeOfSettlingTextToImageResponse = await Attempt.Adapted.toSettle(promisedTextToImageResponse, {
     interpretationOf: (caughtError) => {
       if (
         !(caughtError instanceof HTTP.Endpoint.Error.Request)

--- a/src/features/TextToImage/Client/SDXL/initialize.ts
+++ b/src/features/TextToImage/Client/SDXL/initialize.ts
@@ -9,7 +9,7 @@ const TextToImage_Client_SDXL_initialize = async (): Promise<
     TextToImage_Server.Error.Specification
   >
 > => {
-  const outcomeOfRetrievingCurrentServer = await TextToImage_Server.Current_retrieve();
+  const outcomeOfRetrievingCurrentServer = await TextToImage_Server.Current.retrieve();
 
   const outcomeOfInitializingClient = Attempt.Outcome.fromRewrapping(outcomeOfRetrievingCurrentServer, {
     product: textToImageServer => new ShimmedStabilityAIClient({

--- a/src/features/TextToImage/Config/Dynamic/Fetching/Error/Request.ts
+++ b/src/features/TextToImage/Config/Dynamic/Fetching/Error/Request.ts
@@ -5,7 +5,7 @@ import type {
 } from '@/library/URLComponent';
 
 class TextToImage_Config_Dynamic_Fetching_Error_Request
-  extends Attempt.Error_Actionable<
+  extends Attempt.Error.Actionable<
     'TextToImage_Config_Dynamic_Fetching_Error_Request'
   > {
   public override name = 'TextToImage_Config_Dynamic_Fetching_Error_Request' as const;

--- a/src/features/TextToImage/Config/Dynamic/Fetching/Error/Response.ts
+++ b/src/features/TextToImage/Config/Dynamic/Fetching/Error/Response.ts
@@ -5,7 +5,7 @@ import type {
 } from '@/library/URLComponent';
 
 class TextToImage_Config_Dynamic_Fetching_Error_Response
-  extends Attempt.Error_Actionable<
+  extends Attempt.Error.Actionable<
     'TextToImage_Config_Dynamic_Fetching_Error_Response'
   > {
   public override name = 'TextToImage_Config_Dynamic_Fetching_Error_Response' as const;

--- a/src/features/TextToImage/Config/Dynamic/fetch.ts
+++ b/src/features/TextToImage/Config/Dynamic/fetch.ts
@@ -15,7 +15,7 @@ import {
 
 const TextToImage_Config_Dynamic_fetch = (): Promise<
   TextToImage_Config_Dynamic_Fetching.Outcome
-> => Attempt.Fresh_thatEventually(async (ends) => {
+> => Attempt.Fresh.thatEventually(async (ends) => {
   const endpointResponse = await fetch(TextToImage_Config_Dynamic_endpoint.toString());
   const fetchingError = new TextToImage_Config_Dynamic_Fetching.Error.Request(TextToImage_Config_Dynamic_endpoint);
 

--- a/src/features/TextToImage/Config/Static/Reading/Error.ts
+++ b/src/features/TextToImage/Config/Static/Reading/Error.ts
@@ -5,7 +5,7 @@ import type {
 } from '@/library/URLComponent';
 
 class TextToImage_Config_Static_Reading_Error
-  extends Attempt.Error_Actionable<
+  extends Attempt.Error.Actionable<
     'TextToImage_Config_Static_Reading_Error'
   > {
   public override name = 'TextToImage_Config_Static_Reading_Error' as const;

--- a/src/features/TextToImage/Config/Static/read.ts
+++ b/src/features/TextToImage/Config/Static/read.ts
@@ -14,7 +14,7 @@ import {
 
 const TextToImage_Config_Static_read = (): Promise<
   TextToImage_Config_Static_Reading.Outcome
-> => Attempt.Fresh_thatEventually(async (ends) => {
+> => Attempt.Fresh.thatEventually(async (ends) => {
   const fileResponse = await fetch(TextToImage_Config_Static_file.toString());
 
   if (

--- a/src/features/TextToImage/Server/Current/retrieve.ts
+++ b/src/features/TextToImage/Server/Current/retrieve.ts
@@ -27,7 +27,7 @@ const TextToImage_Server_Current_retrieve = (): Promise<
     WebAPI_Server,
     TextToImage_Server_Error.Specification
   >
-> => Attempt.Fresh_thatEventually(async (ends) => {
+> => Attempt.Fresh.thatEventually(async (ends) => {
   if (
     TextToImage_Server_Current_accordingToEnvironment !== null
   ) return ends.inSuccessWith(TextToImage_Server_Current_accordingToEnvironment);

--- a/src/features/TextToImage/Server/Error/Connection.ts
+++ b/src/features/TextToImage/Server/Error/Connection.ts
@@ -1,7 +1,7 @@
 import Attempt from '@/library/Attempt';
 
 class TextToImage_Server_Error_Connection
-  extends Attempt.Error_Actionable<
+  extends Attempt.Error.Actionable<
     'TextToImage_Server_Error_Connection'
   > {
   public override name = 'TextToImage_Server_Error_Connection' as const;

--- a/src/features/TextToImage/Server/Error/Specification.ts
+++ b/src/features/TextToImage/Server/Error/Specification.ts
@@ -5,7 +5,7 @@ import type {
 } from '@/library/URLComponent';
 
 class TextToImage_Server_Error_Specification
-  extends Attempt.Error_Actionable<
+  extends Attempt.Error.Actionable<
     'TextToImage_Server_Error_Specification'
   > {
   public override name = 'TextToImage_Server_Error_Specification' as const;

--- a/src/features/TextToImage/Server/namespaceMembers.ts
+++ b/src/features/TextToImage/Server/namespaceMembers.ts
@@ -1,7 +1,4 @@
-export {
-  accordingToEnvironment as Current_accordingToEnvironment,
-  retrieve as Current_retrieve,
-} from './Current';
+export * as Current from './Current';
 
 export {
   TextToImage_Server_Error as Error,

--- a/src/features/TextToImage/components/TextToImageOutputImg.vue
+++ b/src/features/TextToImage/components/TextToImageOutputImg.vue
@@ -6,7 +6,7 @@ import {
 import type * as TextToImage from '@/features/TextToImage';
 
 defineProps<{
-  modelValue: TextToImage.Pipeline_Output['image'];
+  modelValue: TextToImage.Pipeline.Output['image'];
 }>();
 </script>
 

--- a/src/features/TextToImage/namespaceMembers.ts
+++ b/src/features/TextToImage/namespaceMembers.ts
@@ -2,8 +2,4 @@ export * as Client from './Client';
 
 export * as Server from './Server';
 
-export type {
-  Input as Pipeline_Input,
-  Output as Pipeline_Output,
-  Output_Nullable_from as Pipeline_Output_Nullable_from,
-} from './Pipeline';
+export type * as Pipeline from './Pipeline';

--- a/src/library/Attempt/namespaceMembers.ts
+++ b/src/library/Attempt/namespaceMembers.ts
@@ -8,29 +8,14 @@ export {
   type Attempt_Outcome_Failure as Outcome_Failure,
 } from './Outcome';
 
-export {
-  to as Adapted_to,
-  toEventually as Adapted_toEventually,
-  toSettle as Adapted_toSettle,
-  type Config as Adapted_Config,
-} from './Adapted';
+export * as Adapted from './Adapted';
 
-export {
-  NonActionable as Error_NonActionable,
-  Actionable as Error_Actionable,
-  type Interpreter as Error_Interpreter,
-} from './Error';
+export * as Error from './Error';
 
-export {
-  that as Fresh_that,
-  thatEventually as Fresh_thatEventually,
-} from './Fresh';
+export * as Fresh from './Fresh';
 
 export type {
   Attempt_Progressive as Progressive,
 } from './Progressive';
 
-export type {
-  Getter as End_Getter,
-  Retriever as End_Retriever,
-} from './End';
+export type * as End from './End';

--- a/src/library/HTTP/Client.ts
+++ b/src/library/HTTP/Client.ts
@@ -45,7 +45,7 @@ class HTTP_Client {
       to: URLComponent_Path;
       using: HTTP_Request.Method;
     },
-  ): Promise<HTTP_Endpoint.Outcome> => Attempt.Fresh_thatEventually(async (ends) => {
+  ): Promise<HTTP_Endpoint.Outcome> => Attempt.Fresh.thatEventually(async (ends) => {
     const endpointURL = this.originAt(givenPath);
 
     const promisedResponse = fetch(endpointURL, {
@@ -54,7 +54,7 @@ class HTTP_Client {
       body   : JSON.stringify(givenRequestBody),
     });
 
-    const outcomeOfSettlingResponse = await Attempt.Adapted_toSettle(promisedResponse, {
+    const outcomeOfSettlingResponse = await Attempt.Adapted.toSettle(promisedResponse, {
       interpretationOf: (caughtError) => {
         const clientFailedToReachServer = caughtError.message.includes('Failed to fetch');
 

--- a/src/library/HTTP/Endpoint/Error/Request.ts
+++ b/src/library/HTTP/Endpoint/Error/Request.ts
@@ -1,7 +1,7 @@
 import Attempt from '@/library/Attempt';
 
 class HTTP_Endpoint_Error_Request
-  extends Attempt.Error_Actionable<
+  extends Attempt.Error.Actionable<
     'HTTP_Endpoint_Error_Request'
   > {
   public override name = 'HTTP_Endpoint_Error_Request' as const;

--- a/src/library/HTTP/Endpoint/Error/Response.ts
+++ b/src/library/HTTP/Endpoint/Error/Response.ts
@@ -5,7 +5,7 @@ import type {
 } from '../../Response';
 
 class HTTP_Endpoint_Error_Response
-  extends Attempt.Error_Actionable<
+  extends Attempt.Error.Actionable<
     'HTTP_Endpoint_Error_Response'
   > {
   public override name = 'HTTP_Endpoint_Error_Response' as const;

--- a/src/library/NonTrivialString/definition.ts
+++ b/src/library/NonTrivialString/definition.ts
@@ -24,7 +24,7 @@ class NonTrivialString
   ): Attempt.Outcome<
     NonTrivialString,
     NonTrivialString_ParsingError
-  > => Attempt.Fresh_that((ends) => {
+  > => Attempt.Fresh.that((ends) => {
     const trimmedSubject = givenSubject.trim();
 
     if (
@@ -39,7 +39,7 @@ class NonTrivialString
   ): Attempt.Outcome<
     NonTrivialString | null,
     NonTrivialString_ParsingError
-  > => Attempt.Fresh_that((ends) => {
+  > => Attempt.Fresh.that((ends) => {
     if (
       givenSubject === null
     ) return ends.inSuccessWith(givenSubject);

--- a/src/library/Parse/instanceFrom.ts
+++ b/src/library/Parse/instanceFrom.ts
@@ -17,7 +17,7 @@ const Parse_instanceFrom = <
 ): Attempt.Outcome<
   Schema.infer<SomeSchema>,
   SomeParsingError
-> => Attempt.Fresh_that((ends) => {
+> => Attempt.Fresh.that((ends) => {
   const resultOfParsingSubject = givenSchema.safeParse(givenSubject);
 
   if (

--- a/src/library/ParsingError.ts
+++ b/src/library/ParsingError.ts
@@ -2,7 +2,7 @@ import Attempt from '@/library/Attempt';
 
 abstract class ParsingError<
   SomeSubject extends string,
-> extends Attempt.Error_Actionable<
+> extends Attempt.Error.Actionable<
     `${SomeSubject}_ParsingError`
   > {
   public constructor(

--- a/src/library/Sequence/Base64/Conformance/Error.ts
+++ b/src/library/Sequence/Base64/Conformance/Error.ts
@@ -2,7 +2,7 @@ import Attempt from '@/library/Attempt';
 import Base64 from '@/library/Base64';
 
 class Sequence_Base64_Conformance_Error
-  extends Attempt.Error_Actionable<
+  extends Attempt.Error.Actionable<
     'Sequence_Base64_Conformance_Error'
   > {
   public override name = 'Sequence_Base64_Conformance_Error' as const;

--- a/src/library/Sequence/Base64/Conformance/ensure.ts
+++ b/src/library/Sequence/Base64/Conformance/ensure.ts
@@ -13,7 +13,7 @@ const Sequence_Base64_Conformance_ensure = (
 ): Attempt.Outcome<
   string,
   Sequence_Base64_Conformance_Error
-> => Attempt.Fresh_that((ends) => {
+> => Attempt.Fresh.that((ends) => {
   if (
     !Sequence_Base64_pattern.test(givenCharacterSequence)
   ) return ends.inFailureDueTo(new Sequence_Base64_Conformance_Error());

--- a/src/library/Sequence/Byte/Encoded/Compatibility/Error.ts
+++ b/src/library/Sequence/Byte/Encoded/Compatibility/Error.ts
@@ -2,7 +2,7 @@ import Attempt from '@/library/Attempt';
 import Byte from '@/library/Byte';
 
 class Sequence_Byte_Encoded_Compatibility_Error
-  extends Attempt.Error_Actionable<
+  extends Attempt.Error.Actionable<
     'Sequence_Byte_Encoded_Compatibility_Error'
   > {
   public override name = 'Sequence_Byte_Encoded_Compatibility_Error' as const;

--- a/src/library/Sequence/Byte/Encoded/Compatibility/ensure.ts
+++ b/src/library/Sequence/Byte/Encoded/Compatibility/ensure.ts
@@ -15,7 +15,7 @@ const Sequence_Byte_Encoded_Compatibility_ensure = (
 ): Attempt.Outcome<
   string,
   Sequence_Byte_Encoded_Compatibility_Error
-> => Attempt.Fresh_that((ends) => {
+> => Attempt.Fresh.that((ends) => {
   const byteCofactor = Byte.cofactorTo(givenBitWidth);
 
   if (

--- a/src/library/Shortfin/TextToImage/SDXL/Client/definition.ts
+++ b/src/library/Shortfin/TextToImage/SDXL/Client/definition.ts
@@ -22,7 +22,7 @@ class Shortfin_TextToImage_SDXL_Client
   > {
     const generationEndpoint = URLComponent_Path.parsedFrom('/generate').forciblyUnwrap();
 
-    return Attempt.Fresh_thatEventually(async (ends) => {
+    return Attempt.Fresh.thatEventually(async (ends) => {
       const outcomeOfSubmittingResource = await this.submitResource({
         bySending: givenBatchedRequestBody,
         to       : generationEndpoint,

--- a/src/library/URLComponent/Origin/definition.ts
+++ b/src/library/URLComponent/Origin/definition.ts
@@ -18,7 +18,7 @@ class URLComponent_Origin
   ): Attempt.Outcome<
     URLComponent_Origin,
     URLComponent_Origin_ParsingError
-  > => Attempt.Fresh_that((ends) => {
+  > => Attempt.Fresh.that((ends) => {
     const derived = new URL(givenSubject);
 
     const newParsingError = new URLComponent_Origin_ParsingError({

--- a/src/library/URLComponent/Path/definition.ts
+++ b/src/library/URLComponent/Path/definition.ts
@@ -18,7 +18,7 @@ class URLComponent_Path
   ): Attempt.Outcome<
     URLComponent_Path,
     URLComponent_Path_ParsingError
-  > => Attempt.Fresh_that((ends) => {
+  > => Attempt.Fresh.that((ends) => {
     const exampleURL = new URL(`https://example.com${givenSubject}`);
 
     const newParsingError = new URLComponent_Path_ParsingError({

--- a/src/library/math/operator/constructive/absoluteValueOf/definition.test.ts
+++ b/src/library/math/operator/constructive/absoluteValueOf/definition.test.ts
@@ -43,7 +43,7 @@ describe(absoluteValueOf, () => {
         it('should safely propagate the error', () => {
           expect.assertions(1);
 
-          expect(() => absoluteValueOf(soleInoperableNumber)).toThrow(Attempt.Error_NonActionable);
+          expect(() => absoluteValueOf(soleInoperableNumber)).toThrow(Attempt.Error.NonActionable);
         });
 
         it('should communicate clearly with developers', () => {

--- a/src/library/math/operator/constructive/greatestCommonDivisor/definition.test.ts
+++ b/src/library/math/operator/constructive/greatestCommonDivisor/definition.test.ts
@@ -100,7 +100,7 @@ describe(greatestCommonDivisor, () => {
         it.each(combosOfFractionalNumbers)('should safely propagate the error', (...$0) => {
           expect.assertions(1);
 
-          expect(() => greatestCommonDivisor(...$0)).toThrow(Attempt.Error_NonActionable);
+          expect(() => greatestCommonDivisor(...$0)).toThrow(Attempt.Error.NonActionable);
         });
 
         const fractionalCombosWithMessage = [

--- a/src/library/math/operator/hyper/rank3/squared.test.ts
+++ b/src/library/math/operator/hyper/rank3/squared.test.ts
@@ -42,7 +42,7 @@ describe(squared, () => {
       it('should safely propagate the error', () => {
         expect.assertions(1);
 
-        expect(() => squared(soleInoperableNumber)).toThrow(Attempt.Error_NonActionable);
+        expect(() => squared(soleInoperableNumber)).toThrow(Attempt.Error.NonActionable);
       });
 
       it('should communicate clearly with developers', () => {

--- a/src/library/math/operator/predicate/isFinite.test.ts
+++ b/src/library/math/operator/predicate/isFinite.test.ts
@@ -27,7 +27,7 @@ describe(isFinite, () => {
     it('should safely propagate the error', () => {
       expect.assertions(1);
 
-      expect(() => isFinite(theSoleInoperableNumber)).toThrow(Attempt.Error_NonActionable);
+      expect(() => isFinite(theSoleInoperableNumber)).toThrow(Attempt.Error.NonActionable);
     });
 
     it('should communicate clearly with developers', () => {

--- a/src/library/math/operator/predicate/isNegative.test.ts
+++ b/src/library/math/operator/predicate/isNegative.test.ts
@@ -42,7 +42,7 @@ describe(isNegative, () => {
       it('should safely propagate the error', () => {
         expect.assertions(1);
 
-        expect(() => isNegative(soleInoperableNumber)).toThrow(Attempt.Error_NonActionable);
+        expect(() => isNegative(soleInoperableNumber)).toThrow(Attempt.Error.NonActionable);
       });
 
       it('should communicate clearly with developers', () => {

--- a/src/library/math/operator/predicate/isWhole/definition.test.ts
+++ b/src/library/math/operator/predicate/isWhole/definition.test.ts
@@ -40,7 +40,7 @@ describe(isWhole, () => {
         it('should safely propagate the error', () => {
           expect.assertions(1);
 
-          expect(() => isWhole(eachInfiniteNumber)).toThrow(Attempt.Error_NonActionable);
+          expect(() => isWhole(eachInfiniteNumber)).toThrow(Attempt.Error.NonActionable);
         });
 
         it('should communicate clearly with developers', () => {

--- a/src/library/vue/composables/useStatefulAttemptThatEventually.ts
+++ b/src/library/vue/composables/useStatefulAttemptThatEventually.ts
@@ -10,9 +10,9 @@ import Attempt from '@/library/Attempt';
 /** Useful when state of UI is dependent on some async operation and the outcome upon completion */
 const useStatefulAttemptThatEventually = <
   SomeProduct,
-  SomeActionableError extends Attempt.Error_Actionable<string>,
+  SomeActionableError extends Attempt.Error.Actionable<string>,
 >(
-  retrieveOutcome: Attempt.End_Retriever<
+  retrieveOutcome: Attempt.End.Retriever<
     Attempt.Outcome<SomeProduct, SomeActionableError>
   >,
 ): Attempt.Progressive<
@@ -38,7 +38,7 @@ const useStatefulAttemptThatEventually = <
       set(flagIsRaised, false);
     });
 
-    const retrievedOutcome = await Attempt.Fresh_thatEventually(retrieveOutcome);
+    const retrievedOutcome = await Attempt.Fresh.thatEventually(retrieveOutcome);
     set(capturedOutcome, retrievedOutcome);
   };
 

--- a/src/pages/TextToImagePage.vue
+++ b/src/pages/TextToImagePage.vue
@@ -38,7 +38,7 @@ import TextToImageInputSection from '@/features/TextToImage/components/TextToIma
 import TextToImageOutputAlert from '@/features/TextToImage/components/TextToImageOutputAlert.vue';
 import TextToImageOutputImg from '@/features/TextToImage/components/TextToImageOutputImg.vue';
 
-const currentPrompt: Ref<TextToImage.Pipeline_Input['text'] | null> = ref(null);
+const currentPrompt: Ref<TextToImage.Pipeline.Input['text'] | null> = ref(null);
 
 const {
   range,


### PR DESCRIPTION
- some namespace member definitions we reaching into their re-exports and using "compound aliases"
- to avoid the anti-pattern, the namespace is labeled
- the resulting dot syntax increases the flexibility and discoverability of the modules while keeping the semantics intact