### PR TITLE
ci(dependabot): auto-approves non-major bumps to vue-tsc

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -30,7 +30,6 @@ jobs:
         if: |
           contains(
             fromJSON('[
-              "vue-tsc"
             ]'),
             steps.metadata.outputs.dependency-names
           )
@@ -52,7 +51,8 @@ jobs:
               "typescript-eslint",
               "typescript",
               "vite",
-              "vite-plugin-vue-devtools"
+              "vite-plugin-vue-devtools",
+              "vue-tsc"
             ]'),
             steps.metadata.outputs.dependency-names
           )


### PR DESCRIPTION
- since this dependency only affects the typescript compiler, the compilation step in the CI's "node" workflow is sufficient to prevent merging in regressions

Incited by #1072