### PR TITLE
refactor: avoids destructuring import namespaces

### DIFF
--- a/src/features/TextToImage/Client/Generation/Outcome.ts
+++ b/src/features/TextToImage/Client/Generation/Outcome.ts
@@ -1,13 +1,10 @@
 import type Attempt from '@/library/Attempt';
 
-import type {
-  Output as TextToImage_Pipeline_Output,
-} from '../../Pipeline';
-
+import type * as TextToImage_Pipeline from '../../Pipeline';
 import type * as TextToImage_Server from '../../Server';
 
 type TextToImage_Client_Generation_Outcome = Attempt.Outcome<
-  TextToImage_Pipeline_Output,
+  TextToImage_Pipeline.Output,
   TextToImage_Server.Error.Any
 >;
 

--- a/src/features/TextToImage/Client/SDXL/generateOutputFrom.ts
+++ b/src/features/TextToImage/Client/SDXL/generateOutputFrom.ts
@@ -15,9 +15,7 @@ import {
   TextToImage_Client_SDXL_initialize,
 } from './initialize';
 
-import {
-  first as toSharkUIOutput_first,
-} from './toSharkUIOutput';
+import * as toSharkUIOutput from './toSharkUIOutput';
 
 const TextToImage_Client_SDXL_generateOutputFrom = async (
   given: {
@@ -64,7 +62,7 @@ const TextToImage_Client_SDXL_generateOutputFrom = async (
   });
 
   const outcomeOfSettlingSoleTextToImageOutput = Attempt.Outcome.fromRewrapping(outcomeOfSettlingTextToImageResponse, {
-    product: textToImageResponse => toSharkUIOutput_first({
+    product: textToImageResponse => toSharkUIOutput.first({
       in          : textToImageResponse,
       inferredFrom: given.textToImageRequestBody.textPrompts,
     }),

--- a/src/features/TextToImage/Client/SDXL/toSharkUIOutput/Image/Description/all.ts
+++ b/src/features/TextToImage/Client/SDXL/toSharkUIOutput/Image/Description/all.ts
@@ -2,9 +2,7 @@ import type {
   TextPrompt,
 } from 'stabilityai-client-typescript/models/components';
 
-import type {
-  Output as TextToImage_Pipeline_Output,
-} from '@/features/TextToImage/Pipeline'; // eslint-disable-line import/no-internal-modules -- more concise than relative import
+import type * as TextToImage_Pipeline from '@/features/TextToImage/Pipeline'; // eslint-disable-line import/no-internal-modules -- more concise than relative import
 
 import {
   toSharkUIOutput_Image_Description_singular,
@@ -12,7 +10,7 @@ import {
 
 const toSharkUIOutput_Image_Description_all = (
   givenPrompts: TextPrompt[],
-): TextToImage_Pipeline_Output['image']['description'] => givenPrompts
+): TextToImage_Pipeline.Output['image']['description'] => givenPrompts
   .map(toSharkUIOutput_Image_Description_singular)
   .join(', ');
 

--- a/src/features/TextToImage/Client/SDXL/toSharkUIOutput/Image/Description/singular.ts
+++ b/src/features/TextToImage/Client/SDXL/toSharkUIOutput/Image/Description/singular.ts
@@ -2,13 +2,11 @@ import type {
   TextPrompt,
 } from 'stabilityai-client-typescript/models/components';
 
-import type {
-  Output as TextToImage_Pipeline_Output,
-} from '@/features/TextToImage/Pipeline'; // eslint-disable-line import/no-internal-modules -- more concise than relative import
+import type * as TextToImage_Pipeline from '@/features/TextToImage/Pipeline'; // eslint-disable-line import/no-internal-modules -- more concise than relative import
 
 const toSharkUIOutput_Image_Description_singular = (
   givenPrompt: TextPrompt,
-): TextToImage_Pipeline_Output['image']['description'] => {
+): TextToImage_Pipeline.Output['image']['description'] => {
   const isDefault = (
     givenWeight: TextPrompt['weight'],
   ) => {

--- a/src/features/TextToImage/Client/SDXL/toSharkUIOutput/Image/definition.ts
+++ b/src/features/TextToImage/Client/SDXL/toSharkUIOutput/Image/definition.ts
@@ -6,16 +6,14 @@ import {
   URI_Image,
 } from '@/library/UniformResourceIdentifier';
 
-import type {
-  Output as TextToImage_Pipeline_Output,
-} from '@/features/TextToImage/Pipeline'; // eslint-disable-line import/no-internal-modules -- more concise than relative import
+import type * as TextToImage_Pipeline from '@/features/TextToImage/Pipeline'; // eslint-disable-line import/no-internal-modules -- more concise than relative import
 
 const toSharkUIOutput_Image = (
   givenImage: StabilityAIClient.Image,
   given: {
-    description: TextToImage_Pipeline_Output['image']['description'];
+    description: TextToImage_Pipeline.Output['image']['description'];
   },
-): TextToImage_Pipeline_Output['image'] | null => {
+): TextToImage_Pipeline.Output['image'] | null => {
   if (
     givenImage.base64 === undefined
   ) return null;

--- a/src/features/TextToImage/Client/SDXL/toSharkUIOutput/first.ts
+++ b/src/features/TextToImage/Client/SDXL/toSharkUIOutput/first.ts
@@ -8,10 +8,7 @@ import {
   hasAtLeastOne,
 } from '@/library/utilitiesByType/array';
 
-import type {
-  Input as TextToImage_Pipeline_Input,
-  Output as TextToImage_Pipeline_Output,
-} from '@/features/TextToImage/Pipeline'; // eslint-disable-line import/no-internal-modules -- more concise than relative import
+import type * as TextToImage_Pipeline from '@/features/TextToImage/Pipeline'; // eslint-disable-line import/no-internal-modules -- more concise than relative import
 
 import {
   toSharkUIOutput_plural,
@@ -23,9 +20,9 @@ const toSharkUIOutput_first = (
     inferredFrom: givenInputText,
   }: {
     in: GenerateFromTextResponse;
-    inferredFrom: TextToImage_Pipeline_Input['text'];
+    inferredFrom: TextToImage_Pipeline.Input['text'];
   },
-): TextToImage_Pipeline_Output => {
+): TextToImage_Pipeline.Output => {
   const inferredOutputs = toSharkUIOutput_plural({
     in          : givenResponse,
     inferredFrom: givenInputText,

--- a/src/features/TextToImage/Client/SDXL/toSharkUIOutput/plural.ts
+++ b/src/features/TextToImage/Client/SDXL/toSharkUIOutput/plural.ts
@@ -4,11 +4,7 @@ import type {
 
 import Attempt from '@/library/Attempt';
 
-import {
-  type Input as TextToImage_Pipeline_Input,
-  type Output as TextToImage_Pipeline_Output,
-  Output_Nullable as TextToImage_Pipeline_Output_Nullable,
-} from '@/features/TextToImage/Pipeline'; // eslint-disable-line import/no-internal-modules -- more concise than relative import
+import * as TextToImage_Pipeline from '@/features/TextToImage/Pipeline'; // eslint-disable-line import/no-internal-modules -- more concise than relative import
 
 import {
   toSharkUIOutput_Image,
@@ -21,9 +17,9 @@ const toSharkUIOutput_plural = (
     inferredFrom: givenInputText,
   }: {
     in: GenerateFromTextResponse;
-    inferredFrom: TextToImage_Pipeline_Input['text'];
+    inferredFrom: TextToImage_Pipeline.Input['text'];
   },
-): (TextToImage_Pipeline_Output | null)[] | null => {
+): (TextToImage_Pipeline.Output | null)[] | null => {
   if (
     !('artifacts' in givenResponse.result)
   ) return Attempt.abandon('Expected response body rather than readable stream');
@@ -38,7 +34,7 @@ const toSharkUIOutput_plural = (
     .map($0 => toSharkUIOutput_Image($0, {
       description: toSharkUIOutput_Image_Description.all(givenInputText),
     }))
-    .map($0 => TextToImage_Pipeline_Output_Nullable.from($0));
+    .map($0 => TextToImage_Pipeline.Output_Nullable.from($0));
 
   return inferredOutputs;
 };

--- a/src/features/TextToImage/Config/Dynamic/Fetching/Error/Request.ts
+++ b/src/features/TextToImage/Config/Dynamic/Fetching/Error/Request.ts
@@ -1,8 +1,5 @@
 import Attempt from '@/library/Attempt';
-
-import type {
-  Path as URLComponent_Path,
-} from '@/library/URLComponent';
+import type * as URLComponent from '@/library/URLComponent';
 
 class TextToImage_Config_Dynamic_Fetching_Error_Request
   extends Attempt.Error.Actionable<
@@ -11,7 +8,7 @@ class TextToImage_Config_Dynamic_Fetching_Error_Request
   public override name = 'TextToImage_Config_Dynamic_Fetching_Error_Request' as const;
 
   public constructor(
-    givenEndpoint: URLComponent_Path,
+    givenEndpoint: URLComponent.Path,
   ) {
     super(`Failed to fetch text-to-image config from endpoint: ${givenEndpoint.toString()}`);
   }

--- a/src/features/TextToImage/Config/Dynamic/Fetching/Error/Response.ts
+++ b/src/features/TextToImage/Config/Dynamic/Fetching/Error/Response.ts
@@ -1,8 +1,5 @@
 import Attempt from '@/library/Attempt';
-
-import type {
-  Path as URLComponent_Path,
-} from '@/library/URLComponent';
+import type * as URLComponent from '@/library/URLComponent';
 
 class TextToImage_Config_Dynamic_Fetching_Error_Response
   extends Attempt.Error.Actionable<
@@ -11,7 +8,7 @@ class TextToImage_Config_Dynamic_Fetching_Error_Response
   public override name = 'TextToImage_Config_Dynamic_Fetching_Error_Response' as const;
 
   public constructor(given: {
-    endpoint: URLComponent_Path;
+    endpoint: URLComponent.Path;
     response: Response;
   }) {
     super(`Expected JSON response from "${given.endpoint.toString()}", but received content-type: ${given.response.headers.get('Content-Type') ?? ''}`);

--- a/src/features/TextToImage/Config/Dynamic/endpoint.ts
+++ b/src/features/TextToImage/Config/Dynamic/endpoint.ts
@@ -1,8 +1,6 @@
-import {
-  Path as URLComponent_Path,
-} from '@/library/URLComponent';
+import * as URLComponent from '@/library/URLComponent';
 
-const TextToImage_Config_Dynamic_endpoint = URLComponent_Path.parsedFrom('/config/text-to-image').forciblyUnwrap();
+const TextToImage_Config_Dynamic_endpoint = URLComponent.Path.parsedFrom('/config/text-to-image').forciblyUnwrap();
 
 export {
   TextToImage_Config_Dynamic_endpoint,

--- a/src/features/TextToImage/Config/Static/Reading/Error.ts
+++ b/src/features/TextToImage/Config/Static/Reading/Error.ts
@@ -1,8 +1,5 @@
 import Attempt from '@/library/Attempt';
-
-import type {
-  Path as URLComponent_Path,
-} from '@/library/URLComponent';
+import type * as URLComponent from '@/library/URLComponent';
 
 class TextToImage_Config_Static_Reading_Error
   extends Attempt.Error.Actionable<
@@ -11,7 +8,7 @@ class TextToImage_Config_Static_Reading_Error
   public override name = 'TextToImage_Config_Static_Reading_Error' as const;
 
   public constructor(
-    givenFile: URLComponent_Path,
+    givenFile: URLComponent.Path,
     givenResponse: Response,
   ) {
     super(`Failed to read config at "${givenFile.toString()}". Cause: "${givenResponse.statusText}"`);

--- a/src/features/TextToImage/Config/Static/file.ts
+++ b/src/features/TextToImage/Config/Static/file.ts
@@ -1,8 +1,6 @@
-import {
-  Path as URLComponent_Path,
-} from '@/library/URLComponent';
+import * as URLComponent from '@/library/URLComponent';
 
-const TextToImage_Config_Static_file = URLComponent_Path.parsedFrom('/config/text-to-image.json').forciblyUnwrap();
+const TextToImage_Config_Static_file = URLComponent.Path.parsedFrom('/config/text-to-image.json').forciblyUnwrap();
 
 export {
   TextToImage_Config_Static_file,

--- a/src/features/TextToImage/Server/Current/accordingToEnvironment.ts
+++ b/src/features/TextToImage/Server/Current/accordingToEnvironment.ts
@@ -1,19 +1,17 @@
-import {
-  Server as WebAPI_Server,
-} from '@/library/WebAPI';
+import * as WebAPI from '@/library/WebAPI';
 
 import {
   TextToImage_Server_Origin,
 } from '../Origin';
 
-const TextToImage_Server_Current_accordingToEnvironment = ((): WebAPI_Server | null => {
+const TextToImage_Server_Current_accordingToEnvironment = ((): WebAPI.Server | null => {
   const originAccordingToEnvironment = import.meta.env[TextToImage_Server_Origin.environmentKey];
 
   if (
     originAccordingToEnvironment === undefined
   ) return null;
 
-  const serverAccordingToEnvironment = WebAPI_Server.from({
+  const serverAccordingToEnvironment = WebAPI.Server.from({
     origin: originAccordingToEnvironment,
   });
 

--- a/src/features/TextToImage/Server/Current/retrieve.ts
+++ b/src/features/TextToImage/Server/Current/retrieve.ts
@@ -1,14 +1,7 @@
 import Attempt from '@/library/Attempt';
+import type * as WebAPI from '@/library/WebAPI';
 
-import type {
-  Server as WebAPI_Server,
-} from '@/library/WebAPI';
-
-import {
-  Dynamic as TextToImage_Config_Dynamic,
-  Static as TextToImage_Config_Static,
-  empty as TextToImage_Config_empty,
-} from '../../Config';
+import * as TextToImage_Config from '../../Config';
 
 import {
   TextToImage_Server_Error,
@@ -24,7 +17,7 @@ import {
 
 const TextToImage_Server_Current_retrieve = (): Promise<
   Attempt.Outcome<
-    WebAPI_Server,
+    WebAPI.Server,
     TextToImage_Server_Error.Specification
   >
 > => Attempt.Fresh.thatEventually(async (ends) => {
@@ -32,13 +25,13 @@ const TextToImage_Server_Current_retrieve = (): Promise<
     TextToImage_Server_Current_accordingToEnvironment !== null
   ) return ends.inSuccessWith(TextToImage_Server_Current_accordingToEnvironment);
 
-  const staticConfig = (await TextToImage_Config_Static.read()).optionallyUnwrap() ?? TextToImage_Config_empty;
+  const staticConfig = (await TextToImage_Config.Static.read()).optionallyUnwrap() ?? TextToImage_Config.empty;
 
   if (
     staticConfig.server !== null
   ) return ends.inSuccessWith(staticConfig.server);
 
-  const dynamicConfig = (await TextToImage_Config_Dynamic.fetch()).optionallyUnwrap() ?? TextToImage_Config_empty;
+  const dynamicConfig = (await TextToImage_Config.Dynamic.fetch()).optionallyUnwrap() ?? TextToImage_Config.empty;
 
   if (
     dynamicConfig.server !== null
@@ -46,8 +39,8 @@ const TextToImage_Server_Current_retrieve = (): Promise<
 
   const newSpecificationError = new TextToImage_Server_Error.Specification(
     TextToImage_Server_Origin.environmentKey,
-    TextToImage_Config_Static.file,
-    TextToImage_Config_Dynamic.endpoint,
+    TextToImage_Config.Static.file,
+    TextToImage_Config.Dynamic.endpoint,
   );
 
   return ends.inFailureDueTo(newSpecificationError);

--- a/src/features/TextToImage/Server/Error/Specification.ts
+++ b/src/features/TextToImage/Server/Error/Specification.ts
@@ -1,8 +1,5 @@
 import Attempt from '@/library/Attempt';
-
-import type {
-  Path as URLComponent_Path,
-} from '@/library/URLComponent';
+import type * as URLComponent from '@/library/URLComponent';
 
 class TextToImage_Server_Error_Specification
   extends Attempt.Error.Actionable<
@@ -12,8 +9,8 @@ class TextToImage_Server_Error_Specification
 
   public constructor(
     public readonly environmentKey: string,
-    public readonly file: URLComponent_Path,
-    public readonly endpoint: URLComponent_Path,
+    public readonly file: URLComponent.Path,
+    public readonly endpoint: URLComponent.Path,
   ) {
     super('Failed to determine text-to-image server');
   }

--- a/src/features/TextToImage/components/TextToImageInputSection.vue
+++ b/src/features/TextToImage/components/TextToImageInputSection.vue
@@ -15,11 +15,9 @@ import {
   VTextarea,
 } from 'vuetify/components/VTextarea';
 
-import type {
-  Input as TextToImage_Pipeline_Input,
-} from '../Pipeline';
+import type * as TextToImage_Pipeline from '../Pipeline';
 
-type StandardizedInputText = TextToImage_Pipeline_Input['text'];
+type StandardizedInputText = TextToImage_Pipeline.Input['text'];
 
 const exposedInputText = defineModel<StandardizedInputText | null>({
   required: true,

--- a/src/library/Attempt/Adapted/Config.ts
+++ b/src/library/Attempt/Adapted/Config.ts
@@ -1,12 +1,9 @@
-import type {
-  Actionable as Attempt_Error_Actionable,
-  Interpreter as Attempt_Error_Interpreter,
-} from '../Error';
+import type * as Attempt_Error from '../Error';
 
 interface Attempt_Adapted_Config<
-  SomeActionableError extends Attempt_Error_Actionable<string>,
+  SomeActionableError extends Attempt_Error.Actionable<string>,
 > {
-  interpretationOf: Attempt_Error_Interpreter<SomeActionableError>;
+  interpretationOf: Attempt_Error.Interpreter<SomeActionableError>;
 }
 
 export type {

--- a/src/library/Attempt/Adapted/to.ts
+++ b/src/library/Attempt/Adapted/to.ts
@@ -1,11 +1,5 @@
-import {
-  type Actionable as Attempt_Error_Actionable,
-  Actionable_from as Attempt_Error_Actionable_from,
-} from '../Error';
-
-import {
-  that as Attempt_Fresh_that,
-} from '../Fresh';
+import * as Attempt_Error from '../Error';
+import * as Attempt_Fresh from '../Fresh';
 
 import type {
   Attempt_Outcome,
@@ -21,17 +15,17 @@ import type {
 
 const Attempt_Adapted_to = <
   SomeProduct,
-  SomeActionableError extends Attempt_Error_Actionable<string>,
+  SomeActionableError extends Attempt_Error.Actionable<string>,
 >(
   forciblyGetProduct: () => SomeProduct,
   given: Attempt_Adapted_Config<SomeActionableError>,
-): Attempt_Outcome<SomeProduct, SomeActionableError> => Attempt_Fresh_that(ends => safe({
+): Attempt_Outcome<SomeProduct, SomeActionableError> => Attempt_Fresh.that(ends => safe({
   try() {
     const gottenProduct = forciblyGetProduct();
     return ends.inSuccessWith(gottenProduct);
   },
   catch(someError) {
-    const someActionableError = Attempt_Error_Actionable_from(someError, {
+    const someActionableError = Attempt_Error.Actionable_from(someError, {
       using: given.interpretationOf,
     });
 

--- a/src/library/Attempt/Adapted/toEventually.ts
+++ b/src/library/Attempt/Adapted/toEventually.ts
@@ -1,11 +1,5 @@
-import {
-  type Actionable as Attempt_Error_Actionable,
-  Actionable_from as Attempt_Error_Actionable_from,
-} from '../Error';
-
-import {
-  thatEventually as Attempt_Fresh_thatEventually,
-} from '../Fresh';
+import * as Attempt_Error from '../Error';
+import * as Attempt_Fresh from '../Fresh';
 
 import type {
   Attempt_Outcome,
@@ -21,7 +15,7 @@ import type {
 
 const Attempt_Adapted_toEventually = async <
   SomeProduct,
-  SomeActionableError extends Attempt_Error_Actionable<string>,
+  SomeActionableError extends Attempt_Error.Actionable<string>,
 >(
   forciblyRetrieveProduct: () => Promise<SomeProduct>,
   given: Attempt_Adapted_Config<SomeActionableError>,
@@ -30,13 +24,13 @@ const Attempt_Adapted_toEventually = async <
     SomeProduct,
     SomeActionableError
   >
-> => Attempt_Fresh_thatEventually(ends => safeAsync({
+> => Attempt_Fresh.thatEventually(ends => safeAsync({
   async try() {
     const retrievedProduct: SomeProduct = await forciblyRetrieveProduct();
     return ends.inSuccessWith(retrievedProduct);
   },
   catch(someError) {
-    const someActionableError = Attempt_Error_Actionable_from(someError, {
+    const someActionableError = Attempt_Error.Actionable_from(someError, {
       using: given.interpretationOf,
     });
 

--- a/src/library/Attempt/Adapted/toSettle.ts
+++ b/src/library/Attempt/Adapted/toSettle.ts
@@ -1,6 +1,4 @@
-import type {
-  Actionable as Attempt_Error_Actionable,
-} from '../Error';
+import type * as Attempt_Error from '../Error';
 
 import type {
   Attempt_Outcome,
@@ -16,7 +14,7 @@ import {
 
 const Attempt_Adapted_toSettle = async <
   SomeProduct,
-  SomeActionableError extends Attempt_Error_Actionable<string>,
+  SomeActionableError extends Attempt_Error.Actionable<string>,
 >(
   promisedProduct: Promise<SomeProduct>,
   givenConfig: Attempt_Adapted_Config<SomeActionableError>,

--- a/src/library/Attempt/End/Getter.ts
+++ b/src/library/Attempt/End/Getter.ts
@@ -1,6 +1,4 @@
-import type {
-  Actionable as Attempt_Error_Actionable,
-} from '../Error';
+import type * as Attempt_Error from '../Error';
 
 import type {
   Attempt_Outcome,
@@ -11,7 +9,7 @@ import type {
 } from '../ended';
 
 type Attempt_End_Getter<
-  SomeInferredOutcome extends Attempt_Outcome<unknown, Attempt_Error_Actionable<string>>,
+  SomeInferredOutcome extends Attempt_Outcome<unknown, Attempt_Error.Actionable<string>>,
 > = (
   givenHandles: typeof handles
 ) => SomeInferredOutcome;

--- a/src/library/Attempt/End/Retriever.ts
+++ b/src/library/Attempt/End/Retriever.ts
@@ -1,6 +1,4 @@
-import type {
-  Actionable as Attempt_Error_Actionable,
-} from '../Error';
+import type * as Attempt_Error from '../Error';
 
 import type {
   Attempt_Outcome,
@@ -11,7 +9,7 @@ import type {
 } from '../ended';
 
 type Attempt_End_Retriever<
-  SomeInferredOutcome extends Attempt_Outcome<unknown, Attempt_Error_Actionable<string>>,
+  SomeInferredOutcome extends Attempt_Outcome<unknown, Attempt_Error.Actionable<string>>,
 > = (
   givenHandles: typeof handles
 ) => Promise<SomeInferredOutcome>;

--- a/src/library/Attempt/Fresh/that.ts
+++ b/src/library/Attempt/Fresh/that.ts
@@ -1,11 +1,5 @@
-import type {
-  Getter as Attempt_End_Getter,
-} from '../End';
-
-import {
-  type Actionable as Attempt_Error_Actionable,
-  Creation as Attempt_Error_Creation,
-} from '../Error';
+import type * as Attempt_End from '../End';
+import * as Attempt_Error from '../Error';
 
 import type {
   Attempt_Outcome,
@@ -22,9 +16,9 @@ import {
 } from '../tryCatchStatements';
 
 const Attempt_Fresh_that = <
-  SomeInferredOutcome extends Attempt_Outcome<unknown, Attempt_Error_Actionable<string>>,
+  SomeInferredOutcome extends Attempt_Outcome<unknown, Attempt_Error.Actionable<string>>,
 >(
-  endsAccordingTo: Attempt_End_Getter<SomeInferredOutcome>,
+  endsAccordingTo: Attempt_End.Getter<SomeInferredOutcome>,
 ) => {
   type EquivalentOutcome = Attempt_Outcome<
     ProductOf<SomeInferredOutcome>,
@@ -36,7 +30,7 @@ const Attempt_Fresh_that = <
       return endsAccordingTo(handles) as EquivalentOutcome;
     },
     catch(someError) {
-      return Attempt_Error_Creation.rethrow(someError);
+      return Attempt_Error.Creation.rethrow(someError);
     },
   });
 };

--- a/src/library/Attempt/Fresh/thatEventually.ts
+++ b/src/library/Attempt/Fresh/thatEventually.ts
@@ -1,11 +1,5 @@
-import type {
-  Retriever as Attempt_End_Retriever,
-} from '../End';
-
-import {
-  type Actionable as Attempt_Error_Actionable,
-  Creation as Attempt_Error_Creation,
-} from '../Error';
+import type * as Attempt_End from '../End';
+import * as Attempt_Error from '../Error';
 
 import type {
   Attempt_Outcome,
@@ -22,9 +16,9 @@ import {
 } from '../tryCatchStatements';
 
 const Attempt_Fresh_thatEventually = async <
-  SomeInferredOutcome extends Attempt_Outcome<unknown, Attempt_Error_Actionable<string>>,
+  SomeInferredOutcome extends Attempt_Outcome<unknown, Attempt_Error.Actionable<string>>,
 >(
-  endsAccordingTo: Attempt_End_Retriever<SomeInferredOutcome>,
+  endsAccordingTo: Attempt_End.Retriever<SomeInferredOutcome>,
 ) => {
   type EquivalentOutcome = Attempt_Outcome<
     ProductOf<SomeInferredOutcome>,
@@ -36,7 +30,7 @@ const Attempt_Fresh_thatEventually = async <
       return await endsAccordingTo(handles) as EquivalentOutcome;
     },
     catch(someError) {
-      return Attempt_Error_Creation.rethrow(someError);
+      return Attempt_Error.Creation.rethrow(someError);
     },
   });
 };

--- a/src/library/Attempt/Outcome/Discriminable/definition.ts
+++ b/src/library/Attempt/Outcome/Discriminable/definition.ts
@@ -4,9 +4,7 @@ import type {
   Not,
 } from '@/library/typeUtilities';
 
-import type {
-  Actionable as Attempt_Error_Actionable,
-} from '../../Error';
+import type * as Attempt_Error from '../../Error';
 
 import type {
   Attempt_Outcome_Discriminant,
@@ -21,7 +19,7 @@ interface Attempt_Outcome_Discriminable<
   SomePayload extends (
     SomeDiscriminant extends 'success'
       ? unknown
-      : Attempt_Error_Actionable<string>
+      : Attempt_Error.Actionable<string>
   ),
 > extends Attempt_Outcome_Discriminable_SyntacticallySugarfree<
     SomeDiscriminant
@@ -43,7 +41,7 @@ interface Attempt_Outcome_Discriminable<
     SomeTransformedPayload extends (
       SomeDiscriminant extends 'success'
         ? unknown
-        : Attempt_Error_Actionable<string>
+        : Attempt_Error.Actionable<string>
     ) = SomePayload,
   >(): Attempt_Outcome_Discriminable<SomeDiscriminant, SomeTransformedPayload>;
 }

--- a/src/library/Attempt/Outcome/Failure/Cause/Transformer/definition.ts
+++ b/src/library/Attempt/Outcome/Failure/Cause/Transformer/definition.ts
@@ -1,10 +1,8 @@
-import type {
-  Actionable as Attempt_Error_Actionable,
-} from '@/library/Attempt/Error'; // eslint-disable-line import/no-internal-modules -- avoids lengthy relative paths
+import type * as Attempt_Error from '@/library/Attempt/Error'; // eslint-disable-line import/no-internal-modules -- avoids lengthy relative paths
 
 type Attempt_Outcome_Failure_Cause_Transformer<
-  SomeTransformableActionableError extends Attempt_Error_Actionable<string>,
-  SomeTransformedActionableError extends Attempt_Error_Actionable<string>,
+  SomeTransformableActionableError extends Attempt_Error.Actionable<string>,
+  SomeTransformedActionableError extends Attempt_Error.Actionable<string>,
 > = (
   transformableCause: SomeTransformableActionableError,
 ) => SomeTransformedActionableError;

--- a/src/library/Attempt/Outcome/Failure/Cause/Transformer/identity.ts
+++ b/src/library/Attempt/Outcome/Failure/Cause/Transformer/identity.ts
@@ -1,10 +1,8 @@
-import type {
-  Actionable as Attempt_Error_Actionable,
-} from '@/library/Attempt/Error'; // eslint-disable-line import/no-internal-modules -- avoids lengthy relative paths
+import type * as Attempt_Error from '@/library/Attempt/Error'; // eslint-disable-line import/no-internal-modules -- avoids lengthy relative paths
 
 const Attempt_Outcome_Failure_Cause_Transformer_identity = <
-  SomeTransformableActionableError extends Attempt_Error_Actionable<string>,
-  SomeTransformedActionableError extends Attempt_Error_Actionable<string>,
+  SomeTransformableActionableError extends Attempt_Error.Actionable<string>,
+  SomeTransformedActionableError extends Attempt_Error.Actionable<string>,
 >(
   transformableCause: NoInfer<SomeTransformableActionableError>,
 ): NoInfer<SomeTransformedActionableError> => {

--- a/src/library/Attempt/Outcome/Failure/SemanticallySugarfree.ts
+++ b/src/library/Attempt/Outcome/Failure/SemanticallySugarfree.ts
@@ -1,13 +1,11 @@
-import type {
-  Actionable as Attempt_Error_Actionable,
-} from '../../Error';
+import type * as Attempt_Error from '../../Error';
 
 import type {
   Attempt_Outcome_Discriminable,
 } from '../Discriminable';
 
 interface Attempt_Outcome_Failure_SemanticallySugarfree<
-  SomeActionableError extends Attempt_Error_Actionable<string>,
+  SomeActionableError extends Attempt_Error.Actionable<string>,
 > extends Attempt_Outcome_Discriminable<
     'failure',
     SomeActionableError

--- a/src/library/Attempt/Outcome/Failure/Transformer.ts
+++ b/src/library/Attempt/Outcome/Failure/Transformer.ts
@@ -1,16 +1,12 @@
-import type {
-  Actionable as Attempt_Error_Actionable,
-} from '../../Error';
+import type * as Attempt_Error from '../../Error';
 
-import type {
-  Transformer as Attempt_Outcome_Failure_Cause_Transformer,
-} from './Cause';
+import type * as Attempt_Outcome_Failure_Cause from './Cause';
 
 interface Attempt_Outcome_Failure_Transformer<
-  SomeTransformableActionableError extends Attempt_Error_Actionable<string>,
-  SomeTransformedActionableError extends Attempt_Error_Actionable<string>,
+  SomeTransformableActionableError extends Attempt_Error.Actionable<string>,
+  SomeTransformedActionableError extends Attempt_Error.Actionable<string>,
 > {
-  cause: Attempt_Outcome_Failure_Cause_Transformer<
+  cause: Attempt_Outcome_Failure_Cause.Transformer<
     SomeTransformableActionableError,
     SomeTransformedActionableError
   >;

--- a/src/library/Attempt/Outcome/Failure/definition.ts
+++ b/src/library/Attempt/Outcome/Failure/definition.ts
@@ -1,6 +1,4 @@
-import type {
-  Actionable as Attempt_Error_Actionable,
-} from '../../Error';
+import type * as Attempt_Error from '../../Error';
 
 import type {
   Attempt_Outcome_Failure_SemanticallySugarfree,
@@ -11,7 +9,7 @@ import type {
 } from './Transformer';
 
 interface Attempt_Outcome_Failure<
-  SomeActionableError extends Attempt_Error_Actionable<string>,
+  SomeActionableError extends Attempt_Error.Actionable<string>,
 > extends Attempt_Outcome_Failure_SemanticallySugarfree<
     SomeActionableError
   > {
@@ -35,7 +33,7 @@ interface Attempt_Outcome_Failure<
   readonly causeOfFailure: this['cause'];
 
   rewrappedWith<
-    SomeTransformedActionableError extends Attempt_Error_Actionable<string> = SomeActionableError,
+    SomeTransformedActionableError extends Attempt_Error.Actionable<string> = SomeActionableError,
   >(
     given?: Attempt_Outcome_Failure_Transformer<
       SomeActionableError,

--- a/src/library/Attempt/Outcome/Failure/dueTo.ts
+++ b/src/library/Attempt/Outcome/Failure/dueTo.ts
@@ -1,17 +1,13 @@
-import type {
-  Actionable as Attempt_Error_Actionable,
-} from '../../Error';
+import type * as Attempt_Error from '../../Error';
 
-import {
-  Transformer_identity as Attempt_Outcome_Failure_Cause_Transformer_identity,
-} from './Cause';
+import * as Attempt_Outcome_Failure_Cause from './Cause';
 
 import type {
   Attempt_Outcome_Failure,
 } from './definition.ts';
 
 const Attempt_Outcome_Failure_dueTo = <
-  SomeActionableError extends Attempt_Error_Actionable<string>,
+  SomeActionableError extends Attempt_Error.Actionable<string>,
 >(
   givenCause: SomeActionableError,
 ): Attempt_Outcome_Failure<SomeActionableError> => ({
@@ -23,12 +19,12 @@ const Attempt_Outcome_Failure_dueTo = <
   forciblyUnwrap  : () => givenCause.throwAnyway('Unexpected forceful unwrap of a failure'),
   causeOfFailure  : givenCause,
   rewrappedWith   : <
-    SomeTransformedActionableError extends Attempt_Error_Actionable<string>,
+    SomeTransformedActionableError extends Attempt_Error.Actionable<string>,
   >(
     {
       cause: transformed,
     } = {
-      cause: Attempt_Outcome_Failure_Cause_Transformer_identity<
+      cause: Attempt_Outcome_Failure_Cause.Transformer_identity<
         SomeActionableError,
         SomeTransformedActionableError
       >,

--- a/src/library/Attempt/Outcome/Success/Transformer.ts
+++ b/src/library/Attempt/Outcome/Success/Transformer.ts
@@ -1,12 +1,10 @@
-import type {
-  Transformer as Attempt_Outcome_Success_Product_Transformer,
-} from './Product';
+import type * as Attempt_Outcome_Success_Product from './Product';
 
 interface Attempt_Outcome_Success_Transformer<
   SomeTransformableProduct,
   SomeTransformedProduct,
 > {
-  product: Attempt_Outcome_Success_Product_Transformer<
+  product: Attempt_Outcome_Success_Product.Transformer<
     SomeTransformableProduct,
     SomeTransformedProduct
   >;

--- a/src/library/Attempt/Outcome/Success/thatYielded.ts
+++ b/src/library/Attempt/Outcome/Success/thatYielded.ts
@@ -1,6 +1,4 @@
-import {
-  Transformer_identity as Attempt_Outcome_Success_Product_Transformer_identity,
-} from './Product';
+import * as Attempt_Outcome_Success_Product from './Product';
 
 import type {
   Attempt_Outcome_Success,
@@ -24,7 +22,7 @@ const Attempt_Outcome_Success_thatYielded = <
     {
       product: transformed,
     } = {
-      product: Attempt_Outcome_Success_Product_Transformer_identity<
+      product: Attempt_Outcome_Success_Product.Transformer_identity<
         SomeProduct,
         SomeTransformedProduct
       >,

--- a/src/library/Attempt/Outcome/Transformer.ts
+++ b/src/library/Attempt/Outcome/Transformer.ts
@@ -1,6 +1,4 @@
-import type {
-  Actionable as Attempt_Error_Actionable,
-} from '../Error';
+import type * as Attempt_Error from '../Error';
 
 import type {
   Attempt_Outcome_Failure_Transformer,
@@ -12,9 +10,9 @@ import type {
 
 type Attempt_Outcome_Transformer<
   SomeTransformableProduct,
-  SomeTransformableActionableError extends Attempt_Error_Actionable<string>,
+  SomeTransformableActionableError extends Attempt_Error.Actionable<string>,
   SomeTransformedProduct,
-  SomeTransformedActionableError extends Attempt_Error_Actionable<string>,
+  SomeTransformedActionableError extends Attempt_Error.Actionable<string>,
 > =
   | (
     & Required<

--- a/src/library/Attempt/Outcome/definition.ts
+++ b/src/library/Attempt/Outcome/definition.ts
@@ -1,6 +1,4 @@
-import type {
-  Actionable as Attempt_Error_Actionable,
-} from '../Error';
+import type * as Attempt_Error from '../Error';
 
 import {
   type Attempt_Outcome_Failure,
@@ -18,7 +16,7 @@ import {
 
 type Attempt_Outcome<
   SomeProduct,
-  SomeActionableError extends Attempt_Error_Actionable<string>,
+  SomeActionableError extends Attempt_Error.Actionable<string>,
 > =
   | Attempt_Outcome_Success<SomeProduct>
   | Attempt_Outcome_Failure<SomeActionableError>

--- a/src/library/Attempt/Outcome/fromRewrapping.ts
+++ b/src/library/Attempt/Outcome/fromRewrapping.ts
@@ -1,6 +1,4 @@
-import type {
-  Actionable as Attempt_Error_Actionable,
-} from '../Error';
+import type * as Attempt_Error from '../Error';
 
 import {
   type Attempt_Outcome_Failure,
@@ -31,8 +29,8 @@ import type {
 * Helps avoid boilerplate when transforming outcomes.
 */
 function Attempt_Outcome_fromRewrapping<
-  SomeTransformableActionableError extends Attempt_Error_Actionable<string>,
-  SomeTransformedActionableError extends Attempt_Error_Actionable<string> = SomeTransformableActionableError,
+  SomeTransformableActionableError extends Attempt_Error.Actionable<string>,
+  SomeTransformedActionableError extends Attempt_Error.Actionable<string> = SomeTransformableActionableError,
 >(
   givenOutcome: Attempt_Outcome_Failure<SomeTransformableActionableError>,
   given?: Attempt_Outcome_Failure_Transformer<
@@ -54,9 +52,9 @@ function Attempt_Outcome_fromRewrapping<
 //
 function Attempt_Outcome_fromRewrapping<
   SomeTransformableProduct,
-  SomeTransformableActionableError extends Attempt_Error_Actionable<string>,
+  SomeTransformableActionableError extends Attempt_Error.Actionable<string>,
   SomeTransformedProduct = SomeTransformableProduct,
-  SomeTransformedActionableError extends Attempt_Error_Actionable<string> = SomeTransformableActionableError,
+  SomeTransformedActionableError extends Attempt_Error.Actionable<string> = SomeTransformableActionableError,
 >(
   givenOutcome: Attempt_Outcome<
     SomeTransformableProduct,
@@ -75,9 +73,9 @@ function Attempt_Outcome_fromRewrapping<
 //
 function Attempt_Outcome_fromRewrapping<
   SomeTransformableProduct,
-  SomeTransformableActionableError extends Attempt_Error_Actionable<string>,
+  SomeTransformableActionableError extends Attempt_Error.Actionable<string>,
   SomeTransformedProduct = SomeTransformableProduct,
-  SomeTransformedActionableError extends Attempt_Error_Actionable<string> = SomeTransformableActionableError,
+  SomeTransformedActionableError extends Attempt_Error.Actionable<string> = SomeTransformableActionableError,
 >(
   givenOutcome: Attempt_Outcome<
     SomeTransformableProduct,

--- a/src/library/Attempt/Outcome/typeParameters/CauseOf.ts
+++ b/src/library/Attempt/Outcome/typeParameters/CauseOf.ts
@@ -1,6 +1,4 @@
-import type {
-  Actionable as Attempt_Error_Actionable,
-} from '../../Error';
+import type * as Attempt_Error from '../../Error';
 
 import type {
   Attempt_Outcome_Failure,
@@ -11,7 +9,7 @@ import type {
 } from '../definition.ts';
 
 type CauseOf<
-  SomeOutcome extends Attempt_Outcome<unknown, Attempt_Error_Actionable<string>>,
+  SomeOutcome extends Attempt_Outcome<unknown, Attempt_Error.Actionable<string>>,
 > = SomeOutcome extends Attempt_Outcome_Failure<infer NestedError>
   ? NestedError
   : never;

--- a/src/library/Attempt/Outcome/typeParameters/ProductOf.ts
+++ b/src/library/Attempt/Outcome/typeParameters/ProductOf.ts
@@ -1,6 +1,4 @@
-import type {
-  Actionable as Attempt_Error_Actionable,
-} from '../../Error';
+import type * as Attempt_Error from '../../Error';
 
 import type {
   Attempt_Outcome_Success,
@@ -11,7 +9,7 @@ import type {
 } from '../definition.ts';
 
 type ProductOf<
-  SomeOutcome extends Attempt_Outcome<unknown, Attempt_Error_Actionable<string>>,
+  SomeOutcome extends Attempt_Outcome<unknown, Attempt_Error.Actionable<string>>,
 > = SomeOutcome extends Attempt_Outcome_Success<infer NestedProduct>
   ? NestedProduct
   : never;

--- a/src/library/Attempt/Progressive.ts
+++ b/src/library/Attempt/Progressive.ts
@@ -1,6 +1,4 @@
-import type {
-  Actionable as Attempt_Error_Actionable,
-} from './Error';
+import type * as Attempt_Error from './Error';
 
 import type {
   Attempt_Outcome,
@@ -8,7 +6,7 @@ import type {
 
 interface Attempt_Progressive<
   SomeProduct,
-  SomeActionableError extends Attempt_Error_Actionable<string>,
+  SomeActionableError extends Attempt_Error.Actionable<string>,
 > {
   initiate: () => Promise<void>;
   isInProgress: boolean;

--- a/src/library/Attempt/ended.ts
+++ b/src/library/Attempt/ended.ts
@@ -1,6 +1,4 @@
-import {
-  NonActionable as Attempt_Error_NonActionable,
-} from './Error';
+import * as Attempt_Error from './Error';
 
 import {
   Attempt_Outcome,
@@ -20,7 +18,7 @@ const Attempt_ended = {
   /** Call this when the attempt has completed in terms of a prior outcome */
   inTermsOf      : Attempt_Outcome.fromRewrapping,
   /** Call this when it's not possible to complete the attempt */
-  inFlamesBecause: Attempt_Error_NonActionable.throw.bind(Attempt_Error_NonActionable),
+  inFlamesBecause: Attempt_Error.NonActionable.throw.bind(Attempt_Error.NonActionable),
 };
 
 export {

--- a/src/library/HTTP/Client.ts
+++ b/src/library/HTTP/Client.ts
@@ -1,9 +1,5 @@
 import Attempt from '@/library/Attempt';
-
-import type {
-  Origin as URLComponent_Origin,
-  Path as URLComponent_Path,
-} from '@/library/URLComponent';
+import type * as URLComponent from '@/library/URLComponent';
 
 import {
   HTTP_Endpoint,
@@ -15,7 +11,7 @@ import {
 
 class HTTP_Client {
   public constructor(
-    public readonly origin: URLComponent_Origin,
+    public readonly origin: URLComponent.Origin,
     public readonly headers: HTTP_Request.HeaderMap,
   ) {}
 
@@ -31,7 +27,7 @@ class HTTP_Client {
     return rawContentDescriptor.includes('application/json');
   };
 
-  public originAt(givenPath: URLComponent_Path): URL {
+  public originAt(givenPath: URLComponent.Path): URL {
     const serializedURLComponents = this.origin.appendedWith(givenPath);
     return new URL(serializedURLComponents);
   }
@@ -42,7 +38,7 @@ class HTTP_Client {
       to: givenPath,
       using: givenMethod,
     }: {
-      to: URLComponent_Path;
+      to: URLComponent.Path;
       using: HTTP_Request.Method;
     },
   ): Promise<HTTP_Endpoint.Outcome> => Attempt.Fresh.thatEventually(async (ends) => {
@@ -84,7 +80,7 @@ class HTTP_Client {
     {
       from: givenPath,
     }: {
-      from: URLComponent_Path;
+      from: URLComponent.Path;
     },
   ): Promise<HTTP_Endpoint.Outcome> {
     return await this.send(null, {
@@ -99,7 +95,7 @@ class HTTP_Client {
       to: givenPath,
     }: {
       bySending: unknown;
-      to: URLComponent_Path;
+      to: URLComponent.Path;
     },
   ): Promise<HTTP_Endpoint.Outcome> {
     return await this.send(givenSubmission, {
@@ -114,7 +110,7 @@ class HTTP_Client {
       to: givenPath,
     }: {
       bySending: unknown;
-      to: URLComponent_Path;
+      to: URLComponent.Path;
     },
   ): Promise<HTTP_Endpoint.Outcome> {
     return await this.send(givenProperties, {
@@ -129,7 +125,7 @@ class HTTP_Client {
       to: givenPath,
     }: {
       bySending: unknown;
-      to: URLComponent_Path;
+      to: URLComponent.Path;
     },
   ): Promise<HTTP_Endpoint.Outcome> {
     return await this.send(givenChanges, {
@@ -139,7 +135,7 @@ class HTTP_Client {
   }
 
   public async deleteResourceAt(
-    givenPath: URLComponent_Path,
+    givenPath: URLComponent.Path,
   ): Promise<HTTP_Endpoint.Outcome> {
     return await this.send(null, {
       to   : givenPath,

--- a/src/library/ShimmedStabilityAIClient/definition.ts
+++ b/src/library/ShimmedStabilityAIClient/definition.ts
@@ -1,8 +1,5 @@
 import HTTP from '@/library/HTTP';
-
-import {
-  Origin as URLComponent_Origin,
-} from '@/library/URLComponent';
+import * as URLComponent from '@/library/URLComponent';
 
 import {
   ShimmedStabilityAIClient_Version1,
@@ -13,7 +10,7 @@ class ShimmedStabilityAIClient
   public constructor(given: {
     serverURL: string;
   }) {
-    const serverOrigin = URLComponent_Origin.parsedFrom(given.serverURL).forciblyUnwrap(/* matches error propagation of actual StabilityAI client */);
+    const serverOrigin = URLComponent.Origin.parsedFrom(given.serverURL).forciblyUnwrap(/* matches error propagation of actual StabilityAI client */);
 
     const defaultHeaders = {
       'Content-Type': 'application/json',

--- a/src/library/Shortfin/TextToImage/SDXL/Client/definition.ts
+++ b/src/library/Shortfin/TextToImage/SDXL/Client/definition.ts
@@ -1,9 +1,6 @@
 import Attempt from '@/library/Attempt';
 import HTTP from '@/library/HTTP';
-
-import {
-  Path as URLComponent_Path,
-} from '@/library/URLComponent';
+import * as URLComponent from '@/library/URLComponent';
 
 import type {
   Shortfin_TextToImage_SDXL_Client_Request,
@@ -20,7 +17,7 @@ class Shortfin_TextToImage_SDXL_Client
   ): Promise<
     Shortfin_TextToImage_SDXL_Client_Request.Outcome
   > {
-    const generationEndpoint = URLComponent_Path.parsedFrom('/generate').forciblyUnwrap();
+    const generationEndpoint = URLComponent.Path.parsedFrom('/generate').forciblyUnwrap();
 
     return Attempt.Fresh.thatEventually(async (ends) => {
       const outcomeOfSubmittingResource = await this.submitResource({

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,9 +10,7 @@ import App from '@/App.vue';
 import vuetify from '@/plugins/vuetify.ts';
 import router from '@/router';
 
-import {
-  promptUserWith as Reporting_promptUserWith,
-} from '@/features/Reporting';
+import * as Reporting from '@/features/Reporting';
 
 const app = createApp(App);
 app.use(router);
@@ -21,12 +19,12 @@ app.mount('#app');
 
 window.onunhandledrejection = (someEvent) => {
   const rejectionReason = asError(someEvent.reason);
-  Reporting_promptUserWith(rejectionReason);
+  Reporting.promptUserWith(rejectionReason);
   someEvent.preventDefault();
 };
 
 // In production version (post build/bundling), errors that originate from Vue components bypass the listeners on the current `Window` instance
 app.config.errorHandler = (whateverThatWasThrown) => {
   const someError = asError(whateverThatWasThrown);
-  Reporting_promptUserWith(someError);
+  Reporting.promptUserWith(someError);
 };


### PR DESCRIPTION
- highlights all the spots where the namespace can be internally labeled for consumers (`* as SomeNamespace`)
- the resulting dot syntax increases discoverability while keeping the same semantics