### PR TITLE
linter: enforces consistent padding for multiline variable declarations

### DIFF
--- a/eslint.stylistic.ts
+++ b/eslint.stylistic.ts
@@ -77,6 +77,8 @@ const extraConfig: ConfigWithExtends = {
           'class',
           'function-overload',
           'if', // for guard clauses
+          'multiline-let', // i.e. for chained calls and object literals
+          'multiline-const', // i.e. for chained calls and object literals
           'multiline-expression', // i.e. for multiline function calls
         ],
       },
@@ -87,6 +89,8 @@ const extraConfig: ConfigWithExtends = {
           'class',
           'function-overload',
           'if', // for guard clauses
+          'multiline-let', // i.e. for chained calls and object literals
+          'multiline-const', // i.e. for chained calls and object literals
           'multiline-expression', // i.e. for multiline function calls
         ],
         next: '*',

--- a/eslint.stylistic.ts
+++ b/eslint.stylistic.ts
@@ -77,7 +77,7 @@ const extraConfig: ConfigWithExtends = {
           'class',
           'function-overload',
           'if', // for guard clauses
-          'multiline-expression', // i.e. const assignment from return value of multiline function call
+          'multiline-expression', // i.e. for multiline function calls
         ],
       },
       {
@@ -87,7 +87,7 @@ const extraConfig: ConfigWithExtends = {
           'class',
           'function-overload',
           'if', // for guard clauses
-          'multiline-expression', // i.e. const assignment from return value of multiline function call
+          'multiline-expression', // i.e. for multiline function calls
         ],
         next: '*',
       },


### PR DESCRIPTION
Overlooked in #1067