### PR TITLE
fix(text-to-image): ensures config is parsable

### DIFF
--- a/docs/setup/for_users.md
+++ b/docs/setup/for_users.md
@@ -23,9 +23,7 @@ Now, specify the existing Shortfin text-to-image server so the SHARK UI knows wh
         ```json
         {
             ...
-            "server": {
-                "origin": null
-            }
+            "server": null
             ...
         }
         ```

--- a/public/config/text-to-image.json
+++ b/public/config/text-to-image.json
@@ -1,5 +1,3 @@
 {
-    "server": {
-        "origin": null
-    }
+    "server": null
 }


### PR DESCRIPTION
- parsing the default static config resulted in a defect because `"server.origin": null`
- `effect` does not appear to have an equivalent for member-wise `.catch(...)` to account for this
- the easiest path was to conform the default config and updates the docs

Broken by #1086