### PR TITLE
refactor: ensures all object-oriented libraries have a `default` top-level export

### DIFF
--- a/src/features/TextToImage/Config/Dynamic/Fetching/Error/Request.ts
+++ b/src/features/TextToImage/Config/Dynamic/Fetching/Error/Request.ts
@@ -1,8 +1,5 @@
 import Attempt from '@/library/Attempt';
-
-import type {
-  URLComponent,
-} from '@/library/URLComponent';
+import type URLComponent from '@/library/URLComponent';
 
 class TextToImage_Config_Dynamic_Fetching_Error_Request
   extends Attempt.Error.Actionable<

--- a/src/features/TextToImage/Config/Dynamic/Fetching/Error/Response.ts
+++ b/src/features/TextToImage/Config/Dynamic/Fetching/Error/Response.ts
@@ -1,8 +1,5 @@
 import Attempt from '@/library/Attempt';
-
-import type {
-  URLComponent,
-} from '@/library/URLComponent';
+import type URLComponent from '@/library/URLComponent';
 
 class TextToImage_Config_Dynamic_Fetching_Error_Response
   extends Attempt.Error.Actionable<

--- a/src/features/TextToImage/Config/Dynamic/endpoint.ts
+++ b/src/features/TextToImage/Config/Dynamic/endpoint.ts
@@ -1,6 +1,4 @@
-import {
-  URLComponent,
-} from '@/library/URLComponent';
+import URLComponent from '@/library/URLComponent';
 
 const TextToImage_Config_Dynamic_endpoint = URLComponent.Path.parsedFrom('/config/text-to-image').forciblyUnwrap();
 

--- a/src/features/TextToImage/Config/Static/Reading/Error.ts
+++ b/src/features/TextToImage/Config/Static/Reading/Error.ts
@@ -1,8 +1,5 @@
 import Attempt from '@/library/Attempt';
-
-import type {
-  URLComponent,
-} from '@/library/URLComponent';
+import type URLComponent from '@/library/URLComponent';
 
 class TextToImage_Config_Static_Reading_Error
   extends Attempt.Error.Actionable<

--- a/src/features/TextToImage/Config/Static/file.ts
+++ b/src/features/TextToImage/Config/Static/file.ts
@@ -1,6 +1,4 @@
-import {
-  URLComponent,
-} from '@/library/URLComponent';
+import URLComponent from '@/library/URLComponent';
 
 const TextToImage_Config_Static_file = URLComponent.Path.parsedFrom('/config/text-to-image.json').forciblyUnwrap();
 

--- a/src/features/TextToImage/Config/definition.ts
+++ b/src/features/TextToImage/Config/definition.ts
@@ -2,10 +2,7 @@ import type Attempt from '@/library/Attempt';
 import type Parsable from '@/library/Parsable';
 import Parse from '@/library/Parse';
 import Schema from '@/library/Schema';
