### PR TITLE
refactor: avoids cramming error construction into failure callbacks

### DIFF
--- a/src/features/TextToImage/Config/Static/read.ts
+++ b/src/features/TextToImage/Config/Static/read.ts
@@ -17,8 +17,9 @@ const TextToImage_Config_Static_read = (): Promise<
 > => Attempt.Fresh.thatEventually(async (ends) => {
   const fileResponse = await fetch(TextToImage_Config_Static_file.toString());
 
-  if (!fileResponse.ok) { // eslint-disable-line curly
-    return ends.inFailureDueTo(new TextToImage_Config_Static_Reading.Error(TextToImage_Config_Static_file, fileResponse));
+  if (!fileResponse.ok) {
+    const newReadingError = new TextToImage_Config_Static_Reading.Error(TextToImage_Config_Static_file, fileResponse);
+    return ends.inFailureDueTo(newReadingError);
   }
 
   const rawConfig = await fileResponse.json() as unknown;

--- a/src/library/HTTP/Client.ts
+++ b/src/library/HTTP/Client.ts
@@ -68,8 +68,9 @@ class HTTP_Client {
 
     const response = outcomeOfSettlingResponse.unwrapped;
 
-    if (!response.ok) { // eslint-disable-line curly
-      return ends.inFailureDueTo(new HTTP_Endpoint.Error.Response(response.statusText, response.status));
+    if (!response.ok) {
+      const newResponseError = new HTTP_Endpoint.Error.Response(response.statusText, response.status);
+      return ends.inFailureDueTo(newResponseError);
     }
 
     const responseBody: unknown = await response.json();

--- a/src/library/NonTrivialString/definition.declared.ts
+++ b/src/library/NonTrivialString/definition.declared.ts
@@ -27,8 +27,9 @@ class NonTrivialString
   > => Attempt.Fresh.that((ends) => {
     const trimmedSubject = givenSubject.trim();
 
-    if (isEmpty(trimmedSubject)) { // eslint-disable-line curly
-      return ends.inFailureDueTo(new NonTrivialString_ParsingError(givenSubject));
+    if (isEmpty(trimmedSubject)) {
+      const newParsingError = new NonTrivialString_ParsingError(givenSubject);
+      return ends.inFailureDueTo(newParsingError);
     }
 
     return ends.inSuccessWith(new NonTrivialString(givenSubject));

--- a/src/library/Sequence/Base64/Conformance/ensure.ts
+++ b/src/library/Sequence/Base64/Conformance/ensure.ts
@@ -18,7 +18,8 @@ const Sequence_Base64_Conformance_ensure = (
     Sequence_Base64_pattern.test(givenCharacterSequence)
   ) return ends.inSuccessWith(givenCharacterSequence);
 
-  return ends.inFailureDueTo(new Sequence_Base64_Conformance_Error());
+  const newConformanceError = new Sequence_Base64_Conformance_Error();
+  return ends.inFailureDueTo(newConformanceError);
 });
 
 export {

--- a/src/library/Sequence/Byte/Encoded/Compatibility/ensure.ts
+++ b/src/library/Sequence/Byte/Encoded/Compatibility/ensure.ts
@@ -22,7 +22,8 @@ const Sequence_Byte_Encoded_Compatibility_ensure = (
     givenSequence.length % byteCofactor === 0
   ) return ends.inSuccessWith(givenSequence);
 
-  return ends.inFailureDueTo(new Sequence_Byte_Encoded_Compatibility_Error(givenBitWidth));
+  const newCompatibilityError = new Sequence_Byte_Encoded_Compatibility_Error(givenBitWidth);
+  return ends.inFailureDueTo(newCompatibilityError);
 });
 
 export {


### PR DESCRIPTION
- would otherwise leave long expressions and miss out an opportunity to capture intent via name of extracted variable

Encountered while drafting #597 