### PR TITLE
refactor: ensures all `ParsingError` submodules are visible under respective parent namespaces

### DIFF
--- a/src/features/TextToImage/Config/namespaceMembers.ts
+++ b/src/features/TextToImage/Config/namespaceMembers.ts
@@ -1,4 +1,8 @@
 export {
+  TextToImage_Config_ParsingError as ParsingError,
+} from './ParsingError';
+
+export {
   TextToImage_Config_Dynamic as Dynamic,
 } from './Dynamic';
 export {

--- a/src/library/NonTrivialString/definitionAugmentation.ts
+++ b/src/library/NonTrivialString/definitionAugmentation.ts
@@ -1,0 +1,17 @@
+import {
+  NonTrivialString_ParsingError,
+} from './ParsingError';
+
+import {
+  NonTrivialString,
+} from './definition.ts';
+
+NonTrivialString.ParsingError = NonTrivialString_ParsingError;
+
+declare module './definition.ts' {
+  namespace NonTrivialString {
+    export {
+      NonTrivialString_ParsingError as ParsingError,
+    };
+  }
+}

--- a/src/library/NonTrivialString/definitionWithAugmentation.ts
+++ b/src/library/NonTrivialString/definitionWithAugmentation.ts
@@ -1,0 +1,3 @@
+import './definitionAugmentation.ts';
+
+export * from './definition.ts';

--- a/src/library/NonTrivialString/exports_objectOriented.ts
+++ b/src/library/NonTrivialString/exports_objectOriented.ts
@@ -1,3 +1,3 @@
 export {
   NonTrivialString,
-} from './definition.ts';
+} from './definitionWithAugmentation.ts';

--- a/src/library/Sequence/Byte/Encoded/Base64/definitionAugmentation.ts
+++ b/src/library/Sequence/Byte/Encoded/Base64/definitionAugmentation.ts
@@ -1,0 +1,17 @@
+import {
+  Sequence_Byte_Encoded_Base64_ParsingError,
+} from './ParsingError';
+
+import {
+  Sequence_Byte_Encoded_Base64,
+} from './definition.ts';
+
+Sequence_Byte_Encoded_Base64.ParsingError = Sequence_Byte_Encoded_Base64_ParsingError;
+
+declare module './definition.ts' {
+  namespace Sequence_Byte_Encoded_Base64 {
+    export {
+      Sequence_Byte_Encoded_Base64_ParsingError as ParsingError,
+    };
+  }
+}

--- a/src/library/Sequence/Byte/Encoded/Base64/definitionWithAugmentation.ts
+++ b/src/library/Sequence/Byte/Encoded/Base64/definitionWithAugmentation.ts
@@ -1,0 +1,3 @@
+import './definitionAugmentation.ts';
+
+export * from './definition.ts';

--- a/src/library/Sequence/Byte/Encoded/Base64/exports_objectOriented.ts
+++ b/src/library/Sequence/Byte/Encoded/Base64/exports_objectOriented.ts
@@ -1,3 +1,3 @@
 export {
   Sequence_Byte_Encoded_Base64,
-} from './definition.ts';
+} from './definitionWithAugmentation.ts';

--- a/src/library/URLComponent/Origin/definitionAugmentation.ts
+++ b/src/library/URLComponent/Origin/definitionAugmentation.ts
@@ -1,0 +1,17 @@
+import {
+  URLComponent_Origin_ParsingError,
+} from './ParsingError';
+
+import {
+  URLComponent_Origin,
+} from './definition.ts';
+
+URLComponent_Origin.ParsingError = URLComponent_Origin_ParsingError;
+
+declare module './definition.ts' {
+  namespace URLComponent_Origin {
+    export {
+      URLComponent_Origin_ParsingError as ParsingError,
+    };
+  }
+}

--- a/src/library/URLComponent/Origin/definitionWithAugmentation.ts
+++ b/src/library/URLComponent/Origin/definitionWithAugmentation.ts
@@ -1,0 +1,3 @@
+import './definitionAugmentation.ts';
+
+export * from './definition.ts';

--- a/src/library/URLComponent/Origin/exports_objectOriented.ts
+++ b/src/library/URLComponent/Origin/exports_objectOriented.ts
@@ -1,5 +1,1 @@
-export * from './definition.ts';
-
-export {
-  URLComponent_Origin_ParsingError,
-} from './ParsingError';
+export * from './definitionWithAugmentation.ts';

--- a/src/library/URLComponent/Path/definitionAugmentation.ts
+++ b/src/library/URLComponent/Path/definitionAugmentation.ts
@@ -1,0 +1,17 @@
+import {
+  URLComponent_Path_ParsingError,
+} from './ParsingError';
+
+import {
+  URLComponent_Path,
+} from './definition.ts';
+
+URLComponent_Path.ParsingError = URLComponent_Path_ParsingError;
+
+declare module './definition.ts' {
+  namespace URLComponent_Path {
+    export {
+      URLComponent_Path_ParsingError as ParsingError,
+    };
+  }
+}

--- a/src/library/URLComponent/Path/definitionWithAugmentation.ts
+++ b/src/library/URLComponent/Path/definitionWithAugmentation.ts
@@ -1,0 +1,3 @@
+import './definitionAugmentation.ts';
+
+export * from './definition.ts';

--- a/src/library/URLComponent/Path/exports_objectOriented.ts
+++ b/src/library/URLComponent/Path/exports_objectOriented.ts
@@ -1,5 +1,1 @@
-export * from './definition.ts';
-
-export {
-  URLComponent_Path_ParsingError,
-} from './ParsingError';
+export * from './definitionWithAugmentation.ts';

--- a/src/library/URLComponent/namespaceMembers.ts
+++ b/src/library/URLComponent/namespaceMembers.ts
@@ -1,6 +1,5 @@
 export {
   URLComponent_Origin as Origin,
-  URLComponent_Origin_ParsingError as Origin_ParsingError,
 } from './Origin';
 export {
   URLComponent_Path as Path,

--- a/src/library/URLComponent/namespaceMembers.ts
+++ b/src/library/URLComponent/namespaceMembers.ts
@@ -3,5 +3,4 @@ export {
 } from './Origin';
 export {
   URLComponent_Path as Path,
-  URLComponent_Path_ParsingError as Path_ParsingError,
 } from './Path';


### PR DESCRIPTION
- allows type safe error propagation to pick up on aliases for `ParsingError` subclasses
  - e.g. `TextToImage.Config.ParsingError` vs `TextToImage_Config_ParsingError`