### PR TITLE
refactor: avoids magic strings

### DIFF
--- a/src/library/HTTP/Client.ts
+++ b/src/library/HTTP/Client.ts
@@ -24,7 +24,8 @@ class HTTP_Client {
       rawContentDescriptor === null
     ) return false;
 
-    return rawContentDescriptor.includes('application/json');
+    const rawJSONDescriptor = 'application/json';
+    return rawContentDescriptor.includes(rawJSONDescriptor);
   };
 
   public originAt(givenPath: URLComponent.Path): URL {


### PR DESCRIPTION
- like "magic numbers", "magic strings" tend to leave a reader wanting for more context
- usually, the missing context is easily captured by an extracted variable
- codebase scrubbed, only one offender found

Encountered while drafting #1042