### PR TITLE
tests(unit): adds all missing stubs

### DIFF
--- a/src/features/Reporting/promptUserWith.test.ts
+++ b/src/features/Reporting/promptUserWith.test.ts
@@ -1,0 +1,9 @@
+import {
+  describe,
+} from 'vitest';
+
+import {
+  Reporting_promptUserWith,
+} from './promptUserWith';
+
+describe.todo(Reporting_promptUserWith);

--- a/src/features/TextToImage/Client/SDXL/generateOutputFrom.test.ts
+++ b/src/features/TextToImage/Client/SDXL/generateOutputFrom.test.ts
@@ -1,0 +1,9 @@
+import {
+  describe,
+} from 'vitest';
+
+import {
+  TextToImage_Client_SDXL_generateOutputFrom,
+} from './generateOutputFrom';
+
+describe.todo(TextToImage_Client_SDXL_generateOutputFrom);

--- a/src/features/TextToImage/Client/SDXL/initialize.test.ts
+++ b/src/features/TextToImage/Client/SDXL/initialize.test.ts
@@ -1,0 +1,9 @@
+import {
+  describe,
+} from 'vitest';
+
+import {
+  TextToImage_Client_SDXL_initialize,
+} from './initialize';
+
+describe.todo(TextToImage_Client_SDXL_initialize);

--- a/src/features/TextToImage/Client/SDXL/toAMDSharkUIOutput/Image/Description/all.test.ts
+++ b/src/features/TextToImage/Client/SDXL/toAMDSharkUIOutput/Image/Description/all.test.ts
@@ -1,0 +1,9 @@
+import {
+  describe,
+} from 'vitest';
+
+import {
+  toAMDSharkUIOutput_Image_Description_all,
+} from './all';
+
+describe.todo(toAMDSharkUIOutput_Image_Description_all);

--- a/src/features/TextToImage/Client/SDXL/toAMDSharkUIOutput/Image/Description/singular.test.ts
+++ b/src/features/TextToImage/Client/SDXL/toAMDSharkUIOutput/Image/Description/singular.test.ts
@@ -1,0 +1,9 @@
+import {
+  describe,
+} from 'vitest';
+
+import {
+  toAMDSharkUIOutput_Image_Description_singular,
+} from './singular';
+
+describe.todo(toAMDSharkUIOutput_Image_Description_singular);

--- a/src/features/TextToImage/Client/SDXL/toAMDSharkUIOutput/Image/definition.declared.test.ts
+++ b/src/features/TextToImage/Client/SDXL/toAMDSharkUIOutput/Image/definition.declared.test.ts
@@ -1,0 +1,9 @@
+import {
+  describe,
+} from 'vitest';
+
+import {
+  toAMDSharkUIOutput_Image,
+} from './definition.declared.ts';
+
+describe.todo(toAMDSharkUIOutput_Image);

--- a/src/features/TextToImage/Client/SDXL/toAMDSharkUIOutput/first.test.ts
+++ b/src/features/TextToImage/Client/SDXL/toAMDSharkUIOutput/first.test.ts
@@ -1,0 +1,9 @@
+import {
+  describe,
+} from 'vitest';
+
+import {
+  toAMDSharkUIOutput_first,
+} from './first';
+
+describe.todo(toAMDSharkUIOutput_first);

--- a/src/features/TextToImage/Client/SDXL/toAMDSharkUIOutput/plural.test.ts
+++ b/src/features/TextToImage/Client/SDXL/toAMDSharkUIOutput/plural.test.ts
@@ -1,0 +1,9 @@
+import {
+  describe,
+} from 'vitest';
+
+import {
+  toAMDSharkUIOutput_plural,
+} from './plural';
+
+describe.todo(toAMDSharkUIOutput_plural);

