### PR TITLE
refactor: relegates all namespace labeling concerns to "/namespace.ts" files

### DIFF
--- a/src/features/Reporting/index.ts
+++ b/src/features/Reporting/index.ts
@@ -1,1 +1,1 @@
-export * as Reporting from './exports_objectOriented.ts';
+export * from './exports_objectOriented.ts';

--- a/src/features/Reporting/namespace.ts
+++ b/src/features/Reporting/namespace.ts
@@ -1,1 +1,1 @@
-export * from './namespaceMembers.ts';
+export * as Reporting from './namespaceMembers.ts';

--- a/src/features/TextToImage/Client/Generation/index.ts
+++ b/src/features/TextToImage/Client/Generation/index.ts
@@ -1,1 +1,1 @@
-export type * as TextToImage_Client_Generation from './exports_objectOriented.ts';
+export type * from './exports_objectOriented.ts';

--- a/src/features/TextToImage/Client/Generation/namespace.ts
+++ b/src/features/TextToImage/Client/Generation/namespace.ts
@@ -1,1 +1,1 @@
-export type * from './namespaceMembers.ts';
+export type * as TextToImage_Client_Generation from './namespaceMembers.ts';

--- a/src/features/TextToImage/Client/SDXL/index.ts
+++ b/src/features/TextToImage/Client/SDXL/index.ts
@@ -1,4 +1,6 @@
-import * as TextToImage_Client_SDXL from './exports_objectOriented.ts';
+import {
+  TextToImage_Client_SDXL,
+} from './exports_objectOriented.ts';
 
 export {
   TextToImage_Client_SDXL,

--- a/src/features/TextToImage/Client/SDXL/namespace.ts
+++ b/src/features/TextToImage/Client/SDXL/namespace.ts
@@ -1,1 +1,1 @@
-export * from './namespaceMembers.ts';
+export * as TextToImage_Client_SDXL from './namespaceMembers.ts';

--- a/src/features/TextToImage/Client/SDXL/toSharkUIOutput/Image/Description/index.ts
+++ b/src/features/TextToImage/Client/SDXL/toSharkUIOutput/Image/Description/index.ts
@@ -1,1 +1,1 @@
-export * as toSharkUIOutput_Image_Description from './exports_objectOriented.ts';
+export * from './exports_objectOriented.ts';

--- a/src/features/TextToImage/Client/SDXL/toSharkUIOutput/Image/Description/namespace.ts
+++ b/src/features/TextToImage/Client/SDXL/toSharkUIOutput/Image/Description/namespace.ts
@@ -1,1 +1,1 @@
-export * from './namespaceMembers.ts';
+export * as toSharkUIOutput_Image_Description from './namespaceMembers.ts';

--- a/src/features/TextToImage/Client/SDXL/toSharkUIOutput/index.ts
+++ b/src/features/TextToImage/Client/SDXL/toSharkUIOutput/index.ts
@@ -1,1 +1,1 @@
-export * as toSharkUIOutput from './exports_objectOriented.ts';
+export * from './exports_objectOriented.ts';

--- a/src/features/TextToImage/Client/SDXL/toSharkUIOutput/namespace.ts
+++ b/src/features/TextToImage/Client/SDXL/toSharkUIOutput/namespace.ts
@@ -1,1 +1,1 @@
-export * from './namespaceMembers.ts';
+export * as toSharkUIOutput from './namespaceMembers.ts';

--- a/src/features/TextToImage/Client/index.ts
+++ b/src/features/TextToImage/Client/index.ts
@@ -1,1 +1,1 @@
-export * as TextToImage_Client from './exports_objectOriented.ts';
+export * from './exports_objectOriented.ts';

--- a/src/features/TextToImage/Client/namespace.ts
+++ b/src/features/TextToImage/Client/namespace.ts
@@ -1,1 +1,1 @@
-export * from './namespaceMembers.ts';
+export * as TextToImage_Client from './namespaceMembers.ts';

--- a/src/features/TextToImage/Config/Dynamic/Fetching/Error/index.ts
+++ b/src/features/TextToImage/Config/Dynamic/Fetching/Error/index.ts
@@ -1,1 +1,1 @@
-export * as TextToImage_Config_Dynamic_Fetching_Error from './exports_objectOriented.ts';
+export * from './exports_objectOriented.ts';

--- a/src/features/TextToImage/Config/Dynamic/Fetching/Error/namespace.ts
+++ b/src/features/TextToImage/Config/Dynamic/Fetching/Error/namespace.ts
@@ -1,1 +1,1 @@
-export * from './namespaceMembers.ts';
+export * as TextToImage_Config_Dynamic_Fetching_Error from './namespaceMembers.ts';

--- a/src/features/TextToImage/Config/Dynamic/Fetching/index.ts
+++ b/src/features/TextToImage/Config/Dynamic/Fetching/index.ts
@@ -1,1 +1,1 @@
-export * as TextToImage_Config_Dynamic_Fetching from './exports_objectOriented.ts';
+export * from './exports_objectOriented.ts';

--- a/src/features/TextToImage/Config/Dynamic/Fetching/namespace.ts
+++ b/src/features/TextToImage/Config/Dynamic/Fetching/namespace.ts
@@ -1,1 +1,1 @@
-export * from './namespaceMembers.ts';
+export * as TextToImage_Config_Dynamic_Fetching from './namespaceMembers.ts';

--- a/src/features/TextToImage/Config/Dynamic/index.ts
+++ b/src/features/TextToImage/Config/Dynamic/index.ts
@@ -1,1 +1,1 @@
-export * as TextToImage_Config_Dynamic from './exports_objectOriented.ts';
+export * from './exports_objectOriented.ts';

--- a/src/features/TextToImage/Config/Dynamic/namespace.ts
+++ b/src/features/TextToImage/Config/Dynamic/namespace.ts
@@ -1,1 +1,1 @@
-export * from './namespaceMembers.ts';
+export * as TextToImage_Config_Dynamic from './namespaceMembers.ts';

--- a/src/features/TextToImage/Config/Static/Reading/index.ts
+++ b/src/features/TextToImage/Config/Static/Reading/index.ts
@@ -1,1 +1,1 @@
-export * as TextToImage_Config_Static_Reading from './exports_objectOriented.ts';
+export * from './exports_objectOriented.ts';

--- a/src/features/TextToImage/Config/Static/Reading/namespace.ts
+++ b/src/features/TextToImage/Config/Static/Reading/namespace.ts
@@ -1,1 +1,1 @@
-export * from './namespaceMembers.ts';
+export * as TextToImage_Config_Static_Reading from './namespaceMembers.ts';

--- a/src/features/TextToImage/Config/Static/index.ts
+++ b/src/features/TextToImage/Config/Static/index.ts
@@ -1,1 +1,1 @@
-export * as TextToImage_Config_Static from './exports_objectOriented.ts';
+export * from './exports_objectOriented.ts';

--- a/src/features/TextToImage/Config/Static/namespace.ts
+++ b/src/features/TextToImage/Config/Static/namespace.ts
@@ -1,1 +1,1 @@
-export * from './namespaceMembers.ts';
+export * as TextToImage_Config_Static from './namespaceMembers.ts';

--- a/src/features/TextToImage/Config/index.ts
+++ b/src/features/TextToImage/Config/index.ts
@@ -1,1 +1,1 @@
-export * as TextToImage_Config from './exports_objectOriented.ts';
+export * from './exports_objectOriented.ts';

--- a/src/features/TextToImage/Config/namespace.ts
+++ b/src/features/TextToImage/Config/namespace.ts
@@ -1,1 +1,1 @@
-export * from './namespaceMembers.ts';
+export * as TextToImage_Config from './namespaceMembers.ts';

--- a/src/features/TextToImage/Pipeline/Output/Nullable/index.ts
+++ b/src/features/TextToImage/Pipeline/Output/Nullable/index.ts
@@ -1,1 +1,1 @@
-export * as TextToImage_Pipeline_Output_Nullable from './exports_objectOriented.ts';
+export * from './exports_objectOriented.ts';

--- a/src/features/TextToImage/Pipeline/Output/Nullable/namespace.ts
+++ b/src/features/TextToImage/Pipeline/Output/Nullable/namespace.ts
@@ -1,1 +1,1 @@
-export * from './namespaceMembers.ts';
+export * as TextToImage_Pipeline_Output_Nullable from './namespaceMembers.ts';

--- a/src/features/TextToImage/Pipeline/index.ts
+++ b/src/features/TextToImage/Pipeline/index.ts
@@ -1,1 +1,1 @@
-export * as TextToImage_Pipeline from './exports_objectOriented.ts';
+export * from './exports_objectOriented.ts';

--- a/src/features/TextToImage/Pipeline/namespace.ts
+++ b/src/features/TextToImage/Pipeline/namespace.ts
@@ -1,1 +1,1 @@
-export * from './namespaceMembers.ts';
+export * as TextToImage_Pipeline from './namespaceMembers.ts';

--- a/src/features/TextToImage/Server/Current/index.ts
+++ b/src/features/TextToImage/Server/Current/index.ts
@@ -1,1 +1,1 @@
-export * as TextToImage_Server_Current from './exports_objectOriented.ts';
+export * from './exports_objectOriented.ts';

--- a/src/features/TextToImage/Server/Current/namespace.ts
+++ b/src/features/TextToImage/Server/Current/namespace.ts
@@ -1,1 +1,1 @@
-export * from './namespaceMembers.ts';
+export * as TextToImage_Server_Current from './namespaceMembers.ts';

--- a/src/features/TextToImage/Server/Error/index.ts
+++ b/src/features/TextToImage/Server/Error/index.ts
@@ -1,1 +1,1 @@
-export * as TextToImage_Server_Error from './exports_objectOriented.ts';
+export * from './exports_objectOriented.ts';

--- a/src/features/TextToImage/Server/Error/namespace.ts
+++ b/src/features/TextToImage/Server/Error/namespace.ts
@@ -1,1 +1,1 @@
-export * from './namespaceMembers.ts';
+export * as TextToImage_Server_Error from './namespaceMembers.ts';

--- a/src/features/TextToImage/Server/Origin/index.ts
+++ b/src/features/TextToImage/Server/Origin/index.ts
@@ -1,1 +1,1 @@
-export * as TextToImage_Server_Origin from './exports_objectOriented.ts';
+export * from './exports_objectOriented.ts';

--- a/src/features/TextToImage/Server/Origin/namespace.ts
+++ b/src/features/TextToImage/Server/Origin/namespace.ts
@@ -1,1 +1,1 @@
-export * from './namespaceMembers.ts';
+export * as TextToImage_Server_Origin from './namespaceMembers.ts';

--- a/src/features/TextToImage/Server/index.ts
+++ b/src/features/TextToImage/Server/index.ts
@@ -1,1 +1,1 @@
-export * as TextToImage_Server from './exports_objectOriented.ts';
+export * from './exports_objectOriented.ts';

--- a/src/features/TextToImage/Server/namespace.ts
+++ b/src/features/TextToImage/Server/namespace.ts
@@ -1,1 +1,1 @@
-export * from './namespaceMembers.ts';
+export * as TextToImage_Server from './namespaceMembers.ts';

--- a/src/features/TextToImage/index.ts
+++ b/src/features/TextToImage/index.ts
@@ -1,4 +1,6 @@
-import * as TextToImage from './exports_objectOriented.ts';
+import {
+  TextToImage,
+} from './exports_objectOriented.ts';
 
 export {
   TextToImage as default,

--- a/src/features/TextToImage/namespace.ts
+++ b/src/features/TextToImage/namespace.ts
@@ -1,1 +1,1 @@
-export * from './namespaceMembers.ts';
+export * as TextToImage from './namespaceMembers.ts';

--- a/src/library/Attempt/Adapted/index.ts
+++ b/src/library/Attempt/Adapted/index.ts
@@ -1,1 +1,1 @@
-export * as Attempt_Adapted from './exports_objectOriented.ts';
+export * from './exports_objectOriented.ts';

--- a/src/library/Attempt/Adapted/namespace.ts
+++ b/src/library/Attempt/Adapted/namespace.ts
@@ -1,1 +1,1 @@
-export * from './namespaceMembers.ts';
+export * as Attempt_Adapted from './namespaceMembers.ts';

--- a/src/library/Attempt/End/index.ts
+++ b/src/library/Attempt/End/index.ts
@@ -1,1 +1,1 @@
-export type * as Attempt_End from './exports_objectOriented.ts';
+export type * from './exports_objectOriented.ts';

--- a/src/library/Attempt/End/namespace.ts
+++ b/src/library/Attempt/End/namespace.ts
@@ -1,1 +1,1 @@
-export type * from './namespaceMembers.ts';
+export type * as Attempt_End from './namespaceMembers.ts';

--- a/src/library/Attempt/Error/index.ts
+++ b/src/library/Attempt/Error/index.ts
@@ -1,3 +1,3 @@
-export * as Attempt_Error from './exports_objectOriented.ts';
+export * from './exports_objectOriented.ts';
 
 export * from './exports_objectAdjacent.ts';

--- a/src/library/Attempt/Error/namespace.ts
+++ b/src/library/Attempt/Error/namespace.ts
@@ -1,1 +1,1 @@
-export * from './namespaceMembers.ts';
+export * as Attempt_Error from './namespaceMembers.ts';

--- a/src/library/Attempt/Fresh/index.ts
+++ b/src/library/Attempt/Fresh/index.ts
@@ -1,1 +1,1 @@
-export * as Attempt_Fresh from './exports_objectOriented.ts';
+export * from './exports_objectOriented.ts';

--- a/src/library/Attempt/Fresh/namespace.ts
+++ b/src/library/Attempt/Fresh/namespace.ts
@@ -1,1 +1,1 @@
-export * from './namespaceMembers.ts';
+export * as Attempt_Fresh from './namespaceMembers.ts';

--- a/src/library/Attempt/Outcome/Failure/Cause/index.ts
+++ b/src/library/Attempt/Outcome/Failure/Cause/index.ts
@@ -1,1 +1,1 @@
-export * as Attempt_Outcome_Failure_Cause from './exports_objectOriented.ts';
+export * from './exports_objectOriented.ts';

--- a/src/library/Attempt/Outcome/Failure/Cause/namespace.ts
+++ b/src/library/Attempt/Outcome/Failure/Cause/namespace.ts
@@ -1,1 +1,1 @@
-export * from './namespaceMembers.ts';
+export * as Attempt_Outcome_Failure_Cause from './namespaceMembers.ts';

--- a/src/library/Attempt/Outcome/Success/Product/index.ts
+++ b/src/library/Attempt/Outcome/Success/Product/index.ts
@@ -1,1 +1,1 @@
-export * as Attempt_Outcome_Success_Product from './exports_objectOriented.ts';
+export * from './exports_objectOriented.ts';

--- a/src/library/Attempt/Outcome/Success/Product/namespace.ts
+++ b/src/library/Attempt/Outcome/Success/Product/namespace.ts
@@ -1,1 +1,1 @@
-export * from './namespaceMembers.ts';
+export * as Attempt_Outcome_Success_Product from './namespaceMembers.ts';

--- a/src/library/Attempt/index.ts
+++ b/src/library/Attempt/index.ts
@@ -1,4 +1,6 @@
-import * as Attempt from './exports_objectOriented.ts';
+import {
+  Attempt,
+} from './exports_objectOriented.ts';
 
 export {
   Attempt as default,

--- a/src/library/Attempt/namespace.ts
+++ b/src/library/Attempt/namespace.ts
@@ -1,1 +1,1 @@
-export * from './namespaceMembers.ts';
+export * as Attempt from './namespaceMembers.ts';

--- a/src/library/ContentDescriptor/StructuredSyntaxNameSuffix/index.ts
+++ b/src/library/ContentDescriptor/StructuredSyntaxNameSuffix/index.ts
@@ -1,1 +1,1 @@
-export * as ContentDescriptor_StructuredSyntaxNameSuffix from './exports_objectOriented.ts';
+export * from './exports_objectOriented.ts';

--- a/src/library/ContentDescriptor/StructuredSyntaxNameSuffix/namespace.ts
+++ b/src/library/ContentDescriptor/StructuredSyntaxNameSuffix/namespace.ts
@@ -1,1 +1,1 @@
-export * from './namespaceMembers.ts';
+export * as ContentDescriptor_StructuredSyntaxNameSuffix from './namespaceMembers.ts';

--- a/src/library/ContentDescriptor/TopLevel/Composite/index.ts
+++ b/src/library/ContentDescriptor/TopLevel/Composite/index.ts
@@ -1,1 +1,1 @@
-export * as ContentDescriptor_TopLevel_Composite from './exports_objectOriented.ts';
+export * from './exports_objectOriented.ts';

--- a/src/library/ContentDescriptor/TopLevel/Composite/namespace.ts
+++ b/src/library/ContentDescriptor/TopLevel/Composite/namespace.ts
@@ -1,1 +1,1 @@
-export * from './namespaceMembers.ts';
+export * as ContentDescriptor_TopLevel_Composite from './namespaceMembers.ts';

--- a/src/library/ContentDescriptor/TopLevel/Discrete/index.ts
+++ b/src/library/ContentDescriptor/TopLevel/Discrete/index.ts
@@ -1,1 +1,1 @@
-export * as ContentDescriptor_TopLevel_Discrete from './exports_objectOriented.ts';
+export * from './exports_objectOriented.ts';

--- a/src/library/ContentDescriptor/TopLevel/Discrete/namespace.ts
+++ b/src/library/ContentDescriptor/TopLevel/Discrete/namespace.ts
@@ -1,1 +1,1 @@
-export * from './namespaceMembers.ts';
+export * as ContentDescriptor_TopLevel_Discrete from './namespaceMembers.ts';

--- a/src/library/ContentDescriptor/TopLevel/index.ts
+++ b/src/library/ContentDescriptor/TopLevel/index.ts
@@ -1,1 +1,1 @@
-export * as ContentDescriptor_TopLevel from './exports_objectOriented.ts';
+export * from './exports_objectOriented.ts';

--- a/src/library/ContentDescriptor/TopLevel/namespace.ts
+++ b/src/library/ContentDescriptor/TopLevel/namespace.ts
@@ -1,1 +1,1 @@
-export * from './namespaceMembers.ts';
+export * as ContentDescriptor_TopLevel from './namespaceMembers.ts';

--- a/src/library/HTTP/Endpoint/Error/index.ts
+++ b/src/library/HTTP/Endpoint/Error/index.ts
@@ -1,1 +1,1 @@
-export * as HTTP_Endpoint_Error from './exports_objectOriented.ts';
+export * from './exports_objectOriented.ts';

--- a/src/library/HTTP/Endpoint/Error/namespace.ts
+++ b/src/library/HTTP/Endpoint/Error/namespace.ts
@@ -1,1 +1,1 @@
-export * from './namespaceMembers.ts';
+export * as HTTP_Endpoint_Error from './namespaceMembers.ts';

--- a/src/library/HTTP/Endpoint/index.ts
+++ b/src/library/HTTP/Endpoint/index.ts
@@ -1,1 +1,1 @@
-export * as HTTP_Endpoint from './exports_objectOriented.ts';
+export * from './exports_objectOriented.ts';

--- a/src/library/HTTP/Endpoint/namespace.ts
+++ b/src/library/HTTP/Endpoint/namespace.ts
@@ -1,1 +1,1 @@
-export * from './namespaceMembers.ts';
+export * as HTTP_Endpoint from './namespaceMembers.ts';

--- a/src/library/HTTP/Request/index.ts
+++ b/src/library/HTTP/Request/index.ts
@@ -1,1 +1,1 @@
-export * as HTTP_Request from './exports_objectOriented.ts';
+export * from './exports_objectOriented.ts';

--- a/src/library/HTTP/Request/namespace.ts
+++ b/src/library/HTTP/Request/namespace.ts
@@ -1,1 +1,1 @@
-export * from './namespaceMembers.ts';
+export * as HTTP_Request from './namespaceMembers.ts';

--- a/src/library/HTTP/Response/StatusCode/Error/index.ts
+++ b/src/library/HTTP/Response/StatusCode/Error/index.ts
@@ -1,1 +1,1 @@
-export * as HTTP_Response_StatusCode_Error from './exports_objectOriented.ts';
+export * from './exports_objectOriented.ts';

--- a/src/library/HTTP/Response/StatusCode/Error/namespace.ts
+++ b/src/library/HTTP/Response/StatusCode/Error/namespace.ts
@@ -1,1 +1,1 @@
-export * from './namespaceMembers.ts';
+export * as HTTP_Response_StatusCode_Error from './namespaceMembers.ts';

--- a/src/library/HTTP/Response/StatusCode/index.ts
+++ b/src/library/HTTP/Response/StatusCode/index.ts
@@ -1,1 +1,1 @@
-export * as HTTP_Response_StatusCode from './exports_objectOriented.ts';
+export * from './exports_objectOriented.ts';

--- a/src/library/HTTP/Response/StatusCode/namespace.ts
+++ b/src/library/HTTP/Response/StatusCode/namespace.ts
@@ -1,1 +1,1 @@
-export * from './namespaceMembers.ts';
+export * as HTTP_Response_StatusCode from './namespaceMembers.ts';

--- a/src/library/HTTP/Response/index.ts
+++ b/src/library/HTTP/Response/index.ts
@@ -1,1 +1,1 @@
-export * as HTTP_Response from './exports_objectOriented.ts';
+export * from './exports_objectOriented.ts';

--- a/src/library/HTTP/Response/namespace.ts
+++ b/src/library/HTTP/Response/namespace.ts
@@ -1,1 +1,1 @@
-export * from './namespaceMembers.ts';
+export * as HTTP_Response from './namespaceMembers.ts';

--- a/src/library/HTTP/index.ts
+++ b/src/library/HTTP/index.ts
@@ -1,4 +1,6 @@
-import * as HTTP from './exports_objectOriented.ts';
+import {
+  HTTP,
+} from './exports_objectOriented.ts';
 
 export {
   HTTP as default,

--- a/src/library/HTTP/namespace.ts
+++ b/src/library/HTTP/namespace.ts
@@ -1,1 +1,1 @@
-export * from './namespaceMembers.ts';
+export * as HTTP from './namespaceMembers.ts';

--- a/src/library/Parse/index.ts
+++ b/src/library/Parse/index.ts
@@ -1,4 +1,6 @@
-import * as Parse from './exports_objectOriented.ts';
+import {
+  Parse,
+} from './exports_objectOriented.ts';
 
 export {
   Parse as default,

--- a/src/library/Parse/namespace.ts
+++ b/src/library/Parse/namespace.ts
@@ -1,1 +1,1 @@
-export * from './namespaceMembers.ts';
+export * as Parse from './namespaceMembers.ts';

--- a/src/library/Schema/index.ts
+++ b/src/library/Schema/index.ts
@@ -1,4 +1,6 @@
-import * as Schema from './exports_objectOriented.ts';
+import {
+  Schema,
+} from './exports_objectOriented.ts';
 
 export {
   Schema as default,

--- a/src/library/Schema/namespace.ts
+++ b/src/library/Schema/namespace.ts
@@ -1,1 +1,1 @@
-export * from './namespaceMembers.ts';
+export * as Schema from './namespaceMembers.ts';

--- a/src/library/Sequence/Base64/Conformance/index.ts
+++ b/src/library/Sequence/Base64/Conformance/index.ts
@@ -1,1 +1,1 @@
-export * as Sequence_Base64_Conformance from './exports_objectOriented.ts';
+export * from './exports_objectOriented.ts';

--- a/src/library/Sequence/Base64/Conformance/namespace.ts
+++ b/src/library/Sequence/Base64/Conformance/namespace.ts
@@ -1,1 +1,1 @@
-export * from './namespaceMembers.ts';
+export * as Sequence_Base64_Conformance from './namespaceMembers.ts';

--- a/src/library/Sequence/Base64/index.ts
+++ b/src/library/Sequence/Base64/index.ts
@@ -1,1 +1,1 @@
-export * as Sequence_Base64 from './exports_objectOriented.ts';
+export * from './exports_objectOriented.ts';

--- a/src/library/Sequence/Base64/namespace.ts
+++ b/src/library/Sequence/Base64/namespace.ts
@@ -1,1 +1,1 @@
-export * from './namespaceMembers.ts';
+export * as Sequence_Base64 from './namespaceMembers.ts';

--- a/src/library/Sequence/Byte/Encoded/Compatibility/index.ts
+++ b/src/library/Sequence/Byte/Encoded/Compatibility/index.ts
@@ -1,1 +1,1 @@
-export * as Sequence_Byte_Encoded_Compatibility from './exports_objectOriented.ts';
+export * from './exports_objectOriented.ts';

--- a/src/library/Sequence/Byte/Encoded/Compatibility/namespace.ts
+++ b/src/library/Sequence/Byte/Encoded/Compatibility/namespace.ts
@@ -1,1 +1,1 @@
-export * from './namespaceMembers.ts';
+export * as Sequence_Byte_Encoded_Compatibility from './namespaceMembers.ts';

--- a/src/library/Sequence/Byte/Encoded/index.ts
+++ b/src/library/Sequence/Byte/Encoded/index.ts
@@ -1,1 +1,1 @@
-export * as Sequence_Byte_Encoded from './exports_objectOriented.ts';
+export * from './exports_objectOriented.ts';

--- a/src/library/Sequence/Byte/Encoded/namespace.ts
+++ b/src/library/Sequence/Byte/Encoded/namespace.ts
@@ -1,1 +1,1 @@
-export * from './namespaceMembers.ts';
+export * as Sequence_Byte_Encoded from './namespaceMembers.ts';

--- a/src/library/Sequence/Byte/index.ts
+++ b/src/library/Sequence/Byte/index.ts
@@ -1,1 +1,1 @@
-export * as Sequence_Byte from './exports_objectOriented.ts';
+export * from './exports_objectOriented.ts';

--- a/src/library/Sequence/Byte/namespace.ts
+++ b/src/library/Sequence/Byte/namespace.ts
@@ -1,1 +1,1 @@
-export * from './namespaceMembers.ts';
+export * as Sequence_Byte from './namespaceMembers.ts';

--- a/src/library/Sequence/index.ts
+++ b/src/library/Sequence/index.ts
@@ -1,4 +1,6 @@
-import * as Sequence from './exports_objectOriented.ts';
+import {
+  Sequence,
+} from './exports_objectOriented.ts';
 
 export {
   Sequence as default,

--- a/src/library/Sequence/namespace.ts
+++ b/src/library/Sequence/namespace.ts
@@ -1,1 +1,1 @@
-export * from './namespaceMembers.ts';
+export * as Sequence from './namespaceMembers.ts';

--- a/src/library/ShimmedStabilityAIClient/SDXL/index.ts
+++ b/src/library/ShimmedStabilityAIClient/SDXL/index.ts
@@ -1,1 +1,1 @@
-export * as SDXL from './exports_objectOriented.ts';
+export * from './exports_objectOriented.ts';

--- a/src/library/ShimmedStabilityAIClient/SDXL/namespace.ts
+++ b/src/library/ShimmedStabilityAIClient/SDXL/namespace.ts
@@ -1,1 +1,1 @@
-export * from './namespaceMembers.ts';
+export * as SDXL from './namespaceMembers.ts';

--- a/src/library/Shortfin/TextToImage/SDXL/Client/Request/index.ts
+++ b/src/library/Shortfin/TextToImage/SDXL/Client/Request/index.ts
@@ -1,1 +1,1 @@
-export * as Shortfin_TextToImage_SDXL_Client_Request from './exports_objectOriented.ts';
+export * from './exports_objectOriented.ts';

--- a/src/library/Shortfin/TextToImage/SDXL/Client/Request/namespace.ts
+++ b/src/library/Shortfin/TextToImage/SDXL/Client/Request/namespace.ts
@@ -1,1 +1,1 @@
-export * from './namespaceMembers.ts';
+export * as Shortfin_TextToImage_SDXL_Client_Request from './namespaceMembers.ts';

--- a/src/library/Shortfin/TextToImage/SDXL/Client/Response/index.ts
+++ b/src/library/Shortfin/TextToImage/SDXL/Client/Response/index.ts
@@ -1,1 +1,1 @@
-export * as Shortfin_TextToImage_SDXL_Client_Response from './exports_objectOriented.ts';
+export * from './exports_objectOriented.ts';

--- a/src/library/Shortfin/TextToImage/SDXL/Client/Response/namespace.ts
+++ b/src/library/Shortfin/TextToImage/SDXL/Client/Response/namespace.ts
@@ -1,1 +1,1 @@
-export * from './namespaceMembers.ts';
+export * as Shortfin_TextToImage_SDXL_Client_Response from './namespaceMembers.ts';

--- a/src/library/Shortfin/TextToImage/SDXL/Pipeline/Input/Text/index.ts
+++ b/src/library/Shortfin/TextToImage/SDXL/Pipeline/Input/Text/index.ts
@@ -1,1 +1,1 @@
-export type * as Shortfin_TextToImage_SDXL_Pipeline_Input_Text from './exports_objectOriented.ts';
+export type * from './exports_objectOriented.ts';

--- a/src/library/Shortfin/TextToImage/SDXL/Pipeline/Input/Text/namespace.ts
+++ b/src/library/Shortfin/TextToImage/SDXL/Pipeline/Input/Text/namespace.ts
@@ -1,1 +1,1 @@
-export type * from './namespaceMembers.ts';
+export type * as Shortfin_TextToImage_SDXL_Pipeline_Input_Text from './namespaceMembers.ts';

--- a/src/library/Shortfin/TextToImage/SDXL/Pipeline/Input/index.ts
+++ b/src/library/Shortfin/TextToImage/SDXL/Pipeline/Input/index.ts
@@ -1,1 +1,1 @@
-export type * as Shortfin_TextToImage_SDXL_Pipeline_Input from './exports_objectOriented.ts';
+export type * from './exports_objectOriented.ts';

--- a/src/library/Shortfin/TextToImage/SDXL/Pipeline/Input/namespace.ts
+++ b/src/library/Shortfin/TextToImage/SDXL/Pipeline/Input/namespace.ts
@@ -1,1 +1,1 @@
-export type * from './namespaceMembers.ts';
+export type * as Shortfin_TextToImage_SDXL_Pipeline_Input from './namespaceMembers.ts';

--- a/src/library/Shortfin/TextToImage/SDXL/Pipeline/index.ts
+++ b/src/library/Shortfin/TextToImage/SDXL/Pipeline/index.ts
@@ -1,1 +1,1 @@
-export type * as Shortfin_TextToImage_SDXL_Pipeline from './exports_objectOriented.ts';
+export type * from './exports_objectOriented.ts';

--- a/src/library/Shortfin/TextToImage/SDXL/Pipeline/namespace.ts
+++ b/src/library/Shortfin/TextToImage/SDXL/Pipeline/namespace.ts
@@ -1,1 +1,1 @@
-export type * from './namespaceMembers.ts';
+export type * as Shortfin_TextToImage_SDXL_Pipeline from './namespaceMembers.ts';

--- a/src/library/Shortfin/TextToImage/SDXL/index.ts
+++ b/src/library/Shortfin/TextToImage/SDXL/index.ts
@@ -1,1 +1,1 @@
-export * as Shortfin_TextToImage_SDXL from './exports_objectOriented.ts';
+export * from './exports_objectOriented.ts';

--- a/src/library/Shortfin/TextToImage/SDXL/namespace.ts
+++ b/src/library/Shortfin/TextToImage/SDXL/namespace.ts
@@ -1,1 +1,1 @@
-export * from './namespaceMembers.ts';
+export * as Shortfin_TextToImage_SDXL from './namespaceMembers.ts';

--- a/src/library/Shortfin/TextToImage/index.ts
+++ b/src/library/Shortfin/TextToImage/index.ts
@@ -1,1 +1,1 @@
-export * as Shortfin_TextToImage from './exports_objectOriented.ts';
+export * from './exports_objectOriented.ts';

--- a/src/library/Shortfin/TextToImage/namespace.ts
+++ b/src/library/Shortfin/TextToImage/namespace.ts
@@ -1,1 +1,1 @@
-export * from './namespaceMembers.ts';
+export * as Shortfin_TextToImage from './namespaceMembers.ts';

--- a/src/library/Shortfin/index.ts
+++ b/src/library/Shortfin/index.ts
@@ -1,4 +1,6 @@
-import * as Shortfin from './exports_objectOriented.ts';
+import {
+  Shortfin,
+} from './exports_objectOriented.ts';
 
 export {
   Shortfin as default,

--- a/src/library/Shortfin/namespace.ts
+++ b/src/library/Shortfin/namespace.ts
@@ -1,1 +1,1 @@
-export * from './namespaceMembers.ts';
+export * as Shortfin from './namespaceMembers.ts';

--- a/src/library/URLComponent/index.ts
+++ b/src/library/URLComponent/index.ts
@@ -1,4 +1,6 @@
-import * as URLComponent from './exports_objectOriented.ts';
+import {
+  URLComponent,
+} from './exports_objectOriented.ts';
 
 export {
   URLComponent as default,

--- a/src/library/URLComponent/namespace.ts
+++ b/src/library/URLComponent/namespace.ts
@@ -1,1 +1,1 @@
-export * from './namespaceMembers.ts';
+export * as URLComponent from './namespaceMembers.ts';

--- a/src/library/UniformResourceIdentifier/Data/EncodingIdentifier/index.ts
+++ b/src/library/UniformResourceIdentifier/Data/EncodingIdentifier/index.ts
@@ -1,1 +1,1 @@
-export * as URI_Data_EncodingIdentifier from './exports_objectOriented.ts';
+export * from './exports_objectOriented.ts';

--- a/src/library/UniformResourceIdentifier/Data/EncodingIdentifier/namespace.ts
+++ b/src/library/UniformResourceIdentifier/Data/EncodingIdentifier/namespace.ts
@@ -1,1 +1,1 @@
-export * from './namespaceMembers.ts';
+export * as URI_Data_EncodingIdentifier from './namespaceMembers.ts';

--- a/src/library/UniformResourceIdentifier/Image/Format/index.ts
+++ b/src/library/UniformResourceIdentifier/Image/Format/index.ts
@@ -1,1 +1,1 @@
-export * as URI_Image_Format from './exports_objectOriented.ts';
+export * from './exports_objectOriented.ts';

--- a/src/library/UniformResourceIdentifier/Image/Format/namespace.ts
+++ b/src/library/UniformResourceIdentifier/Image/Format/namespace.ts
@@ -1,1 +1,1 @@
-export * from './namespaceMembers.ts';
+export * as URI_Image_Format from './namespaceMembers.ts';

--- a/src/library/WebAPI/index.ts
+++ b/src/library/WebAPI/index.ts
@@ -1,4 +1,6 @@
-import * as WebAPI from './exports_objectOriented.ts';
+import {
+  WebAPI,
+} from './exports_objectOriented.ts';
 
 export {
   WebAPI as default,

--- a/src/library/WebAPI/namespace.ts
+++ b/src/library/WebAPI/namespace.ts
@@ -1,1 +1,1 @@
-export * from './namespaceMembers.ts';
+export * as WebAPI from './namespaceMembers.ts';


### PR DESCRIPTION
- the sole responsibility of index files is to dictate whether some symbol from any of those permitted for export can be designated `default`
- assembling an object from namespace members is the sole responsibility of the "namespace.ts" files
- this design makes it easier to ensure that the shaping of the different module archetypes is consistent across the codebase