### PR TITLE
refactor: avoids ".ts" file extensions for "structure-agnostic" modules

### DIFF
--- a/src/components/DiscreteSlider.vue
+++ b/src/components/DiscreteSlider.vue
@@ -20,7 +20,7 @@ import Range from '@/library/Range';
 
 import {
   shallowlyMerged,
-} from '@/library/utilitiesByType/record.ts';
+} from '@/library/utilitiesByType/record';
 
 const currentValue = defineModel<number>({
   required: true,

--- a/src/library/NonTrivialString/definition.ts
+++ b/src/library/NonTrivialString/definition.ts
@@ -10,7 +10,7 @@ import {
 
 import {
   NonTrivialString_ParsingError,
-} from './ParsingError.ts';
+} from './ParsingError';
 
 class NonTrivialString
   extends StringSubset<

--- a/src/library/Sequence/Byte/Encoded/Base64/definition.ts
+++ b/src/library/Sequence/Byte/Encoded/Base64/definition.ts
@@ -20,7 +20,7 @@ import {
 
 import {
   Sequence_Byte_Encoded_Base64_ParsingError,
-} from './ParsingError.ts';
+} from './ParsingError';
 
 /** See [RFC 4648 Section 4](https://www.rfc-editor.org/rfc/rfc4648.html#section-4) for more information */
 class Sequence_Byte_Encoded_Base64

--- a/src/library/WebAPI/namespaceMembers.ts
+++ b/src/library/WebAPI/namespaceMembers.ts
@@ -1,3 +1,3 @@
 export {
   WebAPI_Server as Server,
-} from './Server.ts';
+} from './Server';

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,7 +7,7 @@ import {
 } from '@/library/utilitiesByType/error';
 
 import App from '@/App.vue';
-import vuetify from '@/plugins/vuetify.ts';
+import vuetify from '@/plugins/vuetify';
 import router from '@/router';
 
 import {


### PR DESCRIPTION
Conforms to precedent set by #608