### PR TITLE
refactor: avoids instantiating errors outside of guard scope

### DIFF
--- a/src/features/TextToImage/Config/Dynamic/fetch.ts
+++ b/src/features/TextToImage/Config/Dynamic/fetch.ts
@@ -17,18 +17,18 @@ const TextToImage_Config_Dynamic_fetch = (): Promise<
   TextToImage_Config_Dynamic_Fetching.Outcome
 > => Attempt.Fresh.thatEventually(async (ends) => {
   const endpointResponse = await fetch(TextToImage_Config_Dynamic_endpoint.toString());
-  const fetchingError = new TextToImage_Config_Dynamic_Fetching.Error.Request(TextToImage_Config_Dynamic_endpoint);
 
-  if (!endpointResponse.ok) { // eslint-disable-line curly
+  if (!endpointResponse.ok) {
+    const fetchingError = new TextToImage_Config_Dynamic_Fetching.Error.Request(TextToImage_Config_Dynamic_endpoint);
     return ends.inFailureDueTo(fetchingError);
   }
 
-  const endpointResponseError = new TextToImage_Config_Dynamic_Fetching.Error.Response({
-    endpoint: TextToImage_Config_Dynamic_endpoint,
-    response: endpointResponse,
-  });
+  if (!HTTP.Client.contentIsJSONIn(endpointResponse)) {
+    const endpointResponseError = new TextToImage_Config_Dynamic_Fetching.Error.Response({
+      endpoint: TextToImage_Config_Dynamic_endpoint,
+      response: endpointResponse,
+    });
 
-  if (!HTTP.Client.contentIsJSONIn(endpointResponse)) { // eslint-disable-line curly
     return ends.inFailureDueTo(endpointResponseError);
   }
 

--- a/src/library/URLComponent/Origin/definition.declared.ts
+++ b/src/library/URLComponent/Origin/definition.declared.ts
@@ -21,12 +21,12 @@ class URLComponent_Origin
   > => Attempt.Fresh.that((ends) => {
     const derived = new URL(givenSubject);
 
-    const newParsingError = new URLComponent_Origin_ParsingError({
-      expectation: derived.origin,
-      reality    : givenSubject,
-    });
+    if (derived.origin !== givenSubject) {
+      const newParsingError = new URLComponent_Origin_ParsingError({
+        expectation: derived.origin,
+        reality    : givenSubject,
+      });
 
-    if (derived.origin !== givenSubject) { // eslint-disable-line curly
       return ends.inFailureDueTo(newParsingError);
     }
 

--- a/src/library/URLComponent/Path/definition.declared.ts
+++ b/src/library/URLComponent/Path/definition.declared.ts
@@ -21,12 +21,12 @@ class URLComponent_Path
   > => Attempt.Fresh.that((ends) => {
     const exampleURL = new URL(`https://example.com${givenSubject}`);
 
-    const newParsingError = new URLComponent_Path_ParsingError({
-      expectation: exampleURL.pathname,
-      reality    : givenSubject,
-    });
+    if (exampleURL.pathname !== givenSubject) {
+      const newParsingError = new URLComponent_Path_ParsingError({
+        expectation: exampleURL.pathname,
+        reality    : givenSubject,
+      });
 
-    if (exampleURL.pathname !== givenSubject) { // eslint-disable-line curly
       return ends.inFailureDueTo(newParsingError);
     }
 


### PR DESCRIPTION
Follows up on #1029