### PR TITLE
refactor(text-to-image): ensures all submodules are nested in "/toSharkUIOutput"

### DIFF
--- a/src/features/TextToImage/Client/SDXL/toSharkUIOutput/Image/definition.ts
+++ b/src/features/TextToImage/Client/SDXL/toSharkUIOutput/Image/definition.ts
@@ -7,12 +7,12 @@ import type {
   TextToImage_Pipeline,
 } from '@/features/TextToImage/Pipeline'; // eslint-disable-line import/no-internal-modules -- more concise than relative import
 
-const toSharkUIOutput_Image = (
+function toSharkUIOutput_Image(
   givenImage: StabilityAIClient.Image,
   given: {
     description: TextToImage_Pipeline.Output['image']['description'];
   },
-): TextToImage_Pipeline.Output['image'] | null => {
+): TextToImage_Pipeline.Output['image'] | null {
   if (
     givenImage.base64 === undefined
   ) return null;
@@ -25,7 +25,7 @@ const toSharkUIOutput_Image = (
   };
 
   return derivedImage;
-};
+}
 
 export {
   toSharkUIOutput_Image,

--- a/src/features/TextToImage/Client/SDXL/toSharkUIOutput/Image/definitionAugmentation.ts
+++ b/src/features/TextToImage/Client/SDXL/toSharkUIOutput/Image/definitionAugmentation.ts
@@ -1,0 +1,17 @@
+import {
+  toSharkUIOutput_Image_Description,
+} from './Description';
+
+import {
+  toSharkUIOutput_Image,
+} from './definition.ts';
+
+toSharkUIOutput_Image.Description = toSharkUIOutput_Image_Description;
+
+declare module './definition.ts' {
+  namespace toSharkUIOutput_Image {
+    export {
+      toSharkUIOutput_Image_Description as Description,
+    };
+  }
+}

--- a/src/features/TextToImage/Client/SDXL/toSharkUIOutput/Image/definitionWithAugmentation.ts
+++ b/src/features/TextToImage/Client/SDXL/toSharkUIOutput/Image/definitionWithAugmentation.ts
@@ -1,0 +1,3 @@
+import './definitionAugmentation.ts';
+
+export * from './definition.ts';

--- a/src/features/TextToImage/Client/SDXL/toSharkUIOutput/Image/exports_objectOriented.ts
+++ b/src/features/TextToImage/Client/SDXL/toSharkUIOutput/Image/exports_objectOriented.ts
@@ -1,5 +1,1 @@
-export * from './definition.ts';
-
-export {
-  toSharkUIOutput_Image_Description,
-} from './Description';
+export * from './definitionWithAugmentation.ts';

--- a/src/features/TextToImage/Client/SDXL/toSharkUIOutput/namespaceMembers.ts
+++ b/src/features/TextToImage/Client/SDXL/toSharkUIOutput/namespaceMembers.ts
@@ -1,4 +1,8 @@
 export {
+  toSharkUIOutput_Image as Image,
+} from './Image';
+
+export {
   toSharkUIOutput_plural as plural,
 } from './plural';
 

--- a/src/features/TextToImage/Client/SDXL/toSharkUIOutput/plural.ts
+++ b/src/features/TextToImage/Client/SDXL/toSharkUIOutput/plural.ts
@@ -10,7 +10,6 @@ import {
 
 import {
   toSharkUIOutput_Image,
-  toSharkUIOutput_Image_Description,
 } from './Image';
 
 const toSharkUIOutput_plural = (
@@ -34,7 +33,7 @@ const toSharkUIOutput_plural = (
 
   const inferredOutputs = inferredRawImages
     .map($0 => toSharkUIOutput_Image($0, {
-      description: toSharkUIOutput_Image_Description.all(givenInputText),
+      description: toSharkUIOutput_Image.Description.all(givenInputText),
     }))
     .map($0 => TextToImage_Pipeline.Output_Nullable.from($0));
 


### PR DESCRIPTION
- enables the dot syntax that's consistent with the rest of the codebase