### PR TITLE
refactor: nests namespace members via object literal

### DIFF
--- a/src/features/TextToImage/Client/SDXL/toSharkUIOutput/plural.ts
+++ b/src/features/TextToImage/Client/SDXL/toSharkUIOutput/plural.ts
@@ -35,7 +35,7 @@ const toSharkUIOutput_plural = (
     .map($0 => toSharkUIOutput_Image($0, {
       description: toSharkUIOutput_Image.Description.all(givenInputText),
     }))
-    .map($0 => TextToImage_Pipeline.Output_Nullable.from($0));
+    .map($0 => TextToImage_Pipeline.Output.Nullable.from($0));
 
   return inferredOutputs;
 };

--- a/src/features/TextToImage/Pipeline/Output/definition.ts
+++ b/src/features/TextToImage/Pipeline/Output/definition.ts
@@ -2,11 +2,19 @@ import type {
   TextToImage_Pipeline_Output_Image,
 } from './Image';
 
+import {
+  TextToImage_Pipeline_Output_Nullable,
+} from './Nullable';
+
 /** The resulting information after a text-to-image model has ingested some input with some configuration */
 interface TextToImage_Pipeline_Output {
   image: TextToImage_Pipeline_Output_Image;
 }
 
-export type {
+const TextToImage_Pipeline_Output = {
+  Nullable: TextToImage_Pipeline_Output_Nullable,
+};
+
+export {
   TextToImage_Pipeline_Output,
 };

--- a/src/features/TextToImage/Pipeline/Output/exports_objectOriented.ts
+++ b/src/features/TextToImage/Pipeline/Output/exports_objectOriented.ts
@@ -1,5 +1,1 @@
-export type * from './definition.ts';
-
-export {
-  TextToImage_Pipeline_Output_Nullable,
-} from './Nullable';
+export * from './definition.ts';

--- a/src/features/TextToImage/Pipeline/namespaceMembers.ts
+++ b/src/features/TextToImage/Pipeline/namespaceMembers.ts
@@ -2,6 +2,5 @@ export type {
   TextToImage_Pipeline_Input as Input,
 } from './Input';
 export {
-  type TextToImage_Pipeline_Output as Output,
-  /**/ TextToImage_Pipeline_Output_Nullable as Output_Nullable,
+  TextToImage_Pipeline_Output as Output,
 } from './Output';

--- a/src/library/Attempt/Error/assertActionable.ts
+++ b/src/library/Attempt/Error/assertActionable.ts
@@ -16,7 +16,7 @@ import {
 
 import {
   type AppropriatelyThrown,
-  PotentiallyActionable_assume,
+  PotentiallyActionable,
 } from './modifier';
 
 const Attempt_Error_Actionable_from = <
@@ -29,7 +29,7 @@ const Attempt_Error_Actionable_from = <
     using: Attempt_Error_Interpreter<SomeActionableError>;
   },
 ): SomeActionableError => {
-  const potentiallyActionableError = PotentiallyActionable_assume(givenError);
+  const potentiallyActionableError = PotentiallyActionable.assume(givenError);
   const definitelyActionableError = interpretationOf(potentiallyActionableError);
 
   if (

--- a/src/library/Attempt/Error/modifier/AppropriatelyThrown/definition.ts
+++ b/src/library/Attempt/Error/modifier/AppropriatelyThrown/definition.ts
@@ -2,6 +2,10 @@ import type {
   Attempt_Error_Actionable,
 } from '../../Actionable';
 
+import {
+  AppropriatelyThrown_assume,
+} from './assume';
+
 type AppropriatelyThrown<
   SomeError extends Error,
 > = Exclude<
@@ -9,6 +13,10 @@ type AppropriatelyThrown<
   Attempt_Error_Actionable<string>
 >;
 
-export type {
+const AppropriatelyThrown = {
+  assume: AppropriatelyThrown_assume,
+};
+
+export {
   AppropriatelyThrown,
 };

--- a/src/library/Attempt/Error/modifier/AppropriatelyThrown/exports_objectOriented.ts
+++ b/src/library/Attempt/Error/modifier/AppropriatelyThrown/exports_objectOriented.ts
@@ -1,7 +1,3 @@
-export type {
+export {
   AppropriatelyThrown,
 } from './definition.ts';
-
-export {
-  AppropriatelyThrown_assume,
-} from './assume';

--- a/src/library/Attempt/Error/modifier/AppropriatelyThrown/index.ts
+++ b/src/library/Attempt/Error/modifier/AppropriatelyThrown/index.ts
@@ -1,4 +1,3 @@
 export {
-  type AppropriatelyThrown,
-  AppropriatelyThrown_assume,
+  AppropriatelyThrown,
 } from './exports_objectOriented.ts';

--- a/src/library/Attempt/Error/modifier/PotentiallyActionable/definition.ts
+++ b/src/library/Attempt/Error/modifier/PotentiallyActionable/definition.ts
@@ -2,10 +2,18 @@ import type {
   Attempt_Error_NonActionable,
 } from '../../NonActionable';
 
+import {
+  PotentiallyActionable_assume,
+} from './assume';
+
 type PotentiallyActionable<
   SomeError extends Error,
 > = Exclude<SomeError, Attempt_Error_NonActionable>;
 
-export type {
+const PotentiallyActionable = {
+  assume: PotentiallyActionable_assume,
+};
+
+export {
   PotentiallyActionable,
 };

--- a/src/library/Attempt/Error/modifier/PotentiallyActionable/exports_objectOriented.ts
+++ b/src/library/Attempt/Error/modifier/PotentiallyActionable/exports_objectOriented.ts
@@ -1,7 +1,3 @@
-export type {
+export {
   PotentiallyActionable,
 } from './definition.ts';
-
-export {
-  PotentiallyActionable_assume,
-} from './assume';

--- a/src/library/Attempt/Error/modifier/PotentiallyActionable/index.ts
+++ b/src/library/Attempt/Error/modifier/PotentiallyActionable/index.ts
@@ -1,4 +1,3 @@
 export {
-  type PotentiallyActionable,
-  PotentiallyActionable_assume,
+  PotentiallyActionable,
 } from './exports_objectOriented.ts';

--- a/src/library/Attempt/Error/modifier/exports_toolbox.ts
+++ b/src/library/Attempt/Error/modifier/exports_toolbox.ts
@@ -1,6 +1,5 @@
 export {
-  type AppropriatelyThrown,
-  AppropriatelyThrown_assume,
+  AppropriatelyThrown,
 } from './AppropriatelyThrown';
 
 export {

--- a/src/library/Attempt/Error/modifier/exports_toolbox.ts
+++ b/src/library/Attempt/Error/modifier/exports_toolbox.ts
@@ -4,6 +4,5 @@ export {
 } from './AppropriatelyThrown';
 
 export {
-  type PotentiallyActionable,
-  PotentiallyActionable_assume,
+  PotentiallyActionable,
 } from './PotentiallyActionable';

--- a/src/library/Attempt/Outcome/Failure/Cause/Transformer/definition.ts
+++ b/src/library/Attempt/Outcome/Failure/Cause/Transformer/definition.ts
@@ -2,6 +2,10 @@ import type {
   Attempt_Error,
 } from '@/library/Attempt/Error'; // eslint-disable-line import/no-internal-modules -- avoids lengthy relative paths
 
+import {
+  Attempt_Outcome_Failure_Cause_Transformer_identity,
+} from './identity';
+
 type Attempt_Outcome_Failure_Cause_Transformer<
   SomeTransformableActionableError extends Attempt_Error.Actionable<string>,
   SomeTransformedActionableError extends Attempt_Error.Actionable<string>,
@@ -9,6 +13,10 @@ type Attempt_Outcome_Failure_Cause_Transformer<
   transformableCause: SomeTransformableActionableError,
 ) => SomeTransformedActionableError;
 
-export type {
+const Attempt_Outcome_Failure_Cause_Transformer = {
+  identity: Attempt_Outcome_Failure_Cause_Transformer_identity,
+};
+
+export {
   Attempt_Outcome_Failure_Cause_Transformer,
 };

--- a/src/library/Attempt/Outcome/Failure/Cause/Transformer/exports_objectOriented.ts
+++ b/src/library/Attempt/Outcome/Failure/Cause/Transformer/exports_objectOriented.ts
@@ -1,5 +1,1 @@
-export type * from './definition.ts';
-
-export {
-  Attempt_Outcome_Failure_Cause_Transformer_identity,
-} from './identity';
+export * from './definition.ts';

--- a/src/library/Attempt/Outcome/Failure/Cause/namespaceMembers.ts
+++ b/src/library/Attempt/Outcome/Failure/Cause/namespaceMembers.ts
@@ -1,4 +1,3 @@
 export {
-  type Attempt_Outcome_Failure_Cause_Transformer as Transformer,
-  Attempt_Outcome_Failure_Cause_Transformer_identity as Transformer_identity,
+  Attempt_Outcome_Failure_Cause_Transformer as Transformer,
 } from './Transformer';

--- a/src/library/Attempt/Outcome/Failure/dueTo.ts
+++ b/src/library/Attempt/Outcome/Failure/dueTo.ts
@@ -28,7 +28,7 @@ const Attempt_Outcome_Failure_dueTo = <
     {
       cause: transformed,
     } = {
-      cause: Attempt_Outcome_Failure_Cause.Transformer_identity<
+      cause: Attempt_Outcome_Failure_Cause.Transformer.identity<
         SomeActionableError,
         SomeTransformedActionableError
       >,

--- a/src/library/Attempt/Outcome/Success/Product/Transformer/definition.ts
+++ b/src/library/Attempt/Outcome/Success/Product/Transformer/definition.ts
@@ -1,3 +1,7 @@
+import {
+  Attempt_Outcome_Success_Product_Transformer_identity,
+} from './identity';
+
 type Attempt_Outcome_Success_Product_Transformer<
   SomeTransformableProduct,
   SomeTransformedProduct,
@@ -5,6 +9,10 @@ type Attempt_Outcome_Success_Product_Transformer<
   transformableProduct: SomeTransformableProduct,
 ) => SomeTransformedProduct;
 
-export type {
+const Attempt_Outcome_Success_Product_Transformer = {
+  identity: Attempt_Outcome_Success_Product_Transformer_identity,
+};
+
+export {
   Attempt_Outcome_Success_Product_Transformer,
 };

--- a/src/library/Attempt/Outcome/Success/Product/Transformer/exports_objectOriented.ts
+++ b/src/library/Attempt/Outcome/Success/Product/Transformer/exports_objectOriented.ts
@@ -1,5 +1,1 @@
-export type * from './definition.ts';
-
-export {
-  Attempt_Outcome_Success_Product_Transformer_identity,
-} from './identity';
+export * from './definition.ts';

--- a/src/library/Attempt/Outcome/Success/Product/namespaceMembers.ts
+++ b/src/library/Attempt/Outcome/Success/Product/namespaceMembers.ts
@@ -1,4 +1,3 @@
 export {
-  type Attempt_Outcome_Success_Product_Transformer as Transformer,
-  Attempt_Outcome_Success_Product_Transformer_identity as Transformer_identity,
+  Attempt_Outcome_Success_Product_Transformer as Transformer,
 } from './Transformer';

--- a/src/library/Attempt/Outcome/Success/thatYielded.ts
+++ b/src/library/Attempt/Outcome/Success/thatYielded.ts
@@ -24,7 +24,7 @@ const Attempt_Outcome_Success_thatYielded = <
     {
       product: transformed,
     } = {
-      product: Attempt_Outcome_Success_Product.Transformer_identity<
+      product: Attempt_Outcome_Success_Product.Transformer.identity<
         SomeProduct,
         SomeTransformedProduct
       >,

--- a/src/library/Attempt/Outcome/fromRewrapping.ts
+++ b/src/library/Attempt/Outcome/fromRewrapping.ts
@@ -80,7 +80,7 @@ function Attempt_Outcome_fromRewrapping<
     SomeTransformableActionableError
   >,
   {
-    product: toTransformedProduct = Attempt_Outcome_Success.Product.Transformer_identity<
+    product: toTransformedProduct = Attempt_Outcome_Success.Product.Transformer.identity<
       SomeTransformableProduct,
       SomeTransformedProduct
     >,
@@ -94,7 +94,7 @@ function Attempt_Outcome_fromRewrapping<
     SomeTransformedProduct,
     SomeTransformedActionableError
   > = {
-    product: Attempt_Outcome_Success.Product.Transformer_identity<
+    product: Attempt_Outcome_Success.Product.Transformer.identity<
       SomeTransformableProduct,
       SomeTransformedProduct
     >,

--- a/src/library/Attempt/Outcome/fromRewrapping.ts
+++ b/src/library/Attempt/Outcome/fromRewrapping.ts
@@ -84,7 +84,7 @@ function Attempt_Outcome_fromRewrapping<
       SomeTransformableProduct,
       SomeTransformedProduct
     >,
-    cause: toTransformedCause = Attempt_Outcome_Failure.Cause.Transformer_identity<
+    cause: toTransformedCause = Attempt_Outcome_Failure.Cause.Transformer.identity<
       SomeTransformableActionableError,
       SomeTransformedActionableError
     >,
@@ -98,7 +98,7 @@ function Attempt_Outcome_fromRewrapping<
       SomeTransformableProduct,
       SomeTransformedProduct
     >,
-    cause: Attempt_Outcome_Failure.Cause.Transformer_identity<
+    cause: Attempt_Outcome_Failure.Cause.Transformer.identity<
       SomeTransformableActionableError,
       SomeTransformedActionableError
     >,

--- a/src/library/Attempt/tryCatchStatements/safe.ts
+++ b/src/library/Attempt/tryCatchStatements/safe.ts
@@ -3,8 +3,7 @@ import {
 } from '@/library/utilitiesByType/error';
 
 import {
-  type AppropriatelyThrown,
-  AppropriatelyThrown_assume,
+  AppropriatelyThrown,
 } from '../Error';
 
 const safe = <
@@ -25,7 +24,7 @@ const safe = <
   }
   catch (whateverThatWasThrown) {
     const someError = asError(whateverThatWasThrown);
-    const someAppropriatelyThrownError = AppropriatelyThrown_assume(someError);
+    const someAppropriatelyThrownError = AppropriatelyThrown.assume(someError);
     return catchBlockOutputFor(someAppropriatelyThrownError);
   }
 };


### PR DESCRIPTION
- by merging these targeted types with an object literal, it was possible to:
  - enables the dot syntax that's consistent with the rest of the codebase
  - streamline the object-oriented re-exports within these modules
  - streamline the import from these modules