### PR TITLE
refactor: ensures remaining exposed augmentations are registered

### DIFF
--- a/src/library/Attempt/Error/NonActionable/definitionAugmentation.ts
+++ b/src/library/Attempt/Error/NonActionable/definitionAugmentation.ts
@@ -1,0 +1,11 @@
+import type {
+  Attempt_Error_NonActionable_Options,
+} from './Options';
+
+declare module './definition.ts' {
+  namespace Attempt_Error_NonActionable {
+    export {
+      type Attempt_Error_NonActionable_Options as Options,
+    };
+  }
+}

--- a/src/library/Attempt/Error/NonActionable/definitionWithAugmentation.ts
+++ b/src/library/Attempt/Error/NonActionable/definitionWithAugmentation.ts
@@ -1,0 +1,3 @@
+import './definitionAugmentation.ts';
+
+export * from './definition.ts';

--- a/src/library/Attempt/Error/NonActionable/exports_objectOriented.ts
+++ b/src/library/Attempt/Error/NonActionable/exports_objectOriented.ts
@@ -1,1 +1,1 @@
-export * from './definition.ts';
+export * from './definitionWithAugmentation.ts';

--- a/src/library/ContentDescriptor/definitionAugmentation.ts
+++ b/src/library/ContentDescriptor/definitionAugmentation.ts
@@ -1,0 +1,23 @@
+import {
+  ContentDescriptor_StructuredSyntaxNameSuffix,
+} from './StructuredSyntaxNameSuffix';
+
+import {
+  ContentDescriptor_TopLevel,
+} from './TopLevel';
+
+import {
+  ContentDescriptor,
+} from './definition.ts';
+
+ContentDescriptor.TopLevel /*             */ = ContentDescriptor_TopLevel;
+ContentDescriptor.StructuredSyntaxNameSuffix = ContentDescriptor_StructuredSyntaxNameSuffix;
+
+declare module './definition.ts' {
+  namespace ContentDescriptor {
+    export {
+      ContentDescriptor_TopLevel /*             */ as TopLevel,
+      ContentDescriptor_StructuredSyntaxNameSuffix as StructuredSyntaxNameSuffix,
+    };
+  }
+}

--- a/src/library/ContentDescriptor/definitionWithAugmentation.ts
+++ b/src/library/ContentDescriptor/definitionWithAugmentation.ts
@@ -1,0 +1,3 @@
+import './definitionAugmentation.ts';
+
+export * from './definition.ts';

--- a/src/library/ContentDescriptor/exports_objectOriented.ts
+++ b/src/library/ContentDescriptor/exports_objectOriented.ts
@@ -1,1 +1,1 @@
-export * from './definition.ts';
+export * from './definitionWithAugmentation.ts';

--- a/src/library/ShimmedStabilityAIClient/Version1/definitionAugmentation.ts
+++ b/src/library/ShimmedStabilityAIClient/Version1/definitionAugmentation.ts
@@ -1,0 +1,11 @@
+import type {
+  ShimmedStabilityAIClient_Version1_Image,
+} from './Image';
+
+declare module './definition.ts' {
+  namespace ShimmedStabilityAIClient_Version1 {
+    export {
+      type ShimmedStabilityAIClient_Version1_Image as Image,
+    };
+  }
+}

--- a/src/library/ShimmedStabilityAIClient/Version1/definitionWithAugmentation.ts
+++ b/src/library/ShimmedStabilityAIClient/Version1/definitionWithAugmentation.ts
@@ -1,0 +1,3 @@
+import './definitionAugmentation.ts';
+
+export * from './definition.ts';

--- a/src/library/ShimmedStabilityAIClient/Version1/exports_objectOriented.ts
+++ b/src/library/ShimmedStabilityAIClient/Version1/exports_objectOriented.ts
@@ -1,1 +1,1 @@
-export * from './definition.ts';
+export * from './definitionWithAugmentation.ts';

--- a/src/library/ShimmedStabilityAIClient/definitionAugmentation.ts
+++ b/src/library/ShimmedStabilityAIClient/definitionAugmentation.ts
@@ -1,0 +1,11 @@
+import type {
+  ShimmedStabilityAIClient_Version1,
+} from './Version1';
+
+declare module './definition.ts' {
+  namespace ShimmedStabilityAIClient {
+    export {
+      type ShimmedStabilityAIClient_Version1 as Version1,
+    };
+  }
+}

--- a/src/library/ShimmedStabilityAIClient/definitionWithAugmentation.ts
+++ b/src/library/ShimmedStabilityAIClient/definitionWithAugmentation.ts
@@ -1,0 +1,3 @@
+import './definitionAugmentation.ts';
+
+export * from './definition.ts';

--- a/src/library/ShimmedStabilityAIClient/exports_objectOriented.ts
+++ b/src/library/ShimmedStabilityAIClient/exports_objectOriented.ts
@@ -1,1 +1,1 @@
-export * from './definition.ts';
+export * from './definitionWithAugmentation.ts';

--- a/src/library/URI/Image/definitionAugmentation.ts
+++ b/src/library/URI/Image/definitionAugmentation.ts
@@ -1,0 +1,17 @@
+import {
+  URI_Image_Format,
+} from './Format';
+
+import {
+  URI_Image,
+} from './definition.ts';
+
+URI_Image.Format = URI_Image_Format;
+
+declare module './definition.ts' {
+  namespace URI_Image {
+    export {
+      URI_Image_Format as Format,
+    };
+  }
+}

--- a/src/library/URI/Image/definitionWithAugmentation.ts
+++ b/src/library/URI/Image/definitionWithAugmentation.ts
@@ -1,0 +1,3 @@
+import './definitionAugmentation.ts';
+
+export * from './definition.ts';

--- a/src/library/URI/Image/exports_objectOriented.ts
+++ b/src/library/URI/Image/exports_objectOriented.ts
@@ -1,1 +1,1 @@
-export * from './definition.ts';
+export * from './definitionWithAugmentation.ts';


### PR DESCRIPTION
- The submodules in some libraries were declared with the intention of exposing them to external modules
- Without this exposure, something that was supposed to be like `URI.Image.Format` would show up like `URI_Image_Format` and would require consumers to reach into internal modules for something that should already be accessible
- These changes implement the augmentations needed to expose these namespace members