### PR TITLE
fix: avoids unconventional nesting of `cause` in `Error` subclasses

### DIFF
--- a/src/library/HTTP/Endpoint/Error/IndigestibleResponseBody.ts
+++ b/src/library/HTTP/Endpoint/Error/IndigestibleResponseBody.ts
@@ -10,7 +10,9 @@ class HTTP_Endpoint_Error_IndigestibleResponseBody
     public readonly endpoint: URL,
     givenCause: Error,
   ) {
-    super(`Could not digest body of response from "${endpoint.toString()}". ${givenCause.message}`);
+    super(`Could not digest body of response from "${endpoint.toString()}".`, {
+      cause: givenCause,
+    });
   }
 }
 

--- a/src/library/ParsingError.ts
+++ b/src/library/ParsingError.ts
@@ -9,7 +9,9 @@ abstract class ParsingError<
     givenMessage: string,
     givenCause?: Error,
   ) {
-    super(givenMessage, givenCause);
+    super(givenMessage, {
+      cause: givenCause,
+    });
   }
 }
 


### PR DESCRIPTION
- the `cause` property on the `Error` type is the suggested way to nest or compose errors
- appending just the message loses the preceding stack trace

Found while drafting #1037