### PR TITLE
refactor: ensures error union members have negative connotation

### DIFF
--- a/docs/architecture/modules/consumption.md
+++ b/docs/architecture/modules/consumption.md
@@ -23,7 +23,7 @@ import HTTP from '@/library/HTTP';
 
 // HTTP.Request
 // HTTP.Response
-// HTTP.Endpoint.Error.Request
+// HTTP.Endpoint.Error.FailedToSendRequest
 // HTTP.Client.send(...)
 ```
 

--- a/src/features/TextToImage/Client/SDXL/generateOutputFrom.ts
+++ b/src/features/TextToImage/Client/SDXL/generateOutputFrom.ts
@@ -61,7 +61,7 @@ const TextToImage_Client_SDXL_generateOutputFrom = async (
         !(caughtError instanceof HTTP.Endpoint.Error.Request)
       ) return null;
 
-      return new TextToImage_Server.Error.Connection(caughtError.endpoint);
+      return new TextToImage_Server.Error.FailedToConnect(caughtError.endpoint);
     },
   });
 

--- a/src/features/TextToImage/Client/SDXL/generateOutputFrom.ts
+++ b/src/features/TextToImage/Client/SDXL/generateOutputFrom.ts
@@ -58,7 +58,7 @@ const TextToImage_Client_SDXL_generateOutputFrom = async (
   const outcomeOfSettlingTextToImageResponse = await Attempt.Adapted.toSettle(promisedTextToImageResponse, {
     interpretationOf: (caughtError) => {
       if (
-        !(caughtError instanceof HTTP.Endpoint.Error.Request)
+        !(caughtError instanceof HTTP.Endpoint.Error.FailedToSendRequest)
       ) return null;
 
       return new TextToImage_Server.Error.FailedToConnect(caughtError.endpoint);

--- a/src/features/TextToImage/Client/SDXL/initialize.ts
+++ b/src/features/TextToImage/Client/SDXL/initialize.ts
@@ -8,7 +8,7 @@ import {
 const TextToImage_Client_SDXL_initialize = async (): Promise<
   Attempt.Outcome<
     ShimmedStabilityAIClient,
-    TextToImage_Server.Error.Specification
+    TextToImage_Server.Error.MissingSpecification
   >
 > => {
   const outcomeOfRetrievingCurrentServer = await TextToImage_Server.Current.retrieve();

--- a/src/features/TextToImage/Server/Current/retrieve.ts
+++ b/src/features/TextToImage/Server/Current/retrieve.ts
@@ -20,7 +20,7 @@ import {
 const TextToImage_Server_Current_retrieve = (): Promise<
   Attempt.Outcome<
     WebAPI.Server,
-    TextToImage_Server_Error.Specification
+    TextToImage_Server_Error.MissingSpecification
   >
 > => Attempt.Fresh.thatEventually(async (ends) => {
   if (
@@ -39,7 +39,7 @@ const TextToImage_Server_Current_retrieve = (): Promise<
     dynamicConfig.server !== null
   ) return ends.inSuccessWith(dynamicConfig.server);
 
-  const newSpecificationError = new TextToImage_Server_Error.Specification(
+  const newSpecificationError = new TextToImage_Server_Error.MissingSpecification(
     TextToImage_Server_Origin.environmentKey,
     TextToImage_Config.Static.file,
     TextToImage_Config.Dynamic.endpoint,

--- a/src/features/TextToImage/Server/Error/Any.ts
+++ b/src/features/TextToImage/Server/Error/Any.ts
@@ -1,6 +1,6 @@
 import type {
-  TextToImage_Server_Error_Connection,
-} from './Connection';
+  TextToImage_Server_Error_FailedToConnect,
+} from './FailedToConnect';
 
 import type {
   TextToImage_Server_Error_Specification,
@@ -8,7 +8,7 @@ import type {
 
 type TextToImage_Server_Error_Any =
   | TextToImage_Server_Error_Specification
-  | TextToImage_Server_Error_Connection
+  | TextToImage_Server_Error_FailedToConnect
 ;
 
 export type {

--- a/src/features/TextToImage/Server/Error/Any.ts
+++ b/src/features/TextToImage/Server/Error/Any.ts
@@ -3,11 +3,11 @@ import type {
 } from './FailedToConnect';
 
 import type {
-  TextToImage_Server_Error_Specification,
-} from './Specification';
+  TextToImage_Server_Error_MissingSpecification,
+} from './MissingSpecification';
 
 type TextToImage_Server_Error_Any =
-  | TextToImage_Server_Error_Specification
+  | TextToImage_Server_Error_MissingSpecification
   | TextToImage_Server_Error_FailedToConnect
 ;
 

--- a/src/features/TextToImage/Server/Error/FailedToConnect.ts
+++ b/src/features/TextToImage/Server/Error/FailedToConnect.ts
@@ -1,10 +1,10 @@
 import Attempt from '@/library/Attempt';
 
-class TextToImage_Server_Error_Connection
+class TextToImage_Server_Error_FailedToConnect
   extends Attempt.Error.Actionable<
-    'TextToImage_Server_Error_Connection'
+    'TextToImage_Server_Error_FailedToConnect'
   > {
-  public override name = 'TextToImage_Server_Error_Connection' as const;
+  public override name = 'TextToImage_Server_Error_FailedToConnect' as const;
 
   public constructor(
     public readonly endpoint: URL,
@@ -14,5 +14,5 @@ class TextToImage_Server_Error_Connection
 }
 
 export {
-  TextToImage_Server_Error_Connection,
+  TextToImage_Server_Error_FailedToConnect,
 };

--- a/src/features/TextToImage/Server/Error/MissingSpecification.ts
+++ b/src/features/TextToImage/Server/Error/MissingSpecification.ts
@@ -1,11 +1,11 @@
 import Attempt from '@/library/Attempt';
 import type URLComponent from '@/library/URLComponent';
 
-class TextToImage_Server_Error_Specification
+class TextToImage_Server_Error_MissingSpecification
   extends Attempt.Error.Actionable<
-    'TextToImage_Server_Error_Specification'
+    'TextToImage_Server_Error_MissingSpecification'
   > {
-  public override name = 'TextToImage_Server_Error_Specification' as const;
+  public override name = 'TextToImage_Server_Error_MissingSpecification' as const;
 
   public constructor(
     public readonly environmentKey: string,
@@ -17,5 +17,5 @@ class TextToImage_Server_Error_Specification
 }
 
 export {
-  TextToImage_Server_Error_Specification,
+  TextToImage_Server_Error_MissingSpecification,
 };

--- a/src/features/TextToImage/Server/Error/definition.assembled.members.ts
+++ b/src/features/TextToImage/Server/Error/definition.assembled.members.ts
@@ -1,6 +1,6 @@
 export {
-  TextToImage_Server_Error_Specification as Specification,
-} from './Specification';
+  TextToImage_Server_Error_MissingSpecification as MissingSpecification,
+} from './MissingSpecification';
 
 export {
   TextToImage_Server_Error_FailedToConnect as FailedToConnect,

--- a/src/features/TextToImage/Server/Error/definition.assembled.members.ts
+++ b/src/features/TextToImage/Server/Error/definition.assembled.members.ts
@@ -3,8 +3,8 @@ export {
 } from './Specification';
 
 export {
-  TextToImage_Server_Error_Connection as Connection,
-} from './Connection';
+  TextToImage_Server_Error_FailedToConnect as FailedToConnect,
+} from './FailedToConnect';
 
 export type {
   TextToImage_Server_Error_Any as Any,

--- a/src/features/TextToImage/components/TextToImageOutputAlert.vue
+++ b/src/features/TextToImage/components/TextToImageOutputAlert.vue
@@ -11,7 +11,7 @@ defineProps<{
 
 <template>
   <TextToImageServerSpecificationAlert
-    v-if="(error instanceof TextToImage.Server.Error.Specification)"
+    v-if="(error instanceof TextToImage.Server.Error.MissingSpecification)"
     :error="error"
   />
   <TextToImageServerConnectionAlert

--- a/src/features/TextToImage/components/TextToImageServerConnectionAlert.vue
+++ b/src/features/TextToImage/components/TextToImageServerConnectionAlert.vue
@@ -6,7 +6,7 @@ import {
 import type TextToImage from '@/features/TextToImage';
 
 defineProps<{
-  error: TextToImage.Server.Error.Connection;
+  error: TextToImage.Server.Error.FailedToConnect;
 }>();
 </script>
 

--- a/src/features/TextToImage/components/TextToImageServerSpecificationAlert.vue
+++ b/src/features/TextToImage/components/TextToImageServerSpecificationAlert.vue
@@ -6,7 +6,7 @@ import {
 import type TextToImage from '@/features/TextToImage';
 
 defineProps<{
-  error: TextToImage.Server.Error.Specification;
+  error: TextToImage.Server.Error.MissingSpecification;
 }>();
 </script>
 

--- a/src/library/HTTP/Client.ts
+++ b/src/library/HTTP/Client.ts
@@ -63,7 +63,7 @@ class HTTP_Client {
           !clientFailedToReachServer
         ) return null;
 
-        return new HTTP_Endpoint.Error.Request(endpointURL);
+        return new HTTP_Endpoint.Error.FailedToSendRequest(endpointURL);
       },
     });
 

--- a/src/library/HTTP/Client.ts
+++ b/src/library/HTTP/Client.ts
@@ -74,7 +74,7 @@ class HTTP_Client {
     const response = outcomeOfSettlingResponse.unwrapped;
 
     if (!response.ok) {
-      const newResponseError = new HTTP_Endpoint.Error.Response(response.statusText, response.status);
+      const newResponseError = new HTTP_Endpoint.Error.RespondedWithFailure(response.statusText, response.status);
       return ends.inFailureDueTo(newResponseError);
     }
 

--- a/src/library/HTTP/Endpoint/Error/Any.ts
+++ b/src/library/HTTP/Endpoint/Error/Any.ts
@@ -7,12 +7,12 @@ import type {
 } from './IndigestibleResponseBody';
 
 import type {
-  HTTP_Endpoint_Error_Response,
-} from './Response';
+  HTTP_Endpoint_Error_RespondedWithFailure,
+} from './RespondedWithFailure';
 
 type HTTP_Endpoint_Error_Any =
   | HTTP_Endpoint_Error_FailedToSendRequest
-  | HTTP_Endpoint_Error_Response
+  | HTTP_Endpoint_Error_RespondedWithFailure
   | HTTP_Endpoint_Error_IndigestibleResponseBody
 ;
 

--- a/src/library/HTTP/Endpoint/Error/Any.ts
+++ b/src/library/HTTP/Endpoint/Error/Any.ts
@@ -1,17 +1,17 @@
 import type {
-  HTTP_Endpoint_Error_IndigestibleResponseBody,
-} from './IndigestibleResponseBody';
+  HTTP_Endpoint_Error_FailedToSendRequest,
+} from './FailedToSendRequest';
 
 import type {
-  HTTP_Endpoint_Error_Request,
-} from './Request';
+  HTTP_Endpoint_Error_IndigestibleResponseBody,
+} from './IndigestibleResponseBody';
 
 import type {
   HTTP_Endpoint_Error_Response,
 } from './Response';
 
 type HTTP_Endpoint_Error_Any =
-  | HTTP_Endpoint_Error_Request
+  | HTTP_Endpoint_Error_FailedToSendRequest
   | HTTP_Endpoint_Error_Response
   | HTTP_Endpoint_Error_IndigestibleResponseBody
 ;

--- a/src/library/HTTP/Endpoint/Error/FailedToSendRequest.ts
+++ b/src/library/HTTP/Endpoint/Error/FailedToSendRequest.ts
@@ -1,10 +1,10 @@
 import Attempt from '@/library/Attempt';
 
-class HTTP_Endpoint_Error_Request
+class HTTP_Endpoint_Error_FailedToSendRequest
   extends Attempt.Error.Actionable<
-    'HTTP_Endpoint_Error_Request'
+    'HTTP_Endpoint_Error_FailedToSendRequest'
   > {
-  public override name = 'HTTP_Endpoint_Error_Request' as const;
+  public override name = 'HTTP_Endpoint_Error_FailedToSendRequest' as const;
 
   public constructor(
     public readonly endpoint: URL,
@@ -14,5 +14,5 @@ class HTTP_Endpoint_Error_Request
 }
 
 export {
-  HTTP_Endpoint_Error_Request,
+  HTTP_Endpoint_Error_FailedToSendRequest,
 };

--- a/src/library/HTTP/Endpoint/Error/RespondedWithFailure.ts
+++ b/src/library/HTTP/Endpoint/Error/RespondedWithFailure.ts
@@ -4,11 +4,11 @@ import type {
   HTTP_Response,
 } from '../../Response';
 
-class HTTP_Endpoint_Error_Response
+class HTTP_Endpoint_Error_RespondedWithFailure
   extends Attempt.Error.Actionable<
-    'HTTP_Endpoint_Error_Response'
+    'HTTP_Endpoint_Error_RespondedWithFailure'
   > {
-  public override name = 'HTTP_Endpoint_Error_Response' as const;
+  public override name = 'HTTP_Endpoint_Error_RespondedWithFailure' as const;
 
   public constructor(
     givenMessage: string,
@@ -19,5 +19,5 @@ class HTTP_Endpoint_Error_Response
 }
 
 export {
-  HTTP_Endpoint_Error_Response,
+  HTTP_Endpoint_Error_RespondedWithFailure,
 };

--- a/src/library/HTTP/Endpoint/Error/definition.assembled.members.ts
+++ b/src/library/HTTP/Endpoint/Error/definition.assembled.members.ts
@@ -3,8 +3,8 @@ export {
 } from './FailedToSendRequest';
 
 export {
-  HTTP_Endpoint_Error_Response as Response,
-} from './Response';
+  HTTP_Endpoint_Error_RespondedWithFailure as RespondedWithFailure,
+} from './RespondedWithFailure';
 
 export {
   HTTP_Endpoint_Error_IndigestibleResponseBody as IndigestibleResponseBody,

--- a/src/library/HTTP/Endpoint/Error/definition.assembled.members.ts
+++ b/src/library/HTTP/Endpoint/Error/definition.assembled.members.ts
@@ -1,6 +1,6 @@
 export {
-  HTTP_Endpoint_Error_Request as Request,
-} from './Request';
+  HTTP_Endpoint_Error_FailedToSendRequest as FailedToSendRequest,
+} from './FailedToSendRequest';
 
 export {
   HTTP_Endpoint_Error_Response as Response,


### PR DESCRIPTION
- when a specific error is supposed to convey a failure case, the name at the end of the namespace should convey "this is what went wrong"
- the one-word namespaces that the affected files had previously not only failed to capture intent, but was also prone to namespace collisions
  - e.g. does a "response error" mean "failed to receive response", or "responded with failure"?
- see [PR commits](https://github.com/nod-ai/shark-ui/pull/1050/commits) for summarized examples

Follows precedent set in #1037