### PR TITLE
refactor: avoids blanket type exports in all module augmentations

### DIFF
--- a/src/library/Parsable/definitionAugmentation.ts
+++ b/src/library/Parsable/definitionAugmentation.ts
@@ -4,8 +4,8 @@ import type {
 
 declare module './definition.ts' {
   namespace Parsable {
-    export type {
-      Parsable_String as String,
+    export {
+      type Parsable_String as String,
     };
   }
 }

--- a/src/library/Parser/String/definitionAugmentation.ts
+++ b/src/library/Parser/String/definitionAugmentation.ts
@@ -4,8 +4,8 @@ import type {
 
 declare module './definition.ts' {
   namespace Parser_String {
-    export type {
-      Parser_String_Static as Static,
+    export {
+      type Parser_String_Static as Static,
     };
   }
 }

--- a/src/library/Parser/definitionAugmentation.ts
+++ b/src/library/Parser/definitionAugmentation.ts
@@ -8,9 +8,9 @@ import type {
 
 declare module './definition.ts' {
   namespace Parser {
-    export type {
-      Parser_Static as Static,
-      Parser_String as String,
+    export {
+      type Parser_Static as Static,
+      type Parser_String as String,
     };
   }
 }


### PR DESCRIPTION
- `type` only exports from a given module augmentation risks shadowing the value exports from the definition being augmented
- this can lead to compiler errors
- the line-by-line `type` annotations are guaranteed to avoid this issue without causing any other issues