--- a/src/features/TextToImage/Config/Dynamic/Fetching/Error.test.ts
+++ b/src/features/TextToImage/Config/Dynamic/Fetching/Error.test.ts
@@ -1,0 +1,9 @@
+import {
+  describe,
+} from 'vitest';
+
+import {
+  TextToImage_Config_Dynamic_Fetching_Error,
+} from './Error';
+
+describe.todo(TextToImage_Config_Dynamic_Fetching_Error);

--- a/src/features/TextToImage/Config/Dynamic/fetch.test.ts
+++ b/src/features/TextToImage/Config/Dynamic/fetch.test.ts
@@ -1,0 +1,9 @@
+import {
+  describe,
+} from 'vitest';
+
+import {
+  TextToImage_Config_Dynamic_fetch,
+} from './fetch';
+
+describe.todo(TextToImage_Config_Dynamic_fetch);

--- a/src/features/TextToImage/Config/Static/Reading/Error.test.ts
+++ b/src/features/TextToImage/Config/Static/Reading/Error.test.ts
@@ -1,0 +1,9 @@
+import {
+  describe,
+} from 'vitest';
+
+import {
+  TextToImage_Config_Static_Reading_Error,
+} from './Error';
+
+describe.todo(TextToImage_Config_Static_Reading_Error);

--- a/src/features/TextToImage/Config/Static/read.test.ts
+++ b/src/features/TextToImage/Config/Static/read.test.ts
@@ -1,0 +1,9 @@
+import {
+  describe,
+} from 'vitest';
+
+import {
+  TextToImage_Config_Static_read,
+} from './read';
+
+describe.todo(TextToImage_Config_Static_read);

--- a/src/features/TextToImage/Config/definition.declared.test.ts
+++ b/src/features/TextToImage/Config/definition.declared.test.ts
@@ -1,0 +1,9 @@
+import {
+  describe,
+} from 'vitest';
+
+import {
+  TextToImage_Config,
+} from './definition.declared.ts';
+
+describe.todo(TextToImage_Config);

--- a/src/features/TextToImage/Pipeline/Output/Image.test.ts
+++ b/src/features/TextToImage/Pipeline/Output/Image.test.ts
@@ -1,0 +1,9 @@
+import {
+  describe,
+} from 'vitest';
+
+import {
+  TextToImage_Pipeline_Output_Image,
+} from './Image';
+
+describe.todo(TextToImage_Pipeline_Output_Image);

--- a/src/features/TextToImage/Pipeline/Output/definition.declared.test.ts
+++ b/src/features/TextToImage/Pipeline/Output/definition.declared.test.ts
@@ -1,0 +1,9 @@
+import {
+  describe,
+} from 'vitest';
+
+import {
+  TextToImage_Pipeline_Output,
+} from './definition.declared.ts';
+
+describe.todo(TextToImage_Pipeline_Output);

--- a/src/features/TextToImage/Server/Current/retrieve.test.ts
+++ b/src/features/TextToImage/Server/Current/retrieve.test.ts
@@ -1,0 +1,9 @@
+import {
+  describe,
+} from 'vitest';
+
+import {
+  TextToImage_Server_Current_retrieve,
+} from './retrieve';
+
+describe.todo(TextToImage_Server_Current_retrieve);

--- a/src/features/TextToImage/Server/Error/FailedToConnect.test.ts
+++ b/src/features/TextToImage/Server/Error/FailedToConnect.test.ts
@@ -1,0 +1,9 @@
+import {
+  describe,
+} from 'vitest';
+
+import {
+  TextToImage_Server_Error_FailedToConnect,
+} from './FailedToConnect';
+
+describe.todo(TextToImage_Server_Error_FailedToConnect);

--- a/src/features/TextToImage/Server/Error/MissingSpecification.test.ts
+++ b/src/features/TextToImage/Server/Error/MissingSpecification.test.ts
@@ -1,0 +1,9 @@
+import {
+  describe,
+} from 'vitest';
+
+import {
+  TextToImage_Server_Error_MissingSpecification,
+} from './MissingSpecification';
+
+describe.todo(TextToImage_Server_Error_MissingSpecification);

