### PR TITLE
refactor: avoids useless cherry-picking in all barrel files

### DIFF
--- a/src/features/TextToImage/Client/SDXL/index.ts
+++ b/src/features/TextToImage/Client/SDXL/index.ts
@@ -1,3 +1,1 @@
-export {
-  TextToImage_Client_SDXL,
-} from './exports_objectOriented.ts';
+export * from './exports_objectOriented.ts';

--- a/src/library/Attempt/Error/NonActionable/exports_objectOriented.ts
+++ b/src/library/Attempt/Error/NonActionable/exports_objectOriented.ts
@@ -1,3 +1,1 @@
-export {
-  Attempt_Error_NonActionable,
-} from './definition.ts';
+export * from './definition.ts';

--- a/src/library/Attempt/Error/NonActionable/index.ts
+++ b/src/library/Attempt/Error/NonActionable/index.ts
@@ -1,3 +1,1 @@
-export {
-  Attempt_Error_NonActionable,
-} from './exports_objectOriented.ts';
+export * from './exports_objectOriented.ts';

--- a/src/library/Attempt/Error/NonActionableBuiltInError/exports_objectOriented.ts
+++ b/src/library/Attempt/Error/NonActionableBuiltInError/exports_objectOriented.ts
@@ -1,3 +1,1 @@
-export {
-  NonActionableBuiltInError,
-} from './definition.ts';
+export * from './definition.ts';

--- a/src/library/Attempt/Error/NonActionableBuiltInError/index.ts
+++ b/src/library/Attempt/Error/NonActionableBuiltInError/index.ts
@@ -1,3 +1,1 @@
-export {
-  NonActionableBuiltInError,
-} from './exports_objectOriented.ts';
+export * from './exports_objectOriented.ts';

--- a/src/library/Attempt/Error/modifier/AppropriatelyThrown/exports_objectOriented.ts
+++ b/src/library/Attempt/Error/modifier/AppropriatelyThrown/exports_objectOriented.ts
@@ -1,3 +1,1 @@
-export {
-  AppropriatelyThrown,
-} from './definition.ts';
+export * from './definition.ts';

--- a/src/library/Attempt/Error/modifier/AppropriatelyThrown/index.ts
+++ b/src/library/Attempt/Error/modifier/AppropriatelyThrown/index.ts
@@ -1,3 +1,1 @@
-export {
-  AppropriatelyThrown,
-} from './exports_objectOriented.ts';
+export * from './exports_objectOriented.ts';

--- a/src/library/Attempt/Error/modifier/PotentiallyActionable/exports_objectOriented.ts
+++ b/src/library/Attempt/Error/modifier/PotentiallyActionable/exports_objectOriented.ts
@@ -1,3 +1,1 @@
-export {
-  PotentiallyActionable,
-} from './definition.ts';
+export * from './definition.ts';

--- a/src/library/Attempt/Error/modifier/PotentiallyActionable/index.ts
+++ b/src/library/Attempt/Error/modifier/PotentiallyActionable/index.ts
@@ -1,3 +1,1 @@
-export {
-  PotentiallyActionable,
-} from './exports_objectOriented.ts';
+export * from './exports_objectOriented.ts';

--- a/src/library/Attempt/Error/modifier/exports_toolbox.ts
+++ b/src/library/Attempt/Error/modifier/exports_toolbox.ts
@@ -1,7 +1,3 @@
-export {
-  AppropriatelyThrown,
-} from './AppropriatelyThrown';
+export * from './AppropriatelyThrown';
 
-export {
-  PotentiallyActionable,
-} from './PotentiallyActionable';
+export * from './PotentiallyActionable';

--- a/src/library/ContentDescriptor/exports_objectOriented.ts
+++ b/src/library/ContentDescriptor/exports_objectOriented.ts
@@ -1,3 +1,1 @@
-export {
-  ContentDescriptor,
-} from './definition.ts';
+export * from './definition.ts';

--- a/src/library/NonTrivialString/exports_objectOriented.ts
+++ b/src/library/NonTrivialString/exports_objectOriented.ts
@@ -1,3 +1,1 @@
-export {
-  NonTrivialString,
-} from './definitionWithAugmentation.ts';
+export * from './definitionWithAugmentation.ts';

--- a/src/library/Range/exports_objectOriented.ts
+++ b/src/library/Range/exports_objectOriented.ts
@@ -1,3 +1,1 @@
-export {
-  Range,
-} from './definitionWithAugmentation.ts';
+export * from './definitionWithAugmentation.ts';

