### PR TITLE
refactor: centralizes all namespace labeling concerns

### DIFF
--- a/src/features/Reporting/index.ts
+++ b/src/features/Reporting/index.ts
@@ -1,1 +1,1 @@
-export * from './exports_objectOriented.ts';
+export * as Reporting from './exports_objectOriented.ts';

--- a/src/features/TextToImage/Client/Generation/Outcome.ts
+++ b/src/features/TextToImage/Client/Generation/Outcome.ts
@@ -1,7 +1,12 @@
 import type Attempt from '@/library/Attempt';
 
-import type * as TextToImage_Pipeline from '../../Pipeline';
-import type * as TextToImage_Server from '../../Server';
+import type {
+  TextToImage_Pipeline,
+} from '../../Pipeline';
+
+import type {
+  TextToImage_Server,
+} from '../../Server';
 
 type TextToImage_Client_Generation_Outcome = Attempt.Outcome<
   TextToImage_Pipeline.Output,

--- a/src/features/TextToImage/Client/SDXL/generateOutputFrom.ts
+++ b/src/features/TextToImage/Client/SDXL/generateOutputFrom.ts
@@ -5,7 +5,9 @@ import type {
 import Attempt from '@/library/Attempt';
 import HTTP from '@/library/HTTP';
 
-import * as TextToImage_Server from '../../Server';
+import {
+  TextToImage_Server,
+} from '../../Server';
 
 import type {
   TextToImage_Client_Generation,
@@ -15,7 +17,9 @@ import {
   TextToImage_Client_SDXL_initialize,
 } from './initialize';
 
-import * as toSharkUIOutput from './toSharkUIOutput';
+import {
+  toSharkUIOutput,
+} from './toSharkUIOutput';
 
 const TextToImage_Client_SDXL_generateOutputFrom = async (
   given: {

--- a/src/features/TextToImage/Client/SDXL/initialize.ts
+++ b/src/features/TextToImage/Client/SDXL/initialize.ts
@@ -1,7 +1,9 @@
 import Attempt from '@/library/Attempt';
 import ShimmedStabilityAIClient from '@/library/ShimmedStabilityAIClient';
 
-import * as TextToImage_Server from '../../Server';
+import {
+  TextToImage_Server,
+} from '../../Server';
 
 const TextToImage_Client_SDXL_initialize = async (): Promise<
   Attempt.Outcome<

--- a/src/features/TextToImage/Client/SDXL/toSharkUIOutput/Image/Description/all.ts
+++ b/src/features/TextToImage/Client/SDXL/toSharkUIOutput/Image/Description/all.ts
@@ -2,7 +2,9 @@ import type {
   TextPrompt,
 } from 'stabilityai-client-typescript/models/components';
 
-import type * as TextToImage_Pipeline from '@/features/TextToImage/Pipeline'; // eslint-disable-line import/no-internal-modules -- more concise than relative import
+import type {
+  TextToImage_Pipeline,
+} from '@/features/TextToImage/Pipeline'; // eslint-disable-line import/no-internal-modules -- more concise than relative import
 
 import {
   toSharkUIOutput_Image_Description_singular,

--- a/src/features/TextToImage/Client/SDXL/toSharkUIOutput/Image/Description/index.ts
+++ b/src/features/TextToImage/Client/SDXL/toSharkUIOutput/Image/Description/index.ts
@@ -1,1 +1,1 @@
-export * from './exports_objectOriented.ts';
+export * as toSharkUIOutput_Image_Description from './exports_objectOriented.ts';

--- a/src/features/TextToImage/Client/SDXL/toSharkUIOutput/Image/Description/singular.ts
+++ b/src/features/TextToImage/Client/SDXL/toSharkUIOutput/Image/Description/singular.ts
@@ -2,7 +2,9 @@ import type {
   TextPrompt,
 } from 'stabilityai-client-typescript/models/components';
 
-import type * as TextToImage_Pipeline from '@/features/TextToImage/Pipeline'; // eslint-disable-line import/no-internal-modules -- more concise than relative import
+import type {
+  TextToImage_Pipeline,
+} from '@/features/TextToImage/Pipeline'; // eslint-disable-line import/no-internal-modules -- more concise than relative import
 
 const toSharkUIOutput_Image_Description_singular = (
   givenPrompt: TextPrompt,

--- a/src/features/TextToImage/Client/SDXL/toSharkUIOutput/Image/definition.ts
+++ b/src/features/TextToImage/Client/SDXL/toSharkUIOutput/Image/definition.ts
@@ -6,7 +6,9 @@ import {
   URI_Image,
 } from '@/library/UniformResourceIdentifier';
 
-import type * as TextToImage_Pipeline from '@/features/TextToImage/Pipeline'; // eslint-disable-line import/no-internal-modules -- more concise than relative import
+import type {
+  TextToImage_Pipeline,
+} from '@/features/TextToImage/Pipeline'; // eslint-disable-line import/no-internal-modules -- more concise than relative import
 
 const toSharkUIOutput_Image = (
   givenImage: StabilityAIClient.Image,

--- a/src/features/TextToImage/Client/SDXL/toSharkUIOutput/Image/exports_objectOriented.ts
+++ b/src/features/TextToImage/Client/SDXL/toSharkUIOutput/Image/exports_objectOriented.ts
@@ -1,3 +1,5 @@
 export * from './definition.ts';
 
-export * as toSharkUIOutput_Image_Description from './Description';
+export {
+  toSharkUIOutput_Image_Description,
+} from './Description';

--- a/src/features/TextToImage/Client/SDXL/toSharkUIOutput/first.ts
+++ b/src/features/TextToImage/Client/SDXL/toSharkUIOutput/first.ts
@@ -8,7 +8,9 @@ import {
   hasAtLeastOne,
 } from '@/library/utilitiesByType/array';
 
-import type * as TextToImage_Pipeline from '@/features/TextToImage/Pipeline'; // eslint-disable-line import/no-internal-modules -- more concise than relative import
+import type {
+  TextToImage_Pipeline,
+} from '@/features/TextToImage/Pipeline'; // eslint-disable-line import/no-internal-modules -- more concise than relative import
 
 import {
   toSharkUIOutput_plural,

--- a/src/features/TextToImage/Client/SDXL/toSharkUIOutput/index.ts
+++ b/src/features/TextToImage/Client/SDXL/toSharkUIOutput/index.ts
@@ -1,1 +1,1 @@
-export * from './exports_objectOriented.ts';
+export * as toSharkUIOutput from './exports_objectOriented.ts';

--- a/src/features/TextToImage/Client/SDXL/toSharkUIOutput/plural.ts
+++ b/src/features/TextToImage/Client/SDXL/toSharkUIOutput/plural.ts
@@ -4,7 +4,9 @@ import type {
 
 import Attempt from '@/library/Attempt';
 
-import * as TextToImage_Pipeline from '@/features/TextToImage/Pipeline'; // eslint-disable-line import/no-internal-modules -- more concise than relative import
+import {
+  TextToImage_Pipeline,
+} from '@/features/TextToImage/Pipeline'; // eslint-disable-line import/no-internal-modules -- more concise than relative import
 
 import {
   toSharkUIOutput_Image,

--- a/src/features/TextToImage/Client/index.ts
+++ b/src/features/TextToImage/Client/index.ts
@@ -1,1 +1,1 @@
-export * from './exports_objectOriented.ts';
+export * as TextToImage_Client from './exports_objectOriented.ts';

--- a/src/features/TextToImage/Config/Dynamic/Fetching/Error/Request.ts
+++ b/src/features/TextToImage/Config/Dynamic/Fetching/Error/Request.ts
@@ -1,5 +1,8 @@
 import Attempt from '@/library/Attempt';
-import type * as URLComponent from '@/library/URLComponent';
+
+import type {
+  URLComponent,
+} from '@/library/URLComponent';
 
 class TextToImage_Config_Dynamic_Fetching_Error_Request
   extends Attempt.Error.Actionable<

--- a/src/features/TextToImage/Config/Dynamic/Fetching/Error/Response.ts
+++ b/src/features/TextToImage/Config/Dynamic/Fetching/Error/Response.ts
@@ -1,5 +1,8 @@
 import Attempt from '@/library/Attempt';
-import type * as URLComponent from '@/library/URLComponent';
+
+import type {
+  URLComponent,
+} from '@/library/URLComponent';
 
 class TextToImage_Config_Dynamic_Fetching_Error_Response
   extends Attempt.Error.Actionable<

--- a/src/features/TextToImage/Config/Dynamic/endpoint.ts
+++ b/src/features/TextToImage/Config/Dynamic/endpoint.ts
@@ -1,4 +1,6 @@
-import * as URLComponent from '@/library/URLComponent';
+import {
+  URLComponent,
+} from '@/library/URLComponent';
 
 const TextToImage_Config_Dynamic_endpoint = URLComponent.Path.parsedFrom('/config/text-to-image').forciblyUnwrap();
 

--- a/src/features/TextToImage/Config/Dynamic/index.ts
+++ b/src/features/TextToImage/Config/Dynamic/index.ts
@@ -1,1 +1,1 @@
-export * from './exports_objectOriented.ts';
+export * as TextToImage_Config_Dynamic from './exports_objectOriented.ts';

--- a/src/features/TextToImage/Config/Static/Reading/Error.ts
+++ b/src/features/TextToImage/Config/Static/Reading/Error.ts
@@ -1,5 +1,8 @@
 import Attempt from '@/library/Attempt';
-import type * as URLComponent from '@/library/URLComponent';
+
+import type {
+  URLComponent,
+} from '@/library/URLComponent';
 
 class TextToImage_Config_Static_Reading_Error
   extends Attempt.Error.Actionable<

--- a/src/features/TextToImage/Config/Static/file.ts
+++ b/src/features/TextToImage/Config/Static/file.ts
@@ -1,4 +1,6 @@
-import * as URLComponent from '@/library/URLComponent';
+import {
+  URLComponent,
+} from '@/library/URLComponent';
 
 const TextToImage_Config_Static_file = URLComponent.Path.parsedFrom('/config/text-to-image.json').forciblyUnwrap();
 

--- a/src/features/TextToImage/Config/Static/index.ts
+++ b/src/features/TextToImage/Config/Static/index.ts
@@ -1,1 +1,1 @@
-export * from './exports_objectOriented.ts';
+export * as TextToImage_Config_Static from './exports_objectOriented.ts';

--- a/src/features/TextToImage/Config/definition.ts
+++ b/src/features/TextToImage/Config/definition.ts
@@ -2,7 +2,10 @@ import type Attempt from '@/library/Attempt';
 import type Parsable from '@/library/Parsable';
 import Parse from '@/library/Parse';
 import Schema from '@/library/Schema';
-import * as WebAPI from '@/library/WebAPI';
+
+import {
+  WebAPI,
+} from '@/library/WebAPI';
 
 import {
   TextToImage_Config_ParsingError,

--- a/src/features/TextToImage/Config/index.ts
+++ b/src/features/TextToImage/Config/index.ts
@@ -1,1 +1,1 @@
-export * from './exports_objectOriented.ts';
+export * as TextToImage_Config from './exports_objectOriented.ts';

--- a/src/features/TextToImage/Config/namespaceMembers.ts
+++ b/src/features/TextToImage/Config/namespaceMembers.ts
@@ -1,5 +1,9 @@
-export * as Dynamic from './Dynamic';
-export * as Static from './Static';
+export {
+  TextToImage_Config_Dynamic as Dynamic,
+} from './Dynamic';
+export {
+  TextToImage_Config_Static as Static,
+} from './Static';
 export {
   TextToImage_Config_empty as empty,
 } from './empty';

--- a/src/features/TextToImage/Pipeline/Output/Nullable/index.ts
+++ b/src/features/TextToImage/Pipeline/Output/Nullable/index.ts
@@ -1,1 +1,1 @@
-export * from './exports_objectOriented.ts';
+export * as TextToImage_Pipeline_Output_Nullable from './exports_objectOriented.ts';

--- a/src/features/TextToImage/Pipeline/Output/exports_objectOriented.ts
+++ b/src/features/TextToImage/Pipeline/Output/exports_objectOriented.ts
@@ -1,3 +1,5 @@
 export type * from './definition.ts';
 
-export * as TextToImage_Pipeline_Output_Nullable from './Nullable';
+export {
+  TextToImage_Pipeline_Output_Nullable,
+} from './Nullable';

--- a/src/features/TextToImage/Pipeline/index.ts
+++ b/src/features/TextToImage/Pipeline/index.ts
@@ -1,1 +1,1 @@
-export * from './exports_objectOriented.ts';
+export * as TextToImage_Pipeline from './exports_objectOriented.ts';

--- a/src/features/TextToImage/Server/Current/accordingToEnvironment.ts
+++ b/src/features/TextToImage/Server/Current/accordingToEnvironment.ts
@@ -1,4 +1,6 @@
-import * as WebAPI from '@/library/WebAPI';
+import {
+  WebAPI,
+} from '@/library/WebAPI';
 
 import {
   TextToImage_Server_Origin,

--- a/src/features/TextToImage/Server/Current/index.ts
+++ b/src/features/TextToImage/Server/Current/index.ts
@@ -1,1 +1,1 @@
-export * from './exports_objectOriented.ts';
+export * as TextToImage_Server_Current from './exports_objectOriented.ts';

--- a/src/features/TextToImage/Server/Current/retrieve.ts
+++ b/src/features/TextToImage/Server/Current/retrieve.ts
@@ -1,7 +1,12 @@
 import Attempt from '@/library/Attempt';
-import type * as WebAPI from '@/library/WebAPI';
 
-import * as TextToImage_Config from '../../Config';
+import type {
+  WebAPI,
+} from '@/library/WebAPI';
+
+import {
+  TextToImage_Config,
+} from '../../Config';
 
 import {
   TextToImage_Server_Error,

--- a/src/features/TextToImage/Server/Error/Specification.ts
+++ b/src/features/TextToImage/Server/Error/Specification.ts
@@ -1,5 +1,8 @@
 import Attempt from '@/library/Attempt';
-import type * as URLComponent from '@/library/URLComponent';
+
+import type {
+  URLComponent,
+} from '@/library/URLComponent';
 
 class TextToImage_Server_Error_Specification
   extends Attempt.Error.Actionable<

--- a/src/features/TextToImage/Server/index.ts
+++ b/src/features/TextToImage/Server/index.ts
@@ -1,1 +1,1 @@
-export * from './exports_objectOriented.ts';
+export * as TextToImage_Server from './exports_objectOriented.ts';

--- a/src/features/TextToImage/Server/namespaceMembers.ts
+++ b/src/features/TextToImage/Server/namespaceMembers.ts
@@ -1,4 +1,6 @@
-export * as Current from './Current';
+export {
+  TextToImage_Server_Current as Current,
+} from './Current';
 
 export {
   TextToImage_Server_Error as Error,

--- a/src/features/TextToImage/components/TextToImageInputSection.vue
+++ b/src/features/TextToImage/components/TextToImageInputSection.vue
@@ -15,7 +15,9 @@ import {
   VTextarea,
 } from 'vuetify/components/VTextarea';
 
-import type * as TextToImage_Pipeline from '../Pipeline';
+import type {
+  TextToImage_Pipeline,
+} from '../Pipeline';
 
 type StandardizedInputText = TextToImage_Pipeline.Input['text'];
 

--- a/src/features/TextToImage/components/TextToImageOutputAlert.vue
+++ b/src/features/TextToImage/components/TextToImageOutputAlert.vue
@@ -1,5 +1,7 @@
 <script setup lang="ts">
-import * as TextToImage from '@/features/TextToImage';
+import {
+  TextToImage,
+} from '@/features/TextToImage';
 
 import TextToImageServerConnectionAlert from './TextToImageServerConnectionAlert.vue';
 import TextToImageServerSpecificationAlert from './TextToImageServerSpecificationAlert.vue';

--- a/src/features/TextToImage/components/TextToImageOutputImg.vue
+++ b/src/features/TextToImage/components/TextToImageOutputImg.vue
@@ -3,7 +3,9 @@ import {
   VImg,
 } from 'vuetify/components/VImg';
 
-import type * as TextToImage from '@/features/TextToImage';
+import type {
+  TextToImage,
+} from '@/features/TextToImage';
 
 defineProps<{
   modelValue: TextToImage.Pipeline.Output['image'];

--- a/src/features/TextToImage/components/TextToImageServerConnectionAlert.vue
+++ b/src/features/TextToImage/components/TextToImageServerConnectionAlert.vue
@@ -3,7 +3,9 @@ import {
   VAlert,
 } from 'vuetify/components/VAlert';
 
-import type * as TextToImage from '@/features/TextToImage';
+import type {
+  TextToImage,
+} from '@/features/TextToImage';
 
 defineProps<{
   error: TextToImage.Server.Error.Connection;

--- a/src/features/TextToImage/components/TextToImageServerSpecificationAlert.vue
+++ b/src/features/TextToImage/components/TextToImageServerSpecificationAlert.vue
@@ -3,7 +3,9 @@ import {
   VAlert,
 } from 'vuetify/components/VAlert';
 
-import type * as TextToImage from '@/features/TextToImage';
+import type {
+  TextToImage,
+} from '@/features/TextToImage';
 
 defineProps<{
   error: TextToImage.Server.Error.Specification;

--- a/src/features/TextToImage/index.ts
+++ b/src/features/TextToImage/index.ts
@@ -1,1 +1,1 @@
-export * from './exports_objectOriented.ts';
+export * as TextToImage from './exports_objectOriented.ts';

--- a/src/features/TextToImage/namespaceMembers.ts
+++ b/src/features/TextToImage/namespaceMembers.ts
@@ -1,5 +1,11 @@
-export * as Client from './Client';
+export {
+  TextToImage_Client as Client,
+} from './Client';
 
-export * as Server from './Server';
+export {
+  TextToImage_Server as Server,
+} from './Server';
 
-export type * as Pipeline from './Pipeline';
+export type {
+  TextToImage_Pipeline as Pipeline,
+} from './Pipeline';

--- a/src/library/Attempt/Adapted/Config.ts
+++ b/src/library/Attempt/Adapted/Config.ts
@@ -1,4 +1,6 @@
-import type * as Attempt_Error from '../Error';
+import type {
+  Attempt_Error,
+} from '../Error';
 
 interface Attempt_Adapted_Config<
   SomeActionableError extends Attempt_Error.Actionable<string>,

--- a/src/library/Attempt/Adapted/index.ts
+++ b/src/library/Attempt/Adapted/index.ts
@@ -1,1 +1,1 @@
-export * from './exports_objectOriented.ts';
+export * as Attempt_Adapted from './exports_objectOriented.ts';

--- a/src/library/Attempt/Adapted/to.ts
+++ b/src/library/Attempt/Adapted/to.ts
@@ -1,5 +1,10 @@
-import * as Attempt_Error from '../Error';
-import * as Attempt_Fresh from '../Fresh';
+import {
+  Attempt_Error,
+} from '../Error';
+
+import {
+  Attempt_Fresh,
+} from '../Fresh';
 
 import type {
   Attempt_Outcome,

--- a/src/library/Attempt/Adapted/toEventually.ts
+++ b/src/library/Attempt/Adapted/toEventually.ts
@@ -1,5 +1,10 @@
-import * as Attempt_Error from '../Error';
-import * as Attempt_Fresh from '../Fresh';
+import {
+  Attempt_Error,
+} from '../Error';
+
+import {
+  Attempt_Fresh,
+} from '../Fresh';
 
 import type {
   Attempt_Outcome,

--- a/src/library/Attempt/Adapted/toSettle.ts
+++ b/src/library/Attempt/Adapted/toSettle.ts
@@ -1,4 +1,6 @@
-import type * as Attempt_Error from '../Error';
+import type {
+  Attempt_Error,
+} from '../Error';
 
 import type {
   Attempt_Outcome,

--- a/src/library/Attempt/End/Getter.ts
+++ b/src/library/Attempt/End/Getter.ts
@@ -1,4 +1,6 @@
-import type * as Attempt_Error from '../Error';
+import type {
+  Attempt_Error,
+} from '../Error';
 
 import type {
   Attempt_Outcome,

--- a/src/library/Attempt/End/Retriever.ts
+++ b/src/library/Attempt/End/Retriever.ts
@@ -1,4 +1,6 @@
-import type * as Attempt_Error from '../Error';
+import type {
+  Attempt_Error,
+} from '../Error';
 
 import type {
   Attempt_Outcome,

--- a/src/library/Attempt/End/index.ts
+++ b/src/library/Attempt/End/index.ts
@@ -1,1 +1,1 @@
-export type * from './exports_objectOriented.ts';
+export type * as Attempt_End from './exports_objectOriented.ts';

--- a/src/library/Attempt/Error/index.ts
+++ b/src/library/Attempt/Error/index.ts
@@ -1,3 +1,3 @@
-export * from './exports_objectOriented.ts';
+export * as Attempt_Error from './exports_objectOriented.ts';
 
 export * from './exports_objectAdjacent.ts';

--- a/src/library/Attempt/Fresh/index.ts
+++ b/src/library/Attempt/Fresh/index.ts
@@ -1,1 +1,1 @@
-export * from './exports_objectOriented.ts';
+export * as Attempt_Fresh from './exports_objectOriented.ts';

--- a/src/library/Attempt/Fresh/that.ts
+++ b/src/library/Attempt/Fresh/that.ts
@@ -1,5 +1,10 @@
-import type * as Attempt_End from '../End';
-import * as Attempt_Error from '../Error';
+import type {
+  Attempt_End,
+} from '../End';
+
+import {
+  Attempt_Error,
+} from '../Error';
 
 import type {
   Attempt_Outcome,

--- a/src/library/Attempt/Fresh/thatEventually.ts
+++ b/src/library/Attempt/Fresh/thatEventually.ts
@@ -1,5 +1,10 @@
-import type * as Attempt_End from '../End';
-import * as Attempt_Error from '../Error';
+import type {
+  Attempt_End,
+} from '../End';
+
+import {
+  Attempt_Error,
+} from '../Error';
 
 import type {
   Attempt_Outcome,

--- a/src/library/Attempt/Outcome/Discriminable/definition.ts
+++ b/src/library/Attempt/Outcome/Discriminable/definition.ts
@@ -4,7 +4,9 @@ import type {
   Not,
 } from '@/library/typeUtilities';
 
-import type * as Attempt_Error from '../../Error';
+import type {
+  Attempt_Error,
+} from '../../Error';
 
 import type {
   Attempt_Outcome_Discriminant,

--- a/src/library/Attempt/Outcome/Failure/Cause/Transformer/definition.ts
+++ b/src/library/Attempt/Outcome/Failure/Cause/Transformer/definition.ts
@@ -1,4 +1,6 @@
-import type * as Attempt_Error from '@/library/Attempt/Error'; // eslint-disable-line import/no-internal-modules -- avoids lengthy relative paths
+import type {
+  Attempt_Error,
+} from '@/library/Attempt/Error'; // eslint-disable-line import/no-internal-modules -- avoids lengthy relative paths
 
 type Attempt_Outcome_Failure_Cause_Transformer<
   SomeTransformableActionableError extends Attempt_Error.Actionable<string>,

--- a/src/library/Attempt/Outcome/Failure/Cause/Transformer/identity.ts
+++ b/src/library/Attempt/Outcome/Failure/Cause/Transformer/identity.ts
@@ -1,4 +1,6 @@
-import type * as Attempt_Error from '@/library/Attempt/Error'; // eslint-disable-line import/no-internal-modules -- avoids lengthy relative paths
+import type {
+  Attempt_Error,
+} from '@/library/Attempt/Error'; // eslint-disable-line import/no-internal-modules -- avoids lengthy relative paths
 
 const Attempt_Outcome_Failure_Cause_Transformer_identity = <
   SomeTransformableActionableError extends Attempt_Error.Actionable<string>,

--- a/src/library/Attempt/Outcome/Failure/Cause/index.ts
+++ b/src/library/Attempt/Outcome/Failure/Cause/index.ts
@@ -1,1 +1,1 @@
-export * from './exports_objectOriented.ts';
+export * as Attempt_Outcome_Failure_Cause from './exports_objectOriented.ts';

--- a/src/library/Attempt/Outcome/Failure/SemanticallySugarfree.ts
+++ b/src/library/Attempt/Outcome/Failure/SemanticallySugarfree.ts
@@ -1,4 +1,6 @@
-import type * as Attempt_Error from '../../Error';
+import type {
+  Attempt_Error,
+} from '../../Error';
 
 import type {
   Attempt_Outcome_Discriminable,

--- a/src/library/Attempt/Outcome/Failure/Transformer.ts
+++ b/src/library/Attempt/Outcome/Failure/Transformer.ts
@@ -1,6 +1,10 @@
-import type * as Attempt_Error from '../../Error';
+import type {
+  Attempt_Error,
+} from '../../Error';
 
-import type * as Attempt_Outcome_Failure_Cause from './Cause';
+import type {
+  Attempt_Outcome_Failure_Cause,
+} from './Cause';
 
 interface Attempt_Outcome_Failure_Transformer<
   SomeTransformableActionableError extends Attempt_Error.Actionable<string>,

--- a/src/library/Attempt/Outcome/Failure/definition.ts
+++ b/src/library/Attempt/Outcome/Failure/definition.ts
@@ -1,4 +1,6 @@
-import type * as Attempt_Error from '../../Error';
+import type {
+  Attempt_Error,
+} from '../../Error';
 
 import type {
   Attempt_Outcome_Failure_SemanticallySugarfree,

--- a/src/library/Attempt/Outcome/Failure/dueTo.ts
+++ b/src/library/Attempt/Outcome/Failure/dueTo.ts
@@ -1,6 +1,10 @@
-import type * as Attempt_Error from '../../Error';
+import type {
+  Attempt_Error,
+} from '../../Error';
 
-import * as Attempt_Outcome_Failure_Cause from './Cause';
+import {
+  Attempt_Outcome_Failure_Cause,
+} from './Cause';
 
 import type {
   Attempt_Outcome_Failure,

--- a/src/library/Attempt/Outcome/Failure/exports_objectOriented.ts
+++ b/src/library/Attempt/Outcome/Failure/exports_objectOriented.ts
@@ -1,6 +1,8 @@
 export type * from './definition.ts';
 
-export * as Attempt_Outcome_Failure_Cause from './Cause';
+export {
+  Attempt_Outcome_Failure_Cause,
+} from './Cause';
 
 export type {
   Attempt_Outcome_Failure_Transformer,

--- a/src/library/Attempt/Outcome/Success/Product/index.ts
+++ b/src/library/Attempt/Outcome/Success/Product/index.ts
@@ -1,1 +1,1 @@
-export * from './exports_objectOriented.ts';
+export * as Attempt_Outcome_Success_Product from './exports_objectOriented.ts';

--- a/src/library/Attempt/Outcome/Success/Transformer.ts
+++ b/src/library/Attempt/Outcome/Success/Transformer.ts
@@ -1,4 +1,6 @@
-import type * as Attempt_Outcome_Success_Product from './Product';
+import type {
+  Attempt_Outcome_Success_Product,
+} from './Product';
 
 interface Attempt_Outcome_Success_Transformer<
   SomeTransformableProduct,

--- a/src/library/Attempt/Outcome/Success/exports_objectOriented.ts
+++ b/src/library/Attempt/Outcome/Success/exports_objectOriented.ts
@@ -1,6 +1,8 @@
 export type * from './definition.ts';
 
-export * as Attempt_Outcome_Success_Product from './Product';
+export {
+  Attempt_Outcome_Success_Product,
+} from './Product';
 
 export type {
   Attempt_Outcome_Success_Transformer,

--- a/src/library/Attempt/Outcome/Success/thatYielded.ts
+++ b/src/library/Attempt/Outcome/Success/thatYielded.ts
@@ -1,4 +1,6 @@
-import * as Attempt_Outcome_Success_Product from './Product';
+import {
+  Attempt_Outcome_Success_Product,
+} from './Product';
 
 import type {
   Attempt_Outcome_Success,

--- a/src/library/Attempt/Outcome/Transformer.ts
+++ b/src/library/Attempt/Outcome/Transformer.ts
@@ -1,4 +1,6 @@
-import type * as Attempt_Error from '../Error';
+import type {
+  Attempt_Error,
+} from '../Error';
 
 import type {
   Attempt_Outcome_Failure_Transformer,

--- a/src/library/Attempt/Outcome/definition.ts
+++ b/src/library/Attempt/Outcome/definition.ts
@@ -1,4 +1,6 @@
-import type * as Attempt_Error from '../Error';
+import type {
+  Attempt_Error,
+} from '../Error';
 
 import {
   type Attempt_Outcome_Failure,

--- a/src/library/Attempt/Outcome/fromRewrapping.ts
+++ b/src/library/Attempt/Outcome/fromRewrapping.ts
@@ -1,4 +1,6 @@
-import type * as Attempt_Error from '../Error';
+import type {
+  Attempt_Error,
+} from '../Error';
 
 import {
   type Attempt_Outcome_Failure,

--- a/src/library/Attempt/Outcome/typeParameters/CauseOf.ts
+++ b/src/library/Attempt/Outcome/typeParameters/CauseOf.ts
@@ -1,4 +1,6 @@
-import type * as Attempt_Error from '../../Error';
+import type {
+  Attempt_Error,
+} from '../../Error';
 
 import type {
   Attempt_Outcome_Failure,

--- a/src/library/Attempt/Outcome/typeParameters/ProductOf.ts
+++ b/src/library/Attempt/Outcome/typeParameters/ProductOf.ts
@@ -1,4 +1,6 @@
-import type * as Attempt_Error from '../../Error';
+import type {
+  Attempt_Error,
+} from '../../Error';
 
 import type {
   Attempt_Outcome_Success,

--- a/src/library/Attempt/Progressive.ts
+++ b/src/library/Attempt/Progressive.ts
@@ -1,4 +1,6 @@
-import type * as Attempt_Error from './Error';
+import type {
+  Attempt_Error,
+} from './Error';
 
 import type {
   Attempt_Outcome,

--- a/src/library/Attempt/ended.ts
+++ b/src/library/Attempt/ended.ts
@@ -1,4 +1,6 @@
-import * as Attempt_Error from './Error';
+import {
+  Attempt_Error,
+} from './Error';
 
 import {
   Attempt_Outcome,

--- a/src/library/Attempt/namespaceMembers.ts
+++ b/src/library/Attempt/namespaceMembers.ts
@@ -8,14 +8,22 @@ export {
   type Attempt_Outcome_Failure as Outcome_Failure,
 } from './Outcome';
 
-export * as Adapted from './Adapted';
+export {
+  Attempt_Adapted as Adapted,
+} from './Adapted';
 
-export * as Error from './Error';
+export {
+  Attempt_Error as Error,
+} from './Error';
 
-export * as Fresh from './Fresh';
+export {
+  Attempt_Fresh as Fresh,
+} from './Fresh';
 
 export type {
   Attempt_Progressive as Progressive,
 } from './Progressive';
 
-export type * as End from './End';
+export type {
+  Attempt_End as End,
+} from './End';

--- a/src/library/HTTP/Client.ts
+++ b/src/library/HTTP/Client.ts
@@ -1,5 +1,8 @@
 import Attempt from '@/library/Attempt';
-import type * as URLComponent from '@/library/URLComponent';
+
+import type {
+  URLComponent,
+} from '@/library/URLComponent';
 
 import {
   HTTP_Endpoint,

--- a/src/library/ShimmedStabilityAIClient/SDXL/index.ts
+++ b/src/library/ShimmedStabilityAIClient/SDXL/index.ts
@@ -1,1 +1,1 @@
-export * from './exports_objectOriented.ts';
+export * as SDXL from './exports_objectOriented.ts';

--- a/src/library/ShimmedStabilityAIClient/definition.ts
+++ b/src/library/ShimmedStabilityAIClient/definition.ts
@@ -1,5 +1,8 @@
 import HTTP from '@/library/HTTP';
-import * as URLComponent from '@/library/URLComponent';
+
+import {
+  URLComponent,
+} from '@/library/URLComponent';
 
 import {
   ShimmedStabilityAIClient_Version1,

--- a/src/library/ShimmedStabilityAIClient/exports_objectAdjacent.ts
+++ b/src/library/ShimmedStabilityAIClient/exports_objectAdjacent.ts
@@ -1,1 +1,1 @@
-export * as SDXL from './SDXL';
+export * from './SDXL';

--- a/src/library/Shortfin/TextToImage/SDXL/Client/definition.ts
+++ b/src/library/Shortfin/TextToImage/SDXL/Client/definition.ts
@@ -1,6 +1,9 @@
 import Attempt from '@/library/Attempt';
 import HTTP from '@/library/HTTP';
-import * as URLComponent from '@/library/URLComponent';
+
+import {
+  URLComponent,
+} from '@/library/URLComponent';
 
 import type {
   Shortfin_TextToImage_SDXL_Client_Request,

--- a/src/library/URLComponent/index.ts
+++ b/src/library/URLComponent/index.ts
@@ -1,1 +1,1 @@
-export * from './exports_objectOriented.ts';
+export * as URLComponent from './exports_objectOriented.ts';

--- a/src/library/WebAPI/index.ts
+++ b/src/library/WebAPI/index.ts
@@ -1,1 +1,1 @@
-export * from './exports_objectOriented.ts';
+export * as WebAPI from './exports_objectOriented.ts';

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,7 +10,9 @@ import App from '@/App.vue';
 import vuetify from '@/plugins/vuetify.ts';
 import router from '@/router';
 
-import * as Reporting from '@/features/Reporting';
+import {
+  Reporting,
+} from '@/features/Reporting';
 
 const app = createApp(App);
 app.use(router);

--- a/src/pages/TextToImagePage.vue
+++ b/src/pages/TextToImagePage.vue
@@ -33,7 +33,10 @@ import {
 import DiscreteSlider from '@/components/DiscreteSlider.vue';
 import NavigationPanel from '@/components/NavigationPanel.vue';
 
-import * as TextToImage from '@/features/TextToImage';
+import {
+  TextToImage,
+} from '@/features/TextToImage';
+
 import TextToImageInputSection from '@/features/TextToImage/components/TextToImageInputSection.vue';
 import TextToImageOutputAlert from '@/features/TextToImage/components/TextToImageOutputAlert.vue';
 import TextToImageOutputImg from '@/features/TextToImage/components/TextToImageOutputImg.vue';


### PR DESCRIPTION
- the offending modules were leaving the labeling of their namespace to their consumers
- for object-oriented modules, this was an anti-pattern
- these changes move this responsibility to within each module so their consistency can be guaranteed
- also helps with autocomplete and auto import