--- a/src/library/ContentDescriptor/definition.declared.test.ts
+++ b/src/library/ContentDescriptor/definition.declared.test.ts
@@ -1,0 +1,9 @@
+import {
+  describe,
+} from 'vitest';
+
+import {
+  ContentDescriptor,
+} from './definition.declared.ts';
+
+describe.todo(ContentDescriptor);

--- a/src/library/GitHub/Repository/Issue/Draftable.test.ts
+++ b/src/library/GitHub/Repository/Issue/Draftable.test.ts
@@ -1,0 +1,9 @@
+import {
+  describe,
+} from 'vitest';
+
+import {
+  GitHub_Repository_Issue_Draftable,
+} from './Draftable';
+
+describe.todo(GitHub_Repository_Issue_Draftable);

--- a/src/library/GitHub/Repository/Issue/definition.declared.test.ts
+++ b/src/library/GitHub/Repository/Issue/definition.declared.test.ts
@@ -1,0 +1,9 @@
+import {
+  describe,
+} from 'vitest';
+
+import {
+  GitHub_Repository_Issue,
+} from './definition.declared.ts';
+
+describe.todo(GitHub_Repository_Issue);

--- a/src/library/GitHub/Repository/definition.declared.test.ts
+++ b/src/library/GitHub/Repository/definition.declared.test.ts
@@ -1,0 +1,9 @@
+import {
+  describe,
+} from 'vitest';
+
+import {
+  GitHub_Repository,
+} from './definition.declared.ts';
+
+describe.todo(GitHub_Repository);

--- a/src/library/Range/Discrete.test.ts
+++ b/src/library/Range/Discrete.test.ts
@@ -1,0 +1,9 @@
+import {
+  describe,
+} from 'vitest';
+
+import {
+  Range_Discrete,
+} from './Discrete';
+
+describe.todo(Range_Discrete);

--- a/src/library/Range/definition.declared.test.ts
+++ b/src/library/Range/definition.declared.test.ts
@@ -1,0 +1,9 @@
+import {
+  describe,
+} from 'vitest';
+
+import {
+  Range,
+} from './definition.declared.ts';
+
+describe.todo(Range);

--- a/src/library/Sequence/Byte/Encoded/Base64.test.ts
+++ b/src/library/Sequence/Byte/Encoded/Base64.test.ts
@@ -1,0 +1,9 @@
+import {
+  describe,
+} from 'vitest';
+
+import {
+  Sequence_Byte_Encoded_Base64,
+} from './Base64';
+
+describe.todo(Sequence_Byte_Encoded_Base64);

--- a/src/library/ShimmedStabilityAIClient/SDXL/DiffusionStepCount.test.ts
+++ b/src/library/ShimmedStabilityAIClient/SDXL/DiffusionStepCount.test.ts
@@ -1,0 +1,9 @@
+import {
+  describe,
+} from 'vitest';
+
+import {
+  SDXL_DiffusionStepCount,
+} from './DiffusionStepCount';
+
+describe.todo(SDXL_DiffusionStepCount);

--- a/src/library/ShimmedStabilityAIClient/Version1/Image.test.ts
+++ b/src/library/ShimmedStabilityAIClient/Version1/Image.test.ts
@@ -1,0 +1,9 @@
+import {
+  describe,
+} from 'vitest';
+
+import {
+  ShimmedStabilityAIClient_Version1_Image,
+} from './Image';
+
+describe.todo(ShimmedStabilityAIClient_Version1_Image);

--- a/src/library/ShimmedStabilityAIClient/Version1/definition.declared.test.ts
+++ b/src/library/ShimmedStabilityAIClient/Version1/definition.declared.test.ts
@@ -1,0 +1,9 @@
+import {
+  describe,
+} from 'vitest';
+
+import {
+  ShimmedStabilityAIClient_Version1,
+} from './definition.declared.ts';
+
+describe.todo(ShimmedStabilityAIClient_Version1);

