### PR TITLE
refactor: avoids raw json content descriptors

### DIFF
--- a/src/library/ContentDescriptor/definition.declared.augmentation.ts
+++ b/src/library/ContentDescriptor/definition.declared.augmentation.ts
@@ -10,14 +10,20 @@ import {
   ContentDescriptor,
 } from './definition.declared.ts';
 
+import {
+  ContentDescriptor_json,
+} from './json';
+
 ContentDescriptor.TopLevel /*             */ = ContentDescriptor_TopLevel;
 ContentDescriptor.StructuredSyntaxNameSuffix = ContentDescriptor_StructuredSyntaxNameSuffix;
+ContentDescriptor.json /*                 */ = ContentDescriptor_json;
 
 declare module './definition.declared.ts' {
   namespace ContentDescriptor {
     export {
       ContentDescriptor_TopLevel /*             */ as TopLevel,
       ContentDescriptor_StructuredSyntaxNameSuffix as StructuredSyntaxNameSuffix,
+      ContentDescriptor_json /*                 */ as json,
     };
   }
 }

--- a/src/library/ContentDescriptor/json.ts
+++ b/src/library/ContentDescriptor/json.ts
@@ -1,0 +1,9 @@
+import {
+  ContentDescriptor,
+} from './definition.declared.ts';
+
+const ContentDescriptor_json = new ContentDescriptor('application', null, 'json', null, null);
+
+export {
+  ContentDescriptor_json,
+};

--- a/src/library/HTTP/Client.ts
+++ b/src/library/HTTP/Client.ts
@@ -1,4 +1,5 @@
 import Attempt from '@/library/Attempt';
+import ContentDescriptor from '@/library/ContentDescriptor';
 import type URLComponent from '@/library/URLComponent';
 
 import {
@@ -24,7 +25,7 @@ class HTTP_Client {
       rawContentDescriptor === null
     ) return false;
 
-    const rawJSONDescriptor = 'application/json';
+    const rawJSONDescriptor = ContentDescriptor.json.serialized.toString();
     return rawContentDescriptor.includes(rawJSONDescriptor);
   };
 

--- a/src/library/Shortfin/TextToImage/SDXL/Client/definition.declared.ts
+++ b/src/library/Shortfin/TextToImage/SDXL/Client/definition.declared.ts
@@ -1,4 +1,5 @@
 import Attempt from '@/library/Attempt';
+import ContentDescriptor from '@/library/ContentDescriptor';
 import HTTP from '@/library/HTTP';
 import URLComponent from '@/library/URLComponent';
 
@@ -16,7 +17,7 @@ class Shortfin_TextToImage_SDXL_Client
     givenOrigin: URLComponent.Origin,
   ) {
     const defaultHeaders = {
-      'Content-Type': 'application/json',
+      'Content-Type': ContentDescriptor.json.serialized.toString(),
     };
 
     super(


### PR DESCRIPTION
- raw content descriptors are neither type-checked nor self-documenting

Facilitates #1045