### PR TITLE
prefeature(library/HTTP): makes `HTTP.Client['headers']` optional

### DIFF
--- a/src/library/HTTP/Client.ts
+++ b/src/library/HTTP/Client.ts
@@ -12,7 +12,7 @@ import {
 class HTTP_Client {
   public constructor(
     public readonly origin: URLComponent.Origin,
-    public readonly headers: HTTP_Request.HeaderMap,
+    public readonly headers?: HTTP_Request.HeaderMap,
   ) {}
 
   public static contentIsJSONIn = (


### PR DESCRIPTION
- this matches the convention present in the `fetch` API

Facilitates #1037