### PR TITLE
fix(library/HTTP): ensures that `body` is `null` for "GET" requests

### DIFF
--- a/src/library/HTTP/Client.ts
+++ b/src/library/HTTP/Client.ts
@@ -47,7 +47,9 @@ class HTTP_Client {
     const promisedResponse = fetch(endpointURL, {
       method : givenMethod,
       headers: this.headers,
-      body   : JSON.stringify(givenRequestBody),
+      body   : (givenMethod === HTTP_Request.Method.FETCH)
+        ? null
+        : JSON.stringify(givenRequestBody),
     });
 
     const outcomeOfSettlingResponse = await Attempt.Adapted.toSettle(promisedResponse, {


### PR DESCRIPTION
Encountered while drafting #1037