### PR TITLE
refactor(library/Attempt): ensures all augmentative submodules are nested in "/Outcome"

### DIFF
--- a/src/library/Attempt/Outcome/definition.ts
+++ b/src/library/Attempt/Outcome/definition.ts
@@ -1,18 +1,14 @@
-import type {
+import {
   Attempt_Error,
 } from '../Error';
 
-import {
+import type {
   Attempt_Outcome_Failure,
 } from './Failure';
 
-import {
+import type {
   Attempt_Outcome_Success,
 } from './Success';
-
-import {
-  Attempt_Outcome_fromRewrapping,
-} from './fromRewrapping';
 
 type Attempt_Outcome<
   SomeProduct,
@@ -22,11 +18,13 @@ type Attempt_Outcome<
   | Attempt_Outcome_Failure<SomeActionableError>
 ;
 
-const Attempt_Outcome = {
-  Failure       : Attempt_Outcome_Failure,
-  Success       : Attempt_Outcome_Success,
-  fromRewrapping: Attempt_Outcome_fromRewrapping,
-};
+function Attempt_Outcome(
+  namespaceOnly: never = Attempt_Error.NonActionable.throw(
+    `Unexpected call of module augmentation provision for ${Attempt_Outcome.name}.`,
+  ),
+) {
+  return namespaceOnly;
+}
 
 export {
   Attempt_Outcome,

--- a/src/library/Attempt/Outcome/definitionAugmentation.ts
+++ b/src/library/Attempt/Outcome/definitionAugmentation.ts
@@ -1,0 +1,29 @@
+import {
+  Attempt_Outcome_Failure,
+} from './Failure';
+
+import {
+  Attempt_Outcome_Success,
+} from './Success';
+
+import {
+  Attempt_Outcome,
+} from './definition.ts';
+
+import {
+  Attempt_Outcome_fromRewrapping,
+} from './fromRewrapping';
+
+Attempt_Outcome.Failure /*  */ = Attempt_Outcome_Failure;
+Attempt_Outcome.Success /*  */ = Attempt_Outcome_Success;
+Attempt_Outcome.fromRewrapping = Attempt_Outcome_fromRewrapping;
+
+declare module './definition.ts' {
+  namespace Attempt_Outcome {
+    export {
+      Attempt_Outcome_Failure /*  */ as Failure,
+      Attempt_Outcome_Success /*  */ as Success,
+      Attempt_Outcome_fromRewrapping as fromRewrapping,
+    };
+  }
+}

--- a/src/library/Attempt/Outcome/definitionWithAugmentation.ts
+++ b/src/library/Attempt/Outcome/definitionWithAugmentation.ts
@@ -1,0 +1,3 @@
+import './definitionAugmentation.ts';
+
+export * from './definition.ts';

--- a/src/library/Attempt/Outcome/exports_objectOriented.ts
+++ b/src/library/Attempt/Outcome/exports_objectOriented.ts
@@ -1,9 +1,1 @@
-export * from './definition.ts';
-
-export {
-  Attempt_Outcome_Success,
-} from './Success';
-
-export {
-  Attempt_Outcome_Failure,
-} from './Failure';
+export * from './definitionWithAugmentation.ts';

--- a/src/library/Attempt/namespaceMembers.ts
+++ b/src/library/Attempt/namespaceMembers.ts
@@ -4,8 +4,6 @@ export {
 
 export {
   Attempt_Outcome as Outcome,
-  type Attempt_Outcome_Success as Outcome_Success,
-  type Attempt_Outcome_Failure as Outcome_Failure,
 } from './Outcome';
 
 export {


### PR DESCRIPTION
- enables the dot syntax that's consistent with the rest of the codebase

Enabled by #964, #965