### PR TITLE
refactor(library/Attempt): ensures all augmentative submodules are nested in "/Outcome/Success"

### DIFF
--- a/src/library/Attempt/Outcome/Success/definition.ts
+++ b/src/library/Attempt/Outcome/Success/definition.ts
@@ -1,3 +1,7 @@
+import {
+  Attempt_Error,
+} from '../../Error';
+
 import type {
   Attempt_Outcome_Success_SemanticallySugarfree,
 } from './SemanticallySugarfree';
@@ -52,6 +56,14 @@ interface Attempt_Outcome_Success<
   ): Attempt_Outcome_Success<SomeTransformedProduct>;
 }
 
-export type {
+function Attempt_Outcome_Success(
+  namespaceOnly: never = Attempt_Error.NonActionable.throw(
+    `Unexpected call of module augmentation provision for "${Attempt_Outcome_Success.name}".`,
+  ),
+) {
+  return namespaceOnly;
+}
+
+export {
   Attempt_Outcome_Success,
 };

--- a/src/library/Attempt/Outcome/Success/definitionAugmentation.ts
+++ b/src/library/Attempt/Outcome/Success/definitionAugmentation.ts
@@ -2,6 +2,10 @@ import {
   Attempt_Outcome_Success_Product,
 } from './Product';
 
+import type {
+  Attempt_Outcome_Success_Transformer,
+} from './Transformer';
+
 import {
   Attempt_Outcome_Success,
 } from './definition.ts';
@@ -16,8 +20,9 @@ Attempt_Outcome_Success.thatYielded = Attempt_Outcome_Success_thatYielded;
 declare module './definition.ts' {
   namespace Attempt_Outcome_Success {
     export {
-      Attempt_Outcome_Success_Product/**/ as Product,
-      Attempt_Outcome_Success_thatYielded as thatYielded,
+      /**/ Attempt_Outcome_Success_Product/**/ as Product,
+      type Attempt_Outcome_Success_Transformer as Transformer,
+      /**/ Attempt_Outcome_Success_thatYielded as thatYielded,
     };
   }
 }

--- a/src/library/Attempt/Outcome/Success/definitionAugmentation.ts
+++ b/src/library/Attempt/Outcome/Success/definitionAugmentation.ts
@@ -1,0 +1,17 @@
+import {
+  Attempt_Outcome_Success_Product,
+} from './Product';
+
+import {
+  Attempt_Outcome_Success,
+} from './definition.ts';
+
+Attempt_Outcome_Success.Product = Attempt_Outcome_Success_Product;
+
+declare module './definition.ts' {
+  namespace Attempt_Outcome_Success {
+    export {
+      Attempt_Outcome_Success_Product as Product,
+    };
+  }
+}

--- a/src/library/Attempt/Outcome/Success/definitionAugmentation.ts
+++ b/src/library/Attempt/Outcome/Success/definitionAugmentation.ts
@@ -6,12 +6,18 @@ import {
   Attempt_Outcome_Success,
 } from './definition.ts';
 
-Attempt_Outcome_Success.Product = Attempt_Outcome_Success_Product;
+import {
+  Attempt_Outcome_Success_thatYielded,
+} from './thatYielded';
+
+Attempt_Outcome_Success.Product/**/ = Attempt_Outcome_Success_Product;
+Attempt_Outcome_Success.thatYielded = Attempt_Outcome_Success_thatYielded;
 
 declare module './definition.ts' {
   namespace Attempt_Outcome_Success {
     export {
-      Attempt_Outcome_Success_Product as Product,
+      Attempt_Outcome_Success_Product/**/ as Product,
+      Attempt_Outcome_Success_thatYielded as thatYielded,
     };
   }
 }

--- a/src/library/Attempt/Outcome/Success/definitionWithAugmentation.ts
+++ b/src/library/Attempt/Outcome/Success/definitionWithAugmentation.ts
@@ -1,0 +1,3 @@
+import './definitionAugmentation.ts';
+
+export * from './definition.ts';

--- a/src/library/Attempt/Outcome/Success/exports_objectOriented.ts
+++ b/src/library/Attempt/Outcome/Success/exports_objectOriented.ts
@@ -1,8 +1,4 @@
-export type * from './definition.ts';
-
-export {
-  Attempt_Outcome_Success_Product,
-} from './Product';
+export * from './definitionWithAugmentation.ts';
 
 export type {
   Attempt_Outcome_Success_Transformer,

--- a/src/library/Attempt/Outcome/Success/exports_objectOriented.ts
+++ b/src/library/Attempt/Outcome/Success/exports_objectOriented.ts
@@ -1,5 +1,1 @@
 export * from './definitionWithAugmentation.ts';
-
-export type {
-  Attempt_Outcome_Success_Transformer,
-} from './Transformer';

--- a/src/library/Attempt/Outcome/Success/exports_objectOriented.ts
+++ b/src/library/Attempt/Outcome/Success/exports_objectOriented.ts
@@ -3,7 +3,3 @@ export * from './definitionWithAugmentation.ts';
 export type {
   Attempt_Outcome_Success_Transformer,
 } from './Transformer';
-
-export {
-  Attempt_Outcome_Success_thatYielded,
-} from './thatYielded';

--- a/src/library/Attempt/Outcome/Transformer.ts
+++ b/src/library/Attempt/Outcome/Transformer.ts
@@ -7,7 +7,7 @@ import type {
 } from './Failure';
 
 import type {
-  Attempt_Outcome_Success_Transformer,
+  Attempt_Outcome_Success,
 } from './Success';
 
 type Attempt_Outcome_Transformer<
@@ -18,7 +18,7 @@ type Attempt_Outcome_Transformer<
 > =
   | (
     & Required<
-      Attempt_Outcome_Success_Transformer<
+      Attempt_Outcome_Success.Transformer<
         SomeTransformableProduct,
         SomeTransformedProduct
       >
@@ -32,7 +32,7 @@ type Attempt_Outcome_Transformer<
   )
   | (
     & Partial<
-      Attempt_Outcome_Success_Transformer<
+      Attempt_Outcome_Success.Transformer<
         SomeTransformableProduct,
         SomeTransformedProduct
       >

--- a/src/library/Attempt/Outcome/definition.ts
+++ b/src/library/Attempt/Outcome/definition.ts
@@ -7,8 +7,7 @@ import {
 } from './Failure';
 
 import {
-  type Attempt_Outcome_Success,
-  Attempt_Outcome_Success_thatYielded,
+  Attempt_Outcome_Success,
 } from './Success';
 
 import {
@@ -24,9 +23,9 @@ type Attempt_Outcome<
 ;
 
 const Attempt_Outcome = {
-  Failure            : Attempt_Outcome_Failure,
-  Success_thatYielded: Attempt_Outcome_Success_thatYielded,
-  fromRewrapping     : Attempt_Outcome_fromRewrapping,
+  Failure       : Attempt_Outcome_Failure,
+  Success       : Attempt_Outcome_Success,
+  fromRewrapping: Attempt_Outcome_fromRewrapping,
 };
 
 export {

--- a/src/library/Attempt/Outcome/exports_objectOriented.ts
+++ b/src/library/Attempt/Outcome/exports_objectOriented.ts
@@ -1,8 +1,7 @@
 export * from './definition.ts';
 
 export {
-  type Attempt_Outcome_Success,
-  /**/ Attempt_Outcome_Success_Product,
+  /**/ Attempt_Outcome_Success,
   type Attempt_Outcome_Success_Transformer,
   /**/ Attempt_Outcome_Success_thatYielded,
 } from './Success';

--- a/src/library/Attempt/Outcome/exports_objectOriented.ts
+++ b/src/library/Attempt/Outcome/exports_objectOriented.ts
@@ -1,8 +1,7 @@
 export * from './definition.ts';
 
 export {
-  /**/ Attempt_Outcome_Success,
-  type Attempt_Outcome_Success_Transformer,
+  Attempt_Outcome_Success,
 } from './Success';
 
 export {

--- a/src/library/Attempt/Outcome/exports_objectOriented.ts
+++ b/src/library/Attempt/Outcome/exports_objectOriented.ts
@@ -3,7 +3,6 @@ export * from './definition.ts';
 export {
   /**/ Attempt_Outcome_Success,
   type Attempt_Outcome_Success_Transformer,
-  /**/ Attempt_Outcome_Success_thatYielded,
 } from './Success';
 
 export {

--- a/src/library/Attempt/Outcome/fromRewrapping.ts
+++ b/src/library/Attempt/Outcome/fromRewrapping.ts
@@ -7,9 +7,8 @@ import {
 } from './Failure';
 
 import {
-  type Attempt_Outcome_Success,
+  /**/ Attempt_Outcome_Success,
   type Attempt_Outcome_Success_Transformer,
-  Attempt_Outcome_Success_Product,
 } from './Success';
 
 import type {
@@ -82,7 +81,7 @@ function Attempt_Outcome_fromRewrapping<
     SomeTransformableActionableError
   >,
   {
-    product: toTransformedProduct = Attempt_Outcome_Success_Product.Transformer_identity<
+    product: toTransformedProduct = Attempt_Outcome_Success.Product.Transformer_identity<
       SomeTransformableProduct,
       SomeTransformedProduct
     >,
@@ -96,7 +95,7 @@ function Attempt_Outcome_fromRewrapping<
     SomeTransformedProduct,
     SomeTransformedActionableError
   > = {
-    product: Attempt_Outcome_Success_Product.Transformer_identity<
+    product: Attempt_Outcome_Success.Product.Transformer_identity<
       SomeTransformableProduct,
       SomeTransformedProduct
     >,

--- a/src/library/Attempt/Outcome/fromRewrapping.ts
+++ b/src/library/Attempt/Outcome/fromRewrapping.ts
@@ -7,8 +7,7 @@ import {
 } from './Failure';
 
 import {
-  /**/ Attempt_Outcome_Success,
-  type Attempt_Outcome_Success_Transformer,
+  Attempt_Outcome_Success,
 } from './Success';
 
 import type {
@@ -43,7 +42,7 @@ function Attempt_Outcome_fromRewrapping<
   SomeTransformedProduct = SomeTransformableProduct,
 >(
   givenOutcome: Attempt_Outcome_Success<SomeTransformableProduct>,
-  given?: Attempt_Outcome_Success_Transformer<
+  given?: Attempt_Outcome_Success.Transformer<
     SomeTransformableProduct,
     SomeTransformedProduct
   >,

--- a/src/library/Attempt/ended.ts
+++ b/src/library/Attempt/ended.ts
@@ -14,7 +14,7 @@ import {
 */
 const Attempt_ended = {
   /** Call this when the attempt has completed and was considered successful */
-  inSuccessWith  : Attempt_Outcome.Success_thatYielded,
+  inSuccessWith  : Attempt_Outcome.Success.thatYielded,
   /** Call this when the attempt has completed and was considered a failure */
   inFailureDueTo : Attempt_Outcome.Failure.dueTo,
   /** Call this when the attempt has completed in terms of a prior outcome */


### PR DESCRIPTION
- enables the dot syntax that's consistent with the rest of the codebase