### PR TITLE
refactor: ensures all index files have re-exports only

### DIFF
--- a/src/features/TextToImage/Client/SDXL/index.ts
+++ b/src/features/TextToImage/Client/SDXL/index.ts
@@ -1,7 +1,3 @@
-import {
-  TextToImage_Client_SDXL,
-} from './exports_objectOriented.ts';
-
 export {
   TextToImage_Client_SDXL,
-};
+} from './exports_objectOriented.ts';

--- a/src/features/TextToImage/index.ts
+++ b/src/features/TextToImage/index.ts
@@ -1,7 +1,3 @@
-import {
-  TextToImage,
-} from './exports_objectOriented.ts';
-
 export {
   TextToImage as default,
-};
+} from './exports_objectOriented.ts';

--- a/src/library/Attempt/index.ts
+++ b/src/library/Attempt/index.ts
@@ -1,7 +1,3 @@
-import {
-  Attempt,
-} from './exports_objectOriented.ts';
-
 export {
   Attempt as default,
-};
+} from './exports_objectOriented.ts';

--- a/src/library/HTTP/index.ts
+++ b/src/library/HTTP/index.ts
@@ -1,7 +1,3 @@
-import {
-  HTTP,
-} from './exports_objectOriented.ts';
-
 export {
   HTTP as default,
-};
+} from './exports_objectOriented.ts';

--- a/src/library/Parse/index.ts
+++ b/src/library/Parse/index.ts
@@ -1,7 +1,3 @@
-import {
-  Parse,
-} from './exports_objectOriented.ts';
-
 export {
   Parse as default,
-};
+} from './exports_objectOriented.ts';

--- a/src/library/Schema/index.ts
+++ b/src/library/Schema/index.ts
@@ -1,7 +1,3 @@
-import {
-  Schema,
-} from './exports_objectOriented.ts';
-
 export {
   Schema as default,
-};
+} from './exports_objectOriented.ts';

--- a/src/library/Sequence/index.ts
+++ b/src/library/Sequence/index.ts
@@ -1,7 +1,3 @@
-import {
-  Sequence,
-} from './exports_objectOriented.ts';
-
 export {
   Sequence as default,
-};
+} from './exports_objectOriented.ts';

--- a/src/library/Shortfin/index.ts
+++ b/src/library/Shortfin/index.ts
@@ -1,7 +1,3 @@
-import {
-  Shortfin,
-} from './exports_objectOriented.ts';
-
 export {
   Shortfin as default,
-};
+} from './exports_objectOriented.ts';

--- a/src/library/URLComponent/index.ts
+++ b/src/library/URLComponent/index.ts
@@ -1,7 +1,3 @@
-import {
-  URLComponent,
-} from './exports_objectOriented.ts';
-
 export {
   URLComponent as default,
-};
+} from './exports_objectOriented.ts';

--- a/src/library/WebAPI/index.ts
+++ b/src/library/WebAPI/index.ts
@@ -1,7 +1,3 @@
-import {
-  WebAPI,
-} from './exports_objectOriented.ts';
-
 export {
   WebAPI as default,
-};
+} from './exports_objectOriented.ts';


### PR DESCRIPTION
- index files are only responsible for the "presentation" of the module, i.e. determining the `default` export, if applicable
- since these files should never hold any implementation of their own, there's no need to split the re-exports with both an `import` and `export` expression