### PR TITLE
chore(vulnerability): bumps axios from 1.11.0 to 1.12.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3745,9 +3745,9 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.11.0.tgz",
-      "integrity": "sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.2.tgz",
+      "integrity": "sha512-vMJzPewAlRyOgxV2dU0Cuz2O8zzzx9VYtbJOaBgXFeLc4IV/Eg50n4LowmehOOR61S8ZMpc2K5Sa7g6A4jfkUw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
- patches [CVE-2025-58754](https://github.com/advisories/GHSA-4hjh-wcwx-xvwj)