### PR TITLE
linter: enforces padding between exports

### DIFF
--- a/eslint.stylistic.ts
+++ b/eslint.stylistic.ts
@@ -58,6 +58,14 @@ const extraConfig: ConfigWithExtends = {
         },
       },
     ],
+    '@stylistic/padding-line-between-statements': [
+      'error',
+      {
+        blankLine: 'always', // Each of these statements should be padded to look like an "island" since they will never express an order-sensitive procedure
+        prev     : 'export',
+        next     : 'export',
+      },
+    ],
   },
 };
 

--- a/src/features/TextToImage/Config/namespaceMembers.ts
+++ b/src/features/TextToImage/Config/namespaceMembers.ts
@@ -5,9 +5,11 @@ export {
 export {
   TextToImage_Config_Dynamic as Dynamic,
 } from './Dynamic';
+
 export {
   TextToImage_Config_Static as Static,
 } from './Static';
+
 export {
   TextToImage_Config_empty as empty,
 } from './empty';

--- a/src/features/TextToImage/Pipeline/namespaceMembers.ts
+++ b/src/features/TextToImage/Pipeline/namespaceMembers.ts
@@ -1,6 +1,7 @@
 export type {
   TextToImage_Pipeline_Input as Input,
 } from './Input';
+
 export {
   TextToImage_Pipeline_Output as Output,
 } from './Output';

--- a/src/library/Attempt/Fresh/namespaceMembers.ts
+++ b/src/library/Attempt/Fresh/namespaceMembers.ts
@@ -1,6 +1,7 @@
 export {
   Attempt_Fresh_that as that,
 } from './that';
+
 export {
   Attempt_Fresh_thatEventually as thatEventually,
 } from './thatEventually';

--- a/src/library/URLComponent/namespaceMembers.ts
+++ b/src/library/URLComponent/namespaceMembers.ts
@@ -1,6 +1,7 @@
 export {
   URLComponent_Origin as Origin,
 } from './Origin';
+
 export {
   URLComponent_Path as Path,
 } from './Path';


### PR DESCRIPTION
- Each export statement is an "island"; they will never express an order-sensitive procedure
- hence, they should be padded to _look_ like an "island"