### PR TITLE
refactor: swaps `zod` with `effect`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "shark-ui",
       "version": "0.4.0",
       "dependencies": {
+        "effect": "^3.18.1",
         "stabilityai-client-typescript": "github:nod-ai/StabilityAI-client-typescript#npm/v0.1.0",
         "vue": "^3.5.22",
         "vue-router": "^4.5.1",
@@ -2131,7 +2132,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.0.0.tgz",
       "integrity": "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@stylistic/eslint-plugin": {
@@ -4858,6 +4858,16 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/effect": {
+      "version": "3.18.1",
+      "resolved": "https://registry.npmjs.org/effect/-/effect-3.18.1.tgz",
+      "integrity": "sha512-5aJ7yRlvvkBplMSnhPyol7WYvPenvau12asO3HJhG/126SySWV9D8bscGTbV52XxtC5bwO/VUd5ffjE6uep/1A==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "fast-check": "^3.23.1"
+      }
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.173",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.173.tgz",
@@ -5720,6 +5730,28 @@
         "node >=0.6.0"
       ],
       "license": "MIT"
+    },
+    "node_modules/fast-check": {
+      "version": "3.23.2",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-3.23.2.tgz",
+      "integrity": "sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "pure-rand": "^6.1.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -10285,6 +10317,22 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/pure-rand": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.1.0.tgz",
+      "integrity": "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/qs": {
       "version": "6.14.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,8 +12,7 @@
         "stabilityai-client-typescript": "github:nod-ai/StabilityAI-client-typescript#npm/v0.1.0",
         "vue": "^3.5.22",
         "vue-router": "^4.5.1",
-        "vuetify": "^3.10.4",
-        "zod": "^4.1.11"
+        "vuetify": "^3.10.4"
       },
       "devDependencies": {
         "@eslint/markdown": "^7.3.0",
@@ -13073,6 +13072,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.11.tgz",
       "integrity": "sha512-WPsqwxITS2tzx1bzhIKsEs19ABD5vmCVa4xBo2tq/SrV4RNZtfws1EnCWQXM6yh8bD08a1idvkB5MZSBiZsjwg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "lint:docs": "markdownlint-cli2 --fix '**/*.md'"
   },
   "dependencies": {
+    "effect": "^3.18.1",
     "stabilityai-client-typescript": "github:nod-ai/StabilityAI-client-typescript#npm/v0.1.0",
     "vue": "^3.5.22",
     "vue-router": "^4.5.1",

--- a/package.json
+++ b/package.json
@@ -21,8 +21,7 @@
     "stabilityai-client-typescript": "github:nod-ai/StabilityAI-client-typescript#npm/v0.1.0",
     "vue": "^3.5.22",
     "vue-router": "^4.5.1",
-    "vuetify": "^3.10.4",
-    "zod": "^4.1.11"
+    "vuetify": "^3.10.4"
   },
   "devDependencies": {
     "@eslint/markdown": "^7.3.0",

--- a/src/features/TextToImage/Config/definition.declared.ts
+++ b/src/features/TextToImage/Config/definition.declared.ts
@@ -37,7 +37,7 @@ class TextToImage_Config
     TextToImage_Config_ParsingError
   > {
     const parsedConfig = Parse.instanceFrom(givenSubject, {
-      using      : this.Schema_old,
+      using      : this,
       failingWith: TextToImage_Config_ParsingError,
     });
 

--- a/src/features/TextToImage/Config/definition.declared.ts
+++ b/src/features/TextToImage/Config/definition.declared.ts
@@ -1,3 +1,7 @@
+import {
+  Schema,
+} from 'effect';
+
 import type Attempt from '@/library/Attempt';
 import type Parsable from '@/library/Parsable';
 import Parse from '@/library/Parse';
@@ -10,24 +14,21 @@ import {
 
 /** The user-provided settings for the text-to-image feature */
 class TextToImage_Config
-implements Parsable<
-  typeof TextToImage_Config,
-  /*  */ TextToImage_Config_ParsingError
-> {
-  public constructor(
+  extends Schema.Class<TextToImage_Config>('TextToImage_Config')({
     /** The details of the server that's providing text-to-image generation */
-    public readonly server: WebAPI.Server | null,
-  ) {}
-
+    server: Schema.NullOr(WebAPI.Server),
+  })
+  implements Parsable<
+    typeof TextToImage_Config,
+    /*  */ TextToImage_Config_ParsingError
+  > {
   private static Schema_old = Schema_old
     .object({
       server: WebAPI.Server.Schema_old
         .nullable()
         .catch(null),
     })
-    .transform($0 => new TextToImage_Config(
-      $0.server,
-    ));
+    .transform($0 => new TextToImage_Config($0));
 
   public static parsedFrom(
     givenSubject: unknown,

--- a/src/features/TextToImage/Config/definition.declared.ts
+++ b/src/features/TextToImage/Config/definition.declared.ts
@@ -5,7 +5,6 @@ import {
 import type Attempt from '@/library/Attempt';
 import type Parsable from '@/library/Parsable';
 import Parse from '@/library/Parse';
-import Schema_old from '@/library/Schema';
 import WebAPI from '@/library/WebAPI';
 
 import {
@@ -22,14 +21,6 @@ class TextToImage_Config
     typeof TextToImage_Config,
     /*  */ TextToImage_Config_ParsingError
   > {
-  private static Schema_old = Schema_old
-    .object({
-      server: WebAPI.Server.Schema_old
-        .nullable()
-        .catch(null),
-    })
-    .transform($0 => new TextToImage_Config($0));
-
   public static parsedFrom(
     givenSubject: unknown,
   ): Attempt.Outcome<

--- a/src/features/TextToImage/Config/definition.declared.ts
+++ b/src/features/TextToImage/Config/definition.declared.ts
@@ -1,7 +1,7 @@
 import type Attempt from '@/library/Attempt';
 import type Parsable from '@/library/Parsable';
 import Parse from '@/library/Parse';
-import Schema from '@/library/Schema';
+import Schema_old from '@/library/Schema';
 import WebAPI from '@/library/WebAPI';
 
 import {
@@ -19,9 +19,9 @@ implements Parsable<
     public readonly server: WebAPI.Server | null,
   ) {}
 
-  private static Schema = Schema
+  private static Schema_old = Schema_old
     .object({
-      server: WebAPI.Server.Schema
+      server: WebAPI.Server.Schema_old
         .nullable()
         .catch(null),
     })
@@ -36,7 +36,7 @@ implements Parsable<
     TextToImage_Config_ParsingError
   > {
     const parsedConfig = Parse.instanceFrom(givenSubject, {
-      using      : this.Schema,
+      using      : this.Schema_old,
       failingWith: TextToImage_Config_ParsingError,
     });
 

--- a/src/library/Parse/instanceFrom.ts
+++ b/src/library/Parse/instanceFrom.ts
@@ -1,9 +1,14 @@
+import {
+  Either,
+  Schema,
+} from 'effect';
+
 import Attempt from '@/library/Attempt';
 import type ParsingError from '@/library/ParsingError';
-import type Schema_old from '@/library/Schema';
 
 const Parse_instanceFrom = <
-  SomeSchema extends Schema_old.ZodType,
+  SomeDecodingOutput,
+  SomeEncodingOutput,
   SomeParsingError extends ParsingError<string>,
 >(
   givenSubject: unknown,
@@ -11,20 +16,20 @@ const Parse_instanceFrom = <
     using: givenSchema,
     failingWith: GivenParsingError,
   }: {
-    using: SomeSchema;
+    using: Schema.Schema<SomeDecodingOutput, SomeEncodingOutput>;
     failingWith: new (message: string) => SomeParsingError;
   },
 ): Attempt.Outcome<
-  Schema_old.infer<SomeSchema>,
+  typeof givenSchema.Type,
   SomeParsingError
 > => Attempt.Fresh.that((ends) => {
-  const resultOfParsingSubject = givenSchema.safeParse(givenSubject);
+  const resultOfDecodingSubject = Schema.decodeUnknownEither(givenSchema)(givenSubject);
 
   if (
-    resultOfParsingSubject.success
-  ) return ends.inSuccessWith(resultOfParsingSubject.data);
+    Either.isRight(resultOfDecodingSubject)
+  ) return ends.inSuccessWith(resultOfDecodingSubject.right);
 
-  const newParsingError = new GivenParsingError(resultOfParsingSubject.error.message);
+  const newParsingError = new GivenParsingError(resultOfDecodingSubject.left.message);
   return ends.inFailureDueTo(newParsingError);
 });
 

--- a/src/library/Parse/instanceFrom.ts
+++ b/src/library/Parse/instanceFrom.ts
@@ -1,9 +1,9 @@
 import Attempt from '@/library/Attempt';
 import type ParsingError from '@/library/ParsingError';
-import type Schema from '@/library/Schema';
+import type Schema_old from '@/library/Schema';
 
 const Parse_instanceFrom = <
-  SomeSchema extends Schema.ZodType,
+  SomeSchema extends Schema_old.ZodType,
   SomeParsingError extends ParsingError<string>,
 >(
   givenSubject: unknown,
@@ -15,7 +15,7 @@ const Parse_instanceFrom = <
     failingWith: new (message: string) => SomeParsingError;
   },
 ): Attempt.Outcome<
-  Schema.infer<SomeSchema>,
+  Schema_old.infer<SomeSchema>,
   SomeParsingError
 > => Attempt.Fresh.that((ends) => {
   const resultOfParsingSubject = givenSchema.safeParse(givenSubject);

--- a/src/library/Schema/core.ts
+++ b/src/library/Schema/core.ts
@@ -1,1 +1,0 @@
-export * from 'zod';

--- a/src/library/Schema/definition.assembled.members.ts
+++ b/src/library/Schema/definition.assembled.members.ts
@@ -1,1 +1,0 @@
-export * from './core'; // Uses the aliases as-is

--- a/src/library/Schema/definition.assembled.ts
+++ b/src/library/Schema/definition.assembled.ts
@@ -1,1 +1,0 @@
-export * as Schema from './definition.assembled.members.ts';

--- a/src/library/Schema/exports.object.primary.ts
+++ b/src/library/Schema/exports.object.primary.ts
@@ -1,1 +1,0 @@
-export * from './definition.assembled.ts';

--- a/src/library/Schema/index.ts
+++ b/src/library/Schema/index.ts
@@ -1,3 +1,0 @@
-export {
-  Schema as default,
-} from './exports.object.primary.ts';

--- a/src/library/Sequence/Byte/Encoded/Base64/definition.declared.ts
+++ b/src/library/Sequence/Byte/Encoded/Base64/definition.declared.ts
@@ -7,7 +7,6 @@ import Attempt from '@/library/Attempt';
 import Base64 from '@/library/Base64';
 import Byte from '@/library/Byte';
 import type Parsable from '@/library/Parsable';
-import Schema_old from '@/library/Schema';
 import StringSubset from '@/library/StringSubset';
 
 import {
@@ -110,22 +109,6 @@ class Sequence_Byte_Encoded_Base64
       encode: $0 => ParseResult.succeed($0.toString()),
     },
   );
-
-  /** An alternative to `Schema.base64()` that avoids using the deprecated `atob` conversion under the hood */
-  public static Schema_old = Schema_old.string().transform((someSubject, currentContext) => {
-    const outcomeOfParsingSubject = this.parsedFrom(someSubject);
-
-    if (
-      outcomeOfParsingSubject.isSuccess
-    ) return outcomeOfParsingSubject.unwrapped;
-
-    currentContext.addIssue({
-      code   : 'custom',
-      message: outcomeOfParsingSubject.cause.message,
-    });
-
-    return Schema_old.NEVER;
-  });
 }
 
 export {

--- a/src/library/Sequence/Byte/Encoded/Base64/definition.declared.ts
+++ b/src/library/Sequence/Byte/Encoded/Base64/definition.declared.ts
@@ -1,3 +1,8 @@
+import {
+  ParseResult,
+  Schema,
+} from 'effect';
+
 import Attempt from '@/library/Attempt';
 import Base64 from '@/library/Base64';
 import Byte from '@/library/Byte';
@@ -81,6 +86,30 @@ class Sequence_Byte_Encoded_Base64
 
     return outcomeOfParsingByteSequence;
   };
+
+  public static Schema = Schema.transformOrFail(
+    Schema.String,
+    Schema.instanceOf(Sequence_Byte_Encoded_Base64),
+    {
+      strict: true,
+      decode: (input, options, ast) => {
+        const outcomeOfParsingInput = this.parsedFrom(input);
+
+        if (
+          outcomeOfParsingInput.isSuccess
+        ) return ParseResult.succeed(outcomeOfParsingInput.unwrapped);
+
+        const newParsingIssue = new ParseResult.Type(
+          ast,
+          input,
+          outcomeOfParsingInput.cause.message,
+        );
+
+        return ParseResult.fail(newParsingIssue);
+      },
+      encode: $0 => ParseResult.succeed($0.toString()),
+    },
+  );
 
   /** An alternative to `Schema.base64()` that avoids using the deprecated `atob` conversion under the hood */
   public static Schema_old = Schema_old.string().transform((someSubject, currentContext) => {

--- a/src/library/Sequence/Byte/Encoded/Base64/definition.declared.ts
+++ b/src/library/Sequence/Byte/Encoded/Base64/definition.declared.ts
@@ -2,7 +2,7 @@ import Attempt from '@/library/Attempt';
 import Base64 from '@/library/Base64';
 import Byte from '@/library/Byte';
 import type Parsable from '@/library/Parsable';
-import Schema from '@/library/Schema';
+import Schema_old from '@/library/Schema';
 import StringSubset from '@/library/StringSubset';
 
 import {
@@ -83,7 +83,7 @@ class Sequence_Byte_Encoded_Base64
   };
 
   /** An alternative to `Schema.base64()` that avoids using the deprecated `atob` conversion under the hood */
-  public static Schema = Schema.string().transform((someSubject, currentContext) => {
+  public static Schema_old = Schema_old.string().transform((someSubject, currentContext) => {
     const outcomeOfParsingSubject = this.parsedFrom(someSubject);
 
     if (
@@ -95,7 +95,7 @@ class Sequence_Byte_Encoded_Base64
       message: outcomeOfParsingSubject.cause.message,
     });
 
-    return Schema.NEVER;
+    return Schema_old.NEVER;
   });
 }
 

--- a/src/library/Shortfin/TextToImage/SDXL/Client/Response/Body/definition.declared.ts
+++ b/src/library/Shortfin/TextToImage/SDXL/Client/Response/Body/definition.declared.ts
@@ -1,7 +1,7 @@
 import type Attempt from '@/library/Attempt';
 import type Parsable from '@/library/Parsable';
 import Parse from '@/library/Parse';
-import Schema from '@/library/Schema';
+import Schema_old from '@/library/Schema';
 import Sequence from '@/library/Sequence';
 
 import {
@@ -20,14 +20,14 @@ implements Parsable<
     ],
   ) {}
 
-  private static Schema = Schema
+  private static Schema_old = Schema_old
     .object({
-      images: Schema
+      images: Schema_old
         .tuple([
-          Sequence.Byte.Encoded.Base64.Schema,
+          Sequence.Byte.Encoded.Base64.Schema_old,
         ])
         .rest(
-          Sequence.Byte.Encoded.Base64.Schema,
+          Sequence.Byte.Encoded.Base64.Schema_old,
         ),
     })
     .transform($0 => new Shortfin_TextToImage_SDXL_Client_Response_Body(
@@ -41,7 +41,7 @@ implements Parsable<
     Shortfin_TextToImage_SDXL_Client_Response_Body_ParsingError
   > {
     const parsedBody = Parse.instanceFrom(givenSubject, {
-      using      : this.Schema,
+      using      : this.Schema_old,
       failingWith: Shortfin_TextToImage_SDXL_Client_Response_Body_ParsingError,
     });
 

--- a/src/library/Shortfin/TextToImage/SDXL/Client/Response/Body/definition.declared.ts
+++ b/src/library/Shortfin/TextToImage/SDXL/Client/Response/Body/definition.declared.ts
@@ -39,7 +39,7 @@ class Shortfin_TextToImage_SDXL_Client_Response_Body
     Shortfin_TextToImage_SDXL_Client_Response_Body_ParsingError
   > {
     const parsedBody = Parse.instanceFrom(givenSubject, {
-      using      : this.Schema_old,
+      using      : this,
       failingWith: Shortfin_TextToImage_SDXL_Client_Response_Body_ParsingError,
     });
 

--- a/src/library/Shortfin/TextToImage/SDXL/Client/Response/Body/definition.declared.ts
+++ b/src/library/Shortfin/TextToImage/SDXL/Client/Response/Body/definition.declared.ts
@@ -1,3 +1,7 @@
+import {
+  Schema,
+} from 'effect';
+
 import type Attempt from '@/library/Attempt';
 import type Parsable from '@/library/Parsable';
 import Parse from '@/library/Parse';
@@ -9,17 +13,13 @@ import {
 } from './ParsingError';
 
 class Shortfin_TextToImage_SDXL_Client_Response_Body
-implements Parsable<
-  typeof Shortfin_TextToImage_SDXL_Client_Response_Body,
-  /*  */ Shortfin_TextToImage_SDXL_Client_Response_Body_ParsingError
-> {
-  public constructor(
-    public images: [
-      Sequence.Byte.Encoded.Base64,
-      ...Sequence.Byte.Encoded.Base64[],
-    ],
-  ) {}
-
+  extends Schema.Class<Shortfin_TextToImage_SDXL_Client_Response_Body>('Shortfin_TextToImage_SDXL_Client_Response_Body')({
+    images: Schema.NonEmptyArray(Sequence.Byte.Encoded.Base64.Schema),
+  })
+  implements Parsable<
+    typeof Shortfin_TextToImage_SDXL_Client_Response_Body,
+    /*  */ Shortfin_TextToImage_SDXL_Client_Response_Body_ParsingError
+  > {
   private static Schema_old = Schema_old
     .object({
       images: Schema_old
@@ -30,9 +30,7 @@ implements Parsable<
           Sequence.Byte.Encoded.Base64.Schema_old,
         ),
     })
-    .transform($0 => new Shortfin_TextToImage_SDXL_Client_Response_Body(
-      $0.images,
-    ));
+    .transform($0 => new Shortfin_TextToImage_SDXL_Client_Response_Body($0));
 
   public static parsedFrom(
     givenSubject: unknown,

--- a/src/library/Shortfin/TextToImage/SDXL/Client/Response/Body/definition.declared.ts
+++ b/src/library/Shortfin/TextToImage/SDXL/Client/Response/Body/definition.declared.ts
@@ -5,7 +5,6 @@ import {
 import type Attempt from '@/library/Attempt';
 import type Parsable from '@/library/Parsable';
 import Parse from '@/library/Parse';
-import Schema_old from '@/library/Schema';
 import Sequence from '@/library/Sequence';
 
 import {
@@ -20,18 +19,6 @@ class Shortfin_TextToImage_SDXL_Client_Response_Body
     typeof Shortfin_TextToImage_SDXL_Client_Response_Body,
     /*  */ Shortfin_TextToImage_SDXL_Client_Response_Body_ParsingError
   > {
-  private static Schema_old = Schema_old
-    .object({
-      images: Schema_old
-        .tuple([
-          Sequence.Byte.Encoded.Base64.Schema_old,
-        ])
-        .rest(
-          Sequence.Byte.Encoded.Base64.Schema_old,
-        ),
-    })
-    .transform($0 => new Shortfin_TextToImage_SDXL_Client_Response_Body($0));
-
   public static parsedFrom(
     givenSubject: unknown,
   ): Attempt.Outcome<

--- a/src/library/WebAPI/Server.ts
+++ b/src/library/WebAPI/Server.ts
@@ -1,3 +1,7 @@
+import {
+  Schema,
+} from 'effect';
+
 import Schema_old from '@/library/Schema';
 
 /**
@@ -5,18 +9,17 @@ import Schema_old from '@/library/Schema';
  * - listens for requests
  * - responds to those requests
  */
-class WebAPI_Server {
-  public constructor(
+class WebAPI_Server
+  extends Schema.Class<WebAPI_Server>('WebAPI_Server')({
     /**
      * The web location of the server, which is the base URL of the API.
      * For example: https://api.example.com
      */
-    public readonly origin: string,
-  ) {}
-
+    origin: Schema.String,
+  }) {
   public static from(given: WebAPI_Server): WebAPI_Server {
     const clonedServer = new WebAPI_Server(
-      given.origin,
+      given,
     );
 
     return clonedServer;

--- a/src/library/WebAPI/Server.ts
+++ b/src/library/WebAPI/Server.ts
@@ -2,8 +2,6 @@ import {
   Schema,
 } from 'effect';
 
-import Schema_old from '@/library/Schema';
-
 /**
  * The machine conforming to some web API that:
  * - listens for requests
@@ -24,12 +22,6 @@ class WebAPI_Server
 
     return clonedServer;
   }
-
-  public static Schema_old = Schema_old
-    .object({
-      origin: Schema_old.string(),
-    })
-    .transform($0 => WebAPI_Server.from($0));
 }
 
 export {

--- a/src/library/WebAPI/Server.ts
+++ b/src/library/WebAPI/Server.ts
@@ -1,4 +1,4 @@
-import Schema from '@/library/Schema';
+import Schema_old from '@/library/Schema';
 
 /**
  * The machine conforming to some web API that:
@@ -22,9 +22,9 @@ class WebAPI_Server {
     return clonedServer;
   }
 
-  public static Schema = Schema
+  public static Schema_old = Schema_old
     .object({
-      origin: Schema.string(),
+      origin: Schema_old.string(),
     })
     .transform($0 => WebAPI_Server.from($0));
 }


### PR DESCRIPTION
- [zod](https://github.com/colinhacks/zod) specializes in schema validation, which was used to ingest raw web responses
- [effect](https://github.com/Effect-TS/effect) is able to do this as well while also providing what amounts to an actual standard library for TypeScript/JavaScript
- With `effect` as a dependency, it can be leveraged to replace a fair amount of the home-rolled solutions that have started to weigh down the project (in terms of maintenance required to keep codebase consistent with itself, writing tests, etc.)
- `effect` only adds ~100 kb to the bundled package, which is expected to be offset by the dissolution of several "internal dependencies"