### PR TITLE
refactor(text-to-image): exposes remaining nested namespaces

### DIFF
--- a/src/features/TextToImage/Client/definition.assembled.members.ts
+++ b/src/features/TextToImage/Client/definition.assembled.members.ts
@@ -1,3 +1,7 @@
+export type {
+  TextToImage_Client_Generation as Generation,
+} from './Generation';
+
 export {
   TextToImage_Client_SDXL as SDXL,
 } from './SDXL';

--- a/src/features/TextToImage/Pipeline/Output/definition.declared.augmentation.ts
+++ b/src/features/TextToImage/Pipeline/Output/definition.declared.augmentation.ts
@@ -1,3 +1,7 @@
+import type {
+  TextToImage_Pipeline_Output_Image,
+} from './Image';
+
 import {
   TextToImage_Pipeline_Output_Nullable,
 } from './Nullable';
@@ -11,7 +15,8 @@ TextToImage_Pipeline_Output.Nullable = TextToImage_Pipeline_Output_Nullable;
 declare module './definition.declared.ts' {
   namespace TextToImage_Pipeline_Output {
     export {
-      TextToImage_Pipeline_Output_Nullable as Nullable,
+      /**/ TextToImage_Pipeline_Output_Nullable as Nullable,
+      type TextToImage_Pipeline_Output_Image/**/as Image,
     };
   }
 }

--- a/src/features/TextToImage/Pipeline/Output/definition.declared.augmentation.ts
+++ b/src/features/TextToImage/Pipeline/Output/definition.declared.augmentation.ts
@@ -1,0 +1,17 @@
+import {
+  TextToImage_Pipeline_Output_Nullable,
+} from './Nullable';
+
+import {
+  TextToImage_Pipeline_Output,
+} from './definition.declared.ts';
+
+TextToImage_Pipeline_Output.Nullable = TextToImage_Pipeline_Output_Nullable;
+
+declare module './definition.declared.ts' {
+  namespace TextToImage_Pipeline_Output {
+    export {
+      TextToImage_Pipeline_Output_Nullable as Nullable,
+    };
+  }
+}

--- a/src/features/TextToImage/Pipeline/Output/definition.declared.ts
+++ b/src/features/TextToImage/Pipeline/Output/definition.declared.ts
@@ -1,19 +1,21 @@
+import Attempt from '@/library/Attempt';
+
 import type {
   TextToImage_Pipeline_Output_Image,
 } from './Image';
-
-import {
-  TextToImage_Pipeline_Output_Nullable,
-} from './Nullable';
 
 /** The resulting information after a text-to-image model has ingested some input with some configuration */
 interface TextToImage_Pipeline_Output {
   image: TextToImage_Pipeline_Output_Image;
 }
 
-const TextToImage_Pipeline_Output = {
-  Nullable: TextToImage_Pipeline_Output_Nullable,
-};
+function TextToImage_Pipeline_Output(
+  namespaceOnly: never = Attempt.Error.NonActionable.throw(
+    `Unexpected call of module augmentation provision for ${TextToImage_Pipeline_Output.name}.`,
+  ),
+) {
+  return namespaceOnly;
+}
 
 export {
   TextToImage_Pipeline_Output,

--- a/src/features/TextToImage/Pipeline/Output/definition.declared.withAugmentation.ts
+++ b/src/features/TextToImage/Pipeline/Output/definition.declared.withAugmentation.ts
@@ -1,0 +1,3 @@
+import './definition.declared.augmentation.ts';
+
+export * from './definition.declared.ts';

--- a/src/features/TextToImage/Pipeline/Output/exports.object.primary.ts
+++ b/src/features/TextToImage/Pipeline/Output/exports.object.primary.ts
@@ -1,1 +1,1 @@
-export * from './definition.declared.ts';
+export * from './definition.declared.withAugmentation.ts';


### PR DESCRIPTION
- found while reviewing #1001