### PR TITLE
refactor(library/Attempt): ensures all augmentative submodules are nested in "/Outcome/Failure"

### DIFF
--- a/src/library/Attempt/Outcome/Failure/definition.ts
+++ b/src/library/Attempt/Outcome/Failure/definition.ts
@@ -1,4 +1,4 @@
-import type {
+import {
   Attempt_Error,
 } from '../../Error';
 
@@ -44,6 +44,14 @@ interface Attempt_Outcome_Failure<
   ): Attempt_Outcome_Failure<SomeTransformedActionableError>;
 }
 
-export type {
+function Attempt_Outcome_Failure(
+  namespaceOnly: never = Attempt_Error.NonActionable.throw(
+    `Unexpected call of module augmentation provision for "${Attempt_Outcome_Failure.name}".`,
+  ),
+) {
+  return namespaceOnly;
+}
+
+export {
   Attempt_Outcome_Failure,
 };

--- a/src/library/Attempt/Outcome/Failure/definitionAugmentation.ts
+++ b/src/library/Attempt/Outcome/Failure/definitionAugmentation.ts
@@ -6,12 +6,18 @@ import {
   Attempt_Outcome_Failure,
 } from './definition.ts';
 
+import {
+  Attempt_Outcome_Failure_dueTo,
+} from './dueTo';
+
 Attempt_Outcome_Failure.Cause = Attempt_Outcome_Failure_Cause;
+Attempt_Outcome_Failure.dueTo = Attempt_Outcome_Failure_dueTo;
 
 declare module './definition.ts' {
   namespace Attempt_Outcome_Failure {
     export {
       Attempt_Outcome_Failure_Cause as Cause,
+      Attempt_Outcome_Failure_dueTo as dueTo,
     };
   }
 }

--- a/src/library/Attempt/Outcome/Failure/definitionAugmentation.ts
+++ b/src/library/Attempt/Outcome/Failure/definitionAugmentation.ts
@@ -1,0 +1,17 @@
+import {
+  Attempt_Outcome_Failure_Cause,
+} from './Cause';
+
+import {
+  Attempt_Outcome_Failure,
+} from './definition.ts';
+
+Attempt_Outcome_Failure.Cause = Attempt_Outcome_Failure_Cause;
+
+declare module './definition.ts' {
+  namespace Attempt_Outcome_Failure {
+    export {
+      Attempt_Outcome_Failure_Cause as Cause,
+    };
+  }
+}

--- a/src/library/Attempt/Outcome/Failure/definitionAugmentation.ts
+++ b/src/library/Attempt/Outcome/Failure/definitionAugmentation.ts
@@ -2,6 +2,10 @@ import {
   Attempt_Outcome_Failure_Cause,
 } from './Cause';
 
+import type {
+  Attempt_Outcome_Failure_Transformer,
+} from './Transformer';
+
 import {
   Attempt_Outcome_Failure,
 } from './definition.ts';
@@ -16,8 +20,9 @@ Attempt_Outcome_Failure.dueTo = Attempt_Outcome_Failure_dueTo;
 declare module './definition.ts' {
   namespace Attempt_Outcome_Failure {
     export {
-      Attempt_Outcome_Failure_Cause as Cause,
-      Attempt_Outcome_Failure_dueTo as dueTo,
+      /**/ Attempt_Outcome_Failure_Cause /* */ as Cause,
+      type Attempt_Outcome_Failure_Transformer as Transformer,
+      /**/ Attempt_Outcome_Failure_dueTo /* */ as dueTo,
     };
   }
 }

--- a/src/library/Attempt/Outcome/Failure/definitionWithAugmentation.ts
+++ b/src/library/Attempt/Outcome/Failure/definitionWithAugmentation.ts
@@ -1,0 +1,3 @@
+import './definitionAugmentation.ts';
+
+export * from './definition.ts';

--- a/src/library/Attempt/Outcome/Failure/exports_objectOriented.ts
+++ b/src/library/Attempt/Outcome/Failure/exports_objectOriented.ts
@@ -1,8 +1,4 @@
-export type * from './definition.ts';
-
-export {
-  Attempt_Outcome_Failure_Cause,
-} from './Cause';
+export * from './definitionWithAugmentation.ts';
 
 export type {
   Attempt_Outcome_Failure_Transformer,

--- a/src/library/Attempt/Outcome/Failure/exports_objectOriented.ts
+++ b/src/library/Attempt/Outcome/Failure/exports_objectOriented.ts
@@ -3,7 +3,3 @@ export * from './definitionWithAugmentation.ts';
 export type {
   Attempt_Outcome_Failure_Transformer,
 } from './Transformer';
-
-export {
-  Attempt_Outcome_Failure_dueTo,
-} from './dueTo';

--- a/src/library/Attempt/Outcome/Failure/exports_objectOriented.ts
+++ b/src/library/Attempt/Outcome/Failure/exports_objectOriented.ts
@@ -1,5 +1,1 @@
 export * from './definitionWithAugmentation.ts';
-
-export type {
-  Attempt_Outcome_Failure_Transformer,
-} from './Transformer';

--- a/src/library/Attempt/Outcome/Transformer.ts
+++ b/src/library/Attempt/Outcome/Transformer.ts
@@ -3,7 +3,7 @@ import type {
 } from '../Error';
 
 import type {
-  Attempt_Outcome_Failure_Transformer,
+  Attempt_Outcome_Failure,
 } from './Failure';
 
 import type {
@@ -24,7 +24,7 @@ type Attempt_Outcome_Transformer<
       >
     >
     & Partial<
-      Attempt_Outcome_Failure_Transformer<
+      Attempt_Outcome_Failure.Transformer<
         SomeTransformableActionableError,
         SomeTransformedActionableError
       >
@@ -38,7 +38,7 @@ type Attempt_Outcome_Transformer<
       >
     >
     & Required<
-      Attempt_Outcome_Failure_Transformer<
+      Attempt_Outcome_Failure.Transformer<
         SomeTransformableActionableError,
         SomeTransformedActionableError
       >

--- a/src/library/Attempt/Outcome/definition.ts
+++ b/src/library/Attempt/Outcome/definition.ts
@@ -3,8 +3,7 @@ import type {
 } from '../Error';
 
 import {
-  type Attempt_Outcome_Failure,
-  Attempt_Outcome_Failure_dueTo,
+  Attempt_Outcome_Failure,
 } from './Failure';
 
 import {
@@ -25,7 +24,7 @@ type Attempt_Outcome<
 ;
 
 const Attempt_Outcome = {
-  Failure_dueTo      : Attempt_Outcome_Failure_dueTo,
+  Failure            : Attempt_Outcome_Failure,
   Success_thatYielded: Attempt_Outcome_Success_thatYielded,
   fromRewrapping     : Attempt_Outcome_fromRewrapping,
 };

--- a/src/library/Attempt/Outcome/exports_objectOriented.ts
+++ b/src/library/Attempt/Outcome/exports_objectOriented.ts
@@ -8,6 +8,5 @@ export {
 } from './Success';
 
 export {
-  /**/ Attempt_Outcome_Failure,
-  type Attempt_Outcome_Failure_Transformer,
+  Attempt_Outcome_Failure,
 } from './Failure';

--- a/src/library/Attempt/Outcome/exports_objectOriented.ts
+++ b/src/library/Attempt/Outcome/exports_objectOriented.ts
@@ -10,5 +10,4 @@ export {
 export {
   /**/ Attempt_Outcome_Failure,
   type Attempt_Outcome_Failure_Transformer,
-  /**/ Attempt_Outcome_Failure_dueTo,
 } from './Failure';

--- a/src/library/Attempt/Outcome/exports_objectOriented.ts
+++ b/src/library/Attempt/Outcome/exports_objectOriented.ts
@@ -8,8 +8,7 @@ export {
 } from './Success';
 
 export {
-  type Attempt_Outcome_Failure,
-  /**/ Attempt_Outcome_Failure_Cause,
+  /**/ Attempt_Outcome_Failure,
   type Attempt_Outcome_Failure_Transformer,
   /**/ Attempt_Outcome_Failure_dueTo,
 } from './Failure';

--- a/src/library/Attempt/Outcome/fromRewrapping.ts
+++ b/src/library/Attempt/Outcome/fromRewrapping.ts
@@ -3,8 +3,7 @@ import type {
 } from '../Error';
 
 import {
-  /**/ Attempt_Outcome_Failure,
-  type Attempt_Outcome_Failure_Transformer,
+  Attempt_Outcome_Failure,
 } from './Failure';
 
 import {
@@ -34,7 +33,7 @@ function Attempt_Outcome_fromRewrapping<
   SomeTransformedActionableError extends Attempt_Error.Actionable<string> = SomeTransformableActionableError,
 >(
   givenOutcome: Attempt_Outcome_Failure<SomeTransformableActionableError>,
-  given?: Attempt_Outcome_Failure_Transformer<
+  given?: Attempt_Outcome_Failure.Transformer<
     SomeTransformableActionableError,
     SomeTransformedActionableError
   >,

--- a/src/library/Attempt/Outcome/fromRewrapping.ts
+++ b/src/library/Attempt/Outcome/fromRewrapping.ts
@@ -3,9 +3,8 @@ import type {
 } from '../Error';
 
 import {
-  type Attempt_Outcome_Failure,
+  /**/ Attempt_Outcome_Failure,
   type Attempt_Outcome_Failure_Transformer,
-  Attempt_Outcome_Failure_Cause,
 } from './Failure';
 
 import {
@@ -88,7 +87,7 @@ function Attempt_Outcome_fromRewrapping<
       SomeTransformableProduct,
       SomeTransformedProduct
     >,
-    cause: toTransformedCause = Attempt_Outcome_Failure_Cause.Transformer_identity<
+    cause: toTransformedCause = Attempt_Outcome_Failure.Cause.Transformer_identity<
       SomeTransformableActionableError,
       SomeTransformedActionableError
     >,
@@ -102,7 +101,7 @@ function Attempt_Outcome_fromRewrapping<
       SomeTransformableProduct,
       SomeTransformedProduct
     >,
-    cause: Attempt_Outcome_Failure_Cause.Transformer_identity<
+    cause: Attempt_Outcome_Failure.Cause.Transformer_identity<
       SomeTransformableActionableError,
       SomeTransformedActionableError
     >,

--- a/src/library/Attempt/ended.ts
+++ b/src/library/Attempt/ended.ts
@@ -16,7 +16,7 @@ const Attempt_ended = {
   /** Call this when the attempt has completed and was considered successful */
   inSuccessWith  : Attempt_Outcome.Success_thatYielded,
   /** Call this when the attempt has completed and was considered a failure */
-  inFailureDueTo : Attempt_Outcome.Failure_dueTo,
+  inFailureDueTo : Attempt_Outcome.Failure.dueTo,
   /** Call this when the attempt has completed in terms of a prior outcome */
   inTermsOf      : Attempt_Outcome.fromRewrapping,
   /** Call this when it's not possible to complete the attempt */


### PR DESCRIPTION
- enables the dot syntax that's consistent with the rest of the codebase