### PR TITLE
docs(architecture): formalizes module import shapes

### DIFF
--- a/docs/architecture/modules/consumption.md
+++ b/docs/architecture/modules/consumption.md
@@ -4,6 +4,12 @@ This document explores the different shapes that are encountered when importing 
 
 ## Goal
 
+By understanding the various import shapes, contributors will be able to
+
+- choose the most appropriate import style for their use case
+- design the module's public API before writing any implementation
+- structure a new module to support the desired public API
+
 ## Variations of Public APIs
 
 ### Namespaced (Object-Oriented)

--- a/docs/architecture/modules/consumption.md
+++ b/docs/architecture/modules/consumption.md
@@ -1,5 +1,7 @@
 # Consuming Modules
 
+This document explores the different shapes that are encountered when importing and consuming modules created within this project.
+
 ## Goal
 
 ## Variations of Public APIs

--- a/docs/architecture/modules/consumption.md
+++ b/docs/architecture/modules/consumption.md
@@ -79,3 +79,29 @@ import {
 Here, the `ContentDescriptor` module provides both a default export for the primary object and named exports for common aliases.
 
 ## Consumption of Internal Modules
+
+For modules that are internal to a library (i.e., must be explicitly exposed for public consumption), the same principles apply with the exception that `default` exports are avoided.
+
+Consider the import of a hybrid internal module from one of its peers:
+
+```typescript
+// @/library/Attempt/Fresh/that.ts
+
+import {
+  Attempt_Outcome,
+  type ProductOf,
+  type CauseOf,
+} from '../../Outcome';
+
+...
+
+export {
+  Attempt_Fresh_that,
+};
+```
+
+Here, a level-2 member called `Attempt_Outcome` is imported by name into the `Attempt/Fresh/that` module to define a level-3 member called `Attempt_Fresh_that`.
+
+- Both of these are internal modules that will be explicitly exposed as `Attempt.Outcome` and `Attempt.Fresh.that` to external consumers of the entire library.
+- Because of this, it's important for other internal consumers to acknowledge that these members are safe to expose to these external consumers (e.g. when used as parameter types or return types).
+- Ergo, `default` imports/exports are avoided to help peer consumers avoid inadvertent aliases that may obfuscate how a member will actually look to an external consumer.

--- a/docs/architecture/modules/consumption.md
+++ b/docs/architecture/modules/consumption.md
@@ -60,4 +60,22 @@ Here, the `typeUtilities` module also acts as a "toolbox", but the tools are to 
 
 ### Hybrid
 
+Some modules may choose to expose both a primary object and named exports.
+
+```typescript
+import ContentDescriptor from '@/library/ContentDescriptor';
+
+...
+```
+
+```typescript
+import {
+  ContentType,
+} from '@/library/ContentDescriptor';
+
+...
+```
+
+Here, the `ContentDescriptor` module provides both a default export for the primary object and named exports for common aliases.
+
 ## Consumption of Internal Modules

--- a/docs/architecture/modules/consumption.md
+++ b/docs/architecture/modules/consumption.md
@@ -1,0 +1,13 @@
+# Consuming Modules
+
+## Goal
+
+## Variations of Public APIs
+
+### Namespaced (Object-Oriented)
+
+### Toolbox (Functional)
+
+### Hybrid
+
+## Consumption of Internal Modules

--- a/docs/architecture/modules/consumption.md
+++ b/docs/architecture/modules/consumption.md
@@ -14,6 +14,21 @@ By understanding the various import shapes, contributors will be able to
 
 ### Namespaced (Object-Oriented)
 
+Modules that centralize their functionality within a single object-like structure are considered "namespaced". This generally aligns with the pattern commonly seen in object-oriented programming in the sense that members are accessed via dot syntax.
+
+The trademark of a namespaced module is that it exposes its primary object as the default export, for example:
+
+```typescript
+import HTTP from '@/library/HTTP';
+
+// HTTP.Request
+// HTTP.Response
+// HTTP.Endpoint.Error.Request
+// HTTP.Client.send(...)
+```
+
+Here, the `HTTP` module centralizes access to its various members using a single namespace. Depending on the context, these members may be used in the type system, at runtime, or both.
+
 ### Toolbox (Functional)
 
 ### Hybrid

--- a/docs/architecture/modules/consumption.md
+++ b/docs/architecture/modules/consumption.md
@@ -31,6 +31,33 @@ Here, the `HTTP` module centralizes access to its various members using a single
 
 ### Toolbox (Functional)
 
+Modules that expose a collection of related functions without a central object are considered "toolbox" style. This generally aligns with the functional programming paradigm, where public functions are imported and used directly.
+
+```typescript
+import {
+  greatestCommonDivisor,
+  leastCommonMultiple,
+} from '@/library/math';
+
+...
+```
+
+Here, the `math` module acts as a "toolbox", the "tools" being the various mathematical functions it exposes. In cases like this, the tools are to be used at runtime.
+
+This applies to "type functions" as well:
+
+```typescript
+import type {
+  If,
+  Is,
+  Not,
+} from '@/library/typeUtilities';
+
+...
+```
+
+Here, the `typeUtilities` module also acts as a "toolbox", but the tools are to be used in the type system only.
+
 ### Hybrid
 
 ## Consumption of Internal Modules


### PR DESCRIPTION
- discusses how the common object-oriented and functional programming paradigms are expressed in module exports