--- a/src/library/ShimmedStabilityAIClient/definition.declared.test.ts
+++ b/src/library/ShimmedStabilityAIClient/definition.declared.test.ts
@@ -1,0 +1,9 @@
+import {
+  describe,
+} from 'vitest';
+
+import {
+  ShimmedStabilityAIClient,
+} from './definition.declared.ts';
+
+describe.todo(ShimmedStabilityAIClient);

--- a/src/library/ShimmedStabilityAIClient/toShortfinRequestBody/Batched.test.ts
+++ b/src/library/ShimmedStabilityAIClient/toShortfinRequestBody/Batched.test.ts
@@ -1,0 +1,9 @@
+import {
+  describe,
+} from 'vitest';
+
+import {
+  toShortfinRequestBody_Batched,
+} from './Batched';
+
+describe.todo(toShortfinRequestBody_Batched);

--- a/src/library/ShimmedStabilityAIClient/toShortfinRequestBody/Prompt.test.ts
+++ b/src/library/ShimmedStabilityAIClient/toShortfinRequestBody/Prompt.test.ts
@@ -1,0 +1,9 @@
+import {
+  describe,
+} from 'vitest';
+
+import {
+  toShortfinRequestBody_Prompt,
+} from './Prompt';
+
+describe.todo(toShortfinRequestBody_Prompt);

--- a/src/library/ShimmedStabilityAIClient/toShortfinRequestBody/definition.declared.test.ts
+++ b/src/library/ShimmedStabilityAIClient/toShortfinRequestBody/definition.declared.test.ts
@@ -1,0 +1,9 @@
+import {
+  describe,
+} from 'vitest';
+
+import {
+  toShortfinRequestBody,
+} from './definition.declared.ts';
+
+describe.todo(toShortfinRequestBody);

--- a/src/library/Shortfin/TextToImage/SDXL/Client/Request/Body/Batched.test.ts
+++ b/src/library/Shortfin/TextToImage/SDXL/Client/Request/Body/Batched.test.ts
@@ -1,0 +1,9 @@
+import {
+  describe,
+} from 'vitest';
+
+import {
+  Shortfin_TextToImage_SDXL_Client_Request_Body_Batched,
+} from './Batched';
+
+describe.todo(Shortfin_TextToImage_SDXL_Client_Request_Body_Batched);

--- a/src/library/Shortfin/TextToImage/SDXL/Client/Request/Body/definition.declared.test.ts
+++ b/src/library/Shortfin/TextToImage/SDXL/Client/Request/Body/definition.declared.test.ts
@@ -1,0 +1,9 @@
+import {
+  describe,
+} from 'vitest';
+
+import {
+  Shortfin_TextToImage_SDXL_Client_Request_Body,
+} from './definition.declared.ts';
+
+describe.todo(Shortfin_TextToImage_SDXL_Client_Request_Body);

--- a/src/library/Shortfin/TextToImage/SDXL/Client/Response/Body.test.ts
+++ b/src/library/Shortfin/TextToImage/SDXL/Client/Response/Body.test.ts
@@ -1,0 +1,9 @@
+import {
+  describe,
+} from 'vitest';
+
+import {
+  Shortfin_TextToImage_SDXL_Client_Response_Body,
+} from './Body';
+
+describe.todo(Shortfin_TextToImage_SDXL_Client_Response_Body);

--- a/src/library/Shortfin/TextToImage/SDXL/Client/definition.declared.test.ts
+++ b/src/library/Shortfin/TextToImage/SDXL/Client/definition.declared.test.ts
@@ -1,0 +1,9 @@
+import {
+  describe,
+} from 'vitest';
+
+import {
+  Shortfin_TextToImage_SDXL_Client,
+} from './definition.declared.ts';
+
+describe.todo(Shortfin_TextToImage_SDXL_Client);

