### PR TITLE
refactor: avoids raw header names for content descriptor

### DIFF
--- a/src/library/HTTP/Client.ts
+++ b/src/library/HTTP/Client.ts
@@ -7,6 +7,10 @@ import {
 } from './Endpoint';
 
 import {
+  HTTP_Header,
+} from './Header';
+
+import {
   HTTP_Request,
 } from './Request';
 
@@ -19,8 +23,7 @@ class HTTP_Client {
   public static contentIsJSONIn = (
     givenResponse: Response,
   ): boolean => {
-    const HTTP_Header_Content_Descriptor = 'content-type';
-    const rawContentDescriptor = givenResponse.headers.get(HTTP_Header_Content_Descriptor);
+    const rawContentDescriptor = givenResponse.headers.get(HTTP_Header.Content.Descriptor);
 
     if (
       rawContentDescriptor === null

--- a/src/library/HTTP/Client.ts
+++ b/src/library/HTTP/Client.ts
@@ -19,7 +19,8 @@ class HTTP_Client {
   public static contentIsJSONIn = (
     givenResponse: Response,
   ): boolean => {
-    const rawContentDescriptor = givenResponse.headers.get('Content-Type');
+    const HTTP_Header_Content_Descriptor = 'content-type';
+    const rawContentDescriptor = givenResponse.headers.get(HTTP_Header_Content_Descriptor);
 
     if (
       rawContentDescriptor === null

--- a/src/library/HTTP/Header/Content/Descriptor.ts
+++ b/src/library/HTTP/Header/Content/Descriptor.ts
@@ -1,0 +1,12 @@
+import type ContentDescriptor from '@/library/ContentDescriptor'; // eslint-disable-line @typescript-eslint/no-unused-vars -- used in JSDoc
+
+/**
+ * The name of the header that describes the nature of some content.
+ * See {@link ContentDescriptor}
+ */
+const HTTP_Header_Content_Descriptor = 'content-type';
+type HTTP_Header_Content_Descriptor = typeof HTTP_Header_Content_Descriptor;
+
+export {
+  HTTP_Header_Content_Descriptor,
+};

--- a/src/library/HTTP/Header/Content/definition.assembled.members.ts
+++ b/src/library/HTTP/Header/Content/definition.assembled.members.ts
@@ -1,0 +1,3 @@
+export {
+  HTTP_Header_Content_Descriptor as Descriptor,
+} from './Descriptor';

--- a/src/library/HTTP/Header/Content/definition.assembled.ts
+++ b/src/library/HTTP/Header/Content/definition.assembled.ts
@@ -1,0 +1,1 @@
+export * as HTTP_Header_Content from './definition.assembled.members.ts';

--- a/src/library/HTTP/Header/Content/exports.object.primary.ts
+++ b/src/library/HTTP/Header/Content/exports.object.primary.ts
@@ -1,0 +1,1 @@
+export * from './definition.assembled.ts';

--- a/src/library/HTTP/Header/Content/index.ts
+++ b/src/library/HTTP/Header/Content/index.ts
@@ -1,0 +1,1 @@
+export * from './exports.object.primary.ts';

--- a/src/library/HTTP/Header/definition.assembled.members.ts
+++ b/src/library/HTTP/Header/definition.assembled.members.ts
@@ -1,0 +1,3 @@
+export {
+  HTTP_Header_Content as Content,
+} from './Content';

--- a/src/library/HTTP/Header/definition.assembled.ts
+++ b/src/library/HTTP/Header/definition.assembled.ts
@@ -1,0 +1,1 @@
+export * as HTTP_Header from './definition.assembled.members.ts';

--- a/src/library/HTTP/Header/exports.object.primary.ts
+++ b/src/library/HTTP/Header/exports.object.primary.ts
@@ -1,0 +1,1 @@
+export * from './definition.assembled.ts';

--- a/src/library/HTTP/Header/index.ts
+++ b/src/library/HTTP/Header/index.ts
@@ -1,0 +1,1 @@
+export * from './exports.object.primary.ts';

--- a/src/library/HTTP/definition.assembled.members.ts
+++ b/src/library/HTTP/definition.assembled.members.ts
@@ -1,4 +1,8 @@
 export {
+  HTTP_Header as Header,
+} from './Header';
+
+export {
   HTTP_Request as Request,
 } from './Request';
 

--- a/src/library/Shortfin/TextToImage/SDXL/Client/definition.declared.ts
+++ b/src/library/Shortfin/TextToImage/SDXL/Client/definition.declared.ts
@@ -16,8 +16,10 @@ class Shortfin_TextToImage_SDXL_Client
   public constructor(
     givenOrigin: URLComponent.Origin,
   ) {
+    const HTTP_Header_Content_Descriptor = 'content-type';
+
     const defaultHeaders = {
-      'Content-Type': ContentDescriptor.json.serialized.toString(),
+      [HTTP_Header_Content_Descriptor]: ContentDescriptor.json.serialized.toString(),
     };
 
     super(

--- a/src/library/Shortfin/TextToImage/SDXL/Client/definition.declared.ts
+++ b/src/library/Shortfin/TextToImage/SDXL/Client/definition.declared.ts
@@ -16,10 +16,8 @@ class Shortfin_TextToImage_SDXL_Client
   public constructor(
     givenOrigin: URLComponent.Origin,
   ) {
-    const HTTP_Header_Content_Descriptor = 'content-type';
-
     const defaultHeaders = {
-      [HTTP_Header_Content_Descriptor]: ContentDescriptor.json.serialized.toString(),
+      [HTTP.Header.Content.Descriptor]: ContentDescriptor.json.serialized.toString(),
     };
 
     super(


### PR DESCRIPTION
- before, these were neither type-safe nor self-documenting

Facilitates #1045