### PR TITLE
ci(docs): ensures docs are linted whenever workflow or deps change

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,7 +19,8 @@ jobs:
         uses: tj-actions/changed-files@v46
         id: changed-files
         with:
-          files: '**/*.md'
+          files: |
+            **/*.md
           separator: ','
       - name: Lint the updated Markdown files
         id: lint-markdown-files

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,6 +20,7 @@ jobs:
         id: changed-files
         with:
           files: |
+            .github/workflows/docs.yml
             **/*.md
           separator: ','
       - name: Lint the updated Markdown files
@@ -31,7 +32,7 @@ jobs:
           globs: >-
             ${{
               (
-                'true'
+                contains(steps.changed-files.outputs.all_changed_files, '.github/workflows/docs.yml')
               )
               && '**/*.md'
               || steps.changed-files.outputs.all_changed_files

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,6 +21,7 @@ jobs:
         with:
           files: |
             .github/workflows/docs.yml
+            package.json
             **/*.md
           separator: ','
       - name: Lint the updated Markdown files
@@ -32,7 +33,8 @@ jobs:
           globs: >-
             ${{
               (
-                contains(steps.changed-files.outputs.all_changed_files, '.github/workflows/docs.yml')
+                contains(steps.changed-files.outputs.all_changed_files, '.github/workflows/docs.yml') ||
+                contains(steps.changed-files.outputs.all_changed_files, 'package.json')
               )
               && '**/*.md'
               || steps.changed-files.outputs.all_changed_files

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -30,7 +30,11 @@ jobs:
           config: .markdownlint-cli2.yaml
           globs: >-
             ${{
-              steps.changed-files.outputs.all_changed_files
+              (
+                'true'
+              )
+              && '**/*.md'
+              || steps.changed-files.outputs.all_changed_files
             }}
           separator: ','
         continue-on-error: true

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -28,7 +28,10 @@ jobs:
         if: steps.changed-files.outputs.any_changed == 'true'
         with:
           config: .markdownlint-cli2.yaml
-          globs: ${{ steps.changed-files.outputs.all_changed_files }}
+          globs: >-
+            ${{
+              steps.changed-files.outputs.all_changed_files
+            }}
           separator: ','
         continue-on-error: true
       - name: If linter failed, highlight debug tools


### PR DESCRIPTION
- automated bumps to markdown linter were not triggering the full lint workflow for markdown docs

Incited by #1062