--- a/src/library/URI/Data/definition.declared.test.ts
+++ b/src/library/URI/Data/definition.declared.test.ts
@@ -1,0 +1,9 @@
+import {
+  describe,
+} from 'vitest';
+
+import {
+  URI_Data,
+} from './definition.declared.ts';
+
+describe.todo(URI_Data);

--- a/src/library/URI/Image/definition.declared.test.ts
+++ b/src/library/URI/Image/definition.declared.test.ts
@@ -1,0 +1,9 @@
+import {
+  describe,
+} from 'vitest';
+
+import {
+  URI_Image,
+} from './definition.declared.ts';
+
+describe.todo(URI_Image);

--- a/src/library/URI/definition.declared.test.ts
+++ b/src/library/URI/definition.declared.test.ts
@@ -1,0 +1,9 @@
+import {
+  describe,
+} from 'vitest';
+
+import {
+  URI,
+} from './definition.declared.ts';
+
+describe.todo(URI);

--- a/src/library/URLComponent/Origin.test.ts
+++ b/src/library/URLComponent/Origin.test.ts
@@ -1,0 +1,9 @@
+import {
+  describe,
+} from 'vitest';
+
+import {
+  URLComponent_Origin,
+} from './Origin';
+
+describe.todo(URLComponent_Origin);

--- a/src/library/URLComponent/Path.test.ts
+++ b/src/library/URLComponent/Path.test.ts
@@ -1,0 +1,9 @@
+import {
+  describe,
+} from 'vitest';
+
+import {
+  URLComponent_Path,
+} from './Path';
+
+describe.todo(URLComponent_Path);

--- a/src/library/WebAPI/Server.test.ts
+++ b/src/library/WebAPI/Server.test.ts
@@ -1,0 +1,9 @@
+import {
+  describe,
+} from 'vitest';
+
+import {
+  WebAPI_Server,
+} from './Server';
+
+describe.todo(WebAPI_Server);

--- a/src/library/math/aggregators/arithmeticMeanOf.test.ts
+++ b/src/library/math/aggregators/arithmeticMeanOf.test.ts
@@ -1,0 +1,9 @@
+import {
+  describe,
+} from 'vitest';
+
+import {
+  arithmeticMeanOf,
+} from './arithmeticMeanOf';
+
+describe.todo(arithmeticMeanOf);

--- a/src/library/utilitiesByType/record/shallowlyMerged.test.ts
+++ b/src/library/utilitiesByType/record/shallowlyMerged.test.ts
@@ -1,0 +1,9 @@
+import {
+  describe,
+} from 'vitest';
+
+import {
+  shallowlyMerged,
+} from './shallowlyMerged';
+
+describe.todo(shallowlyMerged);

--- a/src/library/utilitiesByType/string/concatenated.test.ts
+++ b/src/library/utilitiesByType/string/concatenated.test.ts
@@ -1,0 +1,9 @@
+import {
+  describe,
+} from 'vitest';
+
+import {
+  concatenated,
+} from './concatenated';
+
+describe.todo(concatenated);

--- a/src/library/vue/ProgressiveRef/instance.test.ts
+++ b/src/library/vue/ProgressiveRef/instance.test.ts
@@ -1,0 +1,9 @@
+import {
+  describe,
+} from 'vitest';
+
+import {
+  progressiveRef,
+} from './instance';
+
+describe.todo(progressiveRef);

--- a/src/library/vue/Ref/set.test.ts
+++ b/src/library/vue/Ref/set.test.ts
@@ -1,0 +1,9 @@
+import {
+  describe,
+} from 'vitest';
+
+import {
+  set,
+} from './set';
+
+describe.todo(set);


### PR DESCRIPTION
- with these stubs in place, the "TODOs" will show up skipped suites in the unit test output