### PR TITLE
types(library/Sequence): preserves string literals in `ensure` signatures

### DIFF
--- a/src/library/Sequence/Base64/Conformance/ensure.ts
+++ b/src/library/Sequence/Base64/Conformance/ensure.ts
@@ -8,10 +8,12 @@ import {
   Sequence_Base64_Conformance_Error,
 } from './Error';
 
-const Sequence_Base64_Conformance_ensure = (
-  givenCharacterSequence: string,
+const Sequence_Base64_Conformance_ensure = <
+  SomeCharacterSequence extends string,
+>(
+  givenCharacterSequence: SomeCharacterSequence,
 ): Attempt.Outcome<
-  string,
+  SomeCharacterSequence,
   Sequence_Base64_Conformance_Error
 > => Attempt.Fresh.that((ends) => {
   if (

--- a/src/library/Sequence/Byte/Encoded/Compatibility/ensure.ts
+++ b/src/library/Sequence/Byte/Encoded/Compatibility/ensure.ts
@@ -6,7 +6,7 @@ import {
 } from './Error';
 
 const Sequence_Byte_Encoded_Compatibility_ensure = (
-  givenSequence: string,
+  givenCharacterSequence: string,
   {
     assuming: givenBitWidth,
   }: {
@@ -19,8 +19,8 @@ const Sequence_Byte_Encoded_Compatibility_ensure = (
   const byteCofactor = Byte.cofactorTo(givenBitWidth);
 
   if (
-    givenSequence.length % byteCofactor === 0
-  ) return ends.inSuccessWith(givenSequence);
+    givenCharacterSequence.length % byteCofactor === 0
+  ) return ends.inSuccessWith(givenCharacterSequence);
 
   const newCompatibilityError = new Sequence_Byte_Encoded_Compatibility_Error(givenBitWidth);
   return ends.inFailureDueTo(newCompatibilityError);

--- a/src/library/Sequence/Byte/Encoded/Compatibility/ensure.ts
+++ b/src/library/Sequence/Byte/Encoded/Compatibility/ensure.ts
@@ -5,15 +5,17 @@ import {
   Sequence_Byte_Encoded_Compatibility_Error,
 } from './Error';
 
-const Sequence_Byte_Encoded_Compatibility_ensure = (
-  givenCharacterSequence: string,
+const Sequence_Byte_Encoded_Compatibility_ensure = <
+  SomeCharacterSequence extends string,
+>(
+  givenCharacterSequence: SomeCharacterSequence,
   {
     assuming: givenBitWidth,
   }: {
     assuming: number;
   },
 ): Attempt.Outcome<
-  string,
+  SomeCharacterSequence,
   Sequence_Byte_Encoded_Compatibility_Error
 > => Attempt.Fresh.that((ends) => {
   const byteCofactor = Byte.cofactorTo(givenBitWidth);


### PR DESCRIPTION
Encountered while working through #597