-
-import {
-  WebAPI,
-} from '@/library/WebAPI';
+import WebAPI from '@/library/WebAPI';
 
 import {
   TextToImage_Config_ParsingError,

--- a/src/features/TextToImage/Server/Current/accordingToEnvironment.ts
+++ b/src/features/TextToImage/Server/Current/accordingToEnvironment.ts
@@ -1,6 +1,4 @@
-import {
-  WebAPI,
-} from '@/library/WebAPI';
+import WebAPI from '@/library/WebAPI';
 
 import {
   TextToImage_Server_Origin,

--- a/src/features/TextToImage/Server/Current/retrieve.ts
+++ b/src/features/TextToImage/Server/Current/retrieve.ts
@@ -1,8 +1,5 @@
 import Attempt from '@/library/Attempt';
-
-import type {
-  WebAPI,
-} from '@/library/WebAPI';
+import type WebAPI from '@/library/WebAPI';
 
 import {
   TextToImage_Config,

--- a/src/features/TextToImage/Server/Error/Specification.ts
+++ b/src/features/TextToImage/Server/Error/Specification.ts
@@ -1,8 +1,5 @@
 import Attempt from '@/library/Attempt';
-
-import type {
-  URLComponent,
-} from '@/library/URLComponent';
+import type URLComponent from '@/library/URLComponent';
 
 class TextToImage_Server_Error_Specification
   extends Attempt.Error.Actionable<

--- a/src/features/TextToImage/components/TextToImageOutputAlert.vue
+++ b/src/features/TextToImage/components/TextToImageOutputAlert.vue
@@ -1,7 +1,5 @@
 <script setup lang="ts">
-import {
-  TextToImage,
-} from '@/features/TextToImage';
+import TextToImage from '@/features/TextToImage';
 
 import TextToImageServerConnectionAlert from './TextToImageServerConnectionAlert.vue';
 import TextToImageServerSpecificationAlert from './TextToImageServerSpecificationAlert.vue';

--- a/src/features/TextToImage/components/TextToImageOutputImg.vue
+++ b/src/features/TextToImage/components/TextToImageOutputImg.vue
@@ -3,9 +3,7 @@ import {
   VImg,
 } from 'vuetify/components/VImg';
 
-import type {
-  TextToImage,
-} from '@/features/TextToImage';
+import type TextToImage from '@/features/TextToImage';
 
 defineProps<{
   modelValue: TextToImage.Pipeline.Output['image'];

--- a/src/features/TextToImage/components/TextToImageServerConnectionAlert.vue
+++ b/src/features/TextToImage/components/TextToImageServerConnectionAlert.vue
@@ -3,9 +3,7 @@ import {
   VAlert,
 } from 'vuetify/components/VAlert';
 
-import type {
-  TextToImage,
-} from '@/features/TextToImage';
+import type TextToImage from '@/features/TextToImage';
 
 defineProps<{
   error: TextToImage.Server.Error.Connection;

--- a/src/features/TextToImage/components/TextToImageServerSpecificationAlert.vue
+++ b/src/features/TextToImage/components/TextToImageServerSpecificationAlert.vue
@@ -3,9 +3,7 @@ import {
   VAlert,
 } from 'vuetify/components/VAlert';
 
-import type {
-  TextToImage,
-} from '@/features/TextToImage';
+import type TextToImage from '@/features/TextToImage';
 
 defineProps<{
   error: TextToImage.Server.Error.Specification;

--- a/src/features/TextToImage/index.ts
+++ b/src/features/TextToImage/index.ts
@@ -1,1 +1,5 @@
-export * as TextToImage from './exports_objectOriented.ts';
+import * as TextToImage from './exports_objectOriented.ts';
+
+export {
+  TextToImage as default,
+};

--- a/src/library/HTTP/Client.ts
+++ b/src/library/HTTP/Client.ts
@@ -1,8 +1,5 @@
 import Attempt from '@/library/Attempt';
-
-import type {
-  URLComponent,
-} from '@/library/URLComponent';
+import type URLComponent from '@/library/URLComponent';
 
 import {
   HTTP_Endpoint,

--- a/src/library/ShimmedStabilityAIClient/definition.ts
+++ b/src/library/ShimmedStabilityAIClient/definition.ts
@@ -1,8 +1,5 @@
 import HTTP from '@/library/HTTP';
-
-import {
-  URLComponent,
-} from '@/library/URLComponent';
+import URLComponent from '@/library/URLComponent';
 
 import {
   ShimmedStabilityAIClient_Version1,

--- a/src/library/Shortfin/TextToImage/SDXL/Client/definition.ts
+++ b/src/library/Shortfin/TextToImage/SDXL/Client/definition.ts
@@ -1,9 +1,6 @@
 import Attempt from '@/library/Attempt';
 import HTTP from '@/library/HTTP';
-
-import {
-  URLComponent,
-} from '@/library/URLComponent';
+import URLComponent from '@/library/URLComponent';
 
 import type {
   Shortfin_TextToImage_SDXL_Client_Request,

--- a/src/library/URLComponent/index.ts
+++ b/src/library/URLComponent/index.ts
@@ -1,1 +1,5 @@
-export * as URLComponent from './exports_objectOriented.ts';
+import * as URLComponent from './exports_objectOriented.ts';
+
+export {
+  URLComponent as default,
+};

--- a/src/library/WebAPI/index.ts
+++ b/src/library/WebAPI/index.ts
@@ -1,1 +1,5 @@
-export * as WebAPI from './exports_objectOriented.ts';
+import * as WebAPI from './exports_objectOriented.ts';
+
+export {
+  WebAPI as default,
+};

--- a/src/pages/TextToImagePage.vue
+++ b/src/pages/TextToImagePage.vue
@@ -33,10 +33,7 @@ import {
 import DiscreteSlider from '@/components/DiscreteSlider.vue';
 import NavigationPanel from '@/components/NavigationPanel.vue';
 
-import {
-  TextToImage,
-} from '@/features/TextToImage';
-
+import TextToImage from '@/features/TextToImage';
 import TextToImageInputSection from '@/features/TextToImage/components/TextToImageInputSection.vue';
 import TextToImageOutputAlert from '@/features/TextToImage/components/TextToImageOutputAlert.vue';
 import TextToImageOutputImg from '@/features/TextToImage/components/TextToImageOutputImg.vue';


### PR DESCRIPTION
- the `default` export communicates "this is the primary entry point to this library"
- this is appropriate for libraries that embody a single concept via primary object
- makes affected libraries consistent with all others