--- a/src/library/Sequence/Byte/Encoded/Base64/exports_objectOriented.ts
+++ b/src/library/Sequence/Byte/Encoded/Base64/exports_objectOriented.ts
@@ -1,3 +1,1 @@
-export {
-  Sequence_Byte_Encoded_Base64,
-} from './definitionWithAugmentation.ts';
+export * from './definitionWithAugmentation.ts';

--- a/src/library/ShimmedStabilityAIClient/exports_objectOriented.ts
+++ b/src/library/ShimmedStabilityAIClient/exports_objectOriented.ts
@@ -1,3 +1,1 @@
-export {
-  ShimmedStabilityAIClient,
-} from './definition.ts';
+export * from './definition.ts';

--- a/src/library/ShimmedStabilityAIClient/toShortfinRequestBody/exports_objectOriented.ts
+++ b/src/library/ShimmedStabilityAIClient/toShortfinRequestBody/exports_objectOriented.ts
@@ -1,3 +1,1 @@
-export {
-  toShortfinRequestBody,
-} from './definitionWithAugmentation.ts';
+export * from './definitionWithAugmentation.ts';

--- a/src/library/ShimmedStabilityAIClient/toShortfinRequestBody/index.ts
+++ b/src/library/ShimmedStabilityAIClient/toShortfinRequestBody/index.ts
@@ -1,3 +1,1 @@
-export {
-  toShortfinRequestBody,
-} from './exports_objectOriented.ts';
+export * from './exports_objectOriented.ts';

--- a/src/library/Shortfin/TextToImage/SDXL/Client/Request/Body/exports_objectOriented.ts
+++ b/src/library/Shortfin/TextToImage/SDXL/Client/Request/Body/exports_objectOriented.ts
@@ -1,3 +1,1 @@
-export {
-  Shortfin_TextToImage_SDXL_Client_Request_Body,
-} from './definitionWithAugmentation.ts';
+export * from './definitionWithAugmentation.ts';

--- a/src/library/URI/Image/exports_objectOriented.ts
+++ b/src/library/URI/Image/exports_objectOriented.ts
@@ -1,3 +1,1 @@
-export {
-  URI_Image,
-} from './definition.ts';
+export * from './definition.ts';

--- a/src/library/URI/Image/index.ts
+++ b/src/library/URI/Image/index.ts
@@ -1,3 +1,1 @@
-export {
-  URI_Image,
-} from './exports_objectOriented.ts';
+export * from './exports_objectOriented.ts';

--- a/src/library/modifiersByType/error/Contextualized/exports_objectOriented.ts
+++ b/src/library/modifiersByType/error/Contextualized/exports_objectOriented.ts
@@ -1,3 +1,1 @@
-export {
-  Contextualized,
-} from './definition.ts';
+export * from './definition.ts';

--- a/src/library/modifiersByType/error/Contextualized/index.ts
+++ b/src/library/modifiersByType/error/Contextualized/index.ts
@@ -1,3 +1,1 @@
-export {
-  Contextualized,
-} from './exports_objectOriented.ts';
+export * from './exports_objectOriented.ts';

--- a/src/library/modifiersByType/error/exports_toolbox.ts
+++ b/src/library/modifiersByType/error/exports_toolbox.ts
@@ -1,3 +1,1 @@
-export {
-  Contextualized,
-} from './Contextualized';
+export * from './Contextualized';

--- a/src/library/typeUtilities/exports_toolbox.ts
+++ b/src/library/typeUtilities/exports_toolbox.ts
@@ -4,8 +4,6 @@ export type * from './Instantiable';
 
 export type * from './Batched';
 
-export type {
-  Static,
-} from './Static';
+export type * from './Static';
 
 export type * from './Branded';

--- a/src/library/vue/exports_toolbox.ts
+++ b/src/library/vue/exports_toolbox.ts
@@ -2,12 +2,7 @@ export * from './app';
 
 export type * from './component';
 
-export {
-  type Ref,
-  ref,
-  get,
-  set,
-} from './Ref';
+export * from './Ref';
 
 export * from './Reactive';
 

--- a/src/utilities/Repository/exports_objectOriented.ts
+++ b/src/utilities/Repository/exports_objectOriented.ts
@@ -1,3 +1,1 @@
-export {
-  Repository,
-} from './definition.ts';
+export * from './definition.ts';


### PR DESCRIPTION
- "index.ts" files should only call out an individual symbol from an export to make it as `default`
- "exports_*.ts" files should only determine which modules are exposed to external modules
- neither of these should cherry pick from modules because that's a job for each respective "exports_*.ts" file