### PR TITLE
refactor(library/vue): avoids consumption of 3rd party libraries within exports

### DIFF
--- a/src/library/vue/Reactive.ts
+++ b/src/library/vue/Reactive.ts
@@ -1,0 +1,4 @@
+export {
+  reactive,
+  type Reactive,
+} from 'vue';

--- a/src/library/vue/app.ts
+++ b/src/library/vue/app.ts
@@ -1,0 +1,3 @@
+export {
+  createApp,
+} from 'vue';

--- a/src/library/vue/component.ts
+++ b/src/library/vue/component.ts
@@ -1,0 +1,3 @@
+export {
+  type DefineComponent,
+} from 'vue';

--- a/src/library/vue/exports_toolbox.ts
+++ b/src/library/vue/exports_toolbox.ts
@@ -1,8 +1,6 @@
 export {
   createApp,
   type DefineComponent,
-  reactive,
-  type Reactive,
 } from 'vue';
 
 export {
@@ -11,6 +9,8 @@ export {
   get,
   set,
 } from './Ref';
+
+export * from './Reactive';
 
 export * from './watchers';
 

--- a/src/library/vue/exports_toolbox.ts
+++ b/src/library/vue/exports_toolbox.ts
@@ -3,7 +3,6 @@ export {
   type DefineComponent,
   reactive,
   type Reactive,
-  watch,
 } from 'vue';
 
 export {
@@ -12,5 +11,7 @@ export {
   get,
   set,
 } from './Ref';
+
+export * from './watchers';
 
 export * from './composables';

--- a/src/library/vue/exports_toolbox.ts
+++ b/src/library/vue/exports_toolbox.ts
@@ -1,7 +1,8 @@
 export {
   createApp,
-  type DefineComponent,
 } from 'vue';
+
+export type * from './component';
 
 export {
   type Ref,

--- a/src/library/vue/exports_toolbox.ts
+++ b/src/library/vue/exports_toolbox.ts
@@ -1,6 +1,4 @@
-export {
-  createApp,
-} from 'vue';
+export * from './app';
 
 export type * from './component';
 

--- a/src/library/vue/watchers.ts
+++ b/src/library/vue/watchers.ts
@@ -1,0 +1,3 @@
+export {
+  watch,
+} from 'vue';


### PR DESCRIPTION
- "exports_*.ts" files should only determine which modules are exposed to external modules
- they should not cherry pick from modules because that's a job for each respective "exports_*.ts" file
- effectively categorizes re-exports along conceptual boundaries