### PR TITLE
style: makes heritage patterns easier to search for

### DIFF
--- a/src/library/Attempt/Error/Actionable.ts
+++ b/src/library/Attempt/Error/Actionable.ts
@@ -22,7 +22,8 @@ import {
 /** Extend this class to describe errors from which callers ought to recover */
 abstract class Attempt_Error_Actionable<
   SomeBrand extends string,
-> extends Error
+>
+  extends Error
   implements Branded<
     SomeBrand
   > {

--- a/src/library/Attempt/Outcome/Discriminable/definition.declared.ts
+++ b/src/library/Attempt/Outcome/Discriminable/definition.declared.ts
@@ -23,7 +23,8 @@ interface Attempt_Outcome_Discriminable<
       ? unknown
       : Attempt_Error.Actionable<string>
   ),
-> extends Attempt_Outcome_Discriminable_SyntacticallySugarfree<
+>
+  extends Attempt_Outcome_Discriminable_SyntacticallySugarfree<
     SomeDiscriminant
   > {
   readonly isSuccess: Is<this['discriminant'], 'success'>;

--- a/src/library/Attempt/Outcome/Failure/SemanticallySugarfree.ts
+++ b/src/library/Attempt/Outcome/Failure/SemanticallySugarfree.ts
@@ -8,7 +8,8 @@ import type {
 
 interface Attempt_Outcome_Failure_SemanticallySugarfree<
   SomeActionableError extends Attempt_Error.Actionable<string>,
-> extends Attempt_Outcome_Discriminable<
+>
+  extends Attempt_Outcome_Discriminable<
     'failure',
     SomeActionableError
   > {

--- a/src/library/Attempt/Outcome/Failure/definition.declared.ts
+++ b/src/library/Attempt/Outcome/Failure/definition.declared.ts
@@ -12,7 +12,8 @@ import type {
 
 interface Attempt_Outcome_Failure<
   SomeActionableError extends Attempt_Error.Actionable<string>,
-> extends Attempt_Outcome_Failure_SemanticallySugarfree<
+>
+  extends Attempt_Outcome_Failure_SemanticallySugarfree<
     SomeActionableError
   > {
   /**

--- a/src/library/Attempt/Outcome/Success/SemanticallySugarfree.ts
+++ b/src/library/Attempt/Outcome/Success/SemanticallySugarfree.ts
@@ -4,7 +4,8 @@ import type {
 
 interface Attempt_Outcome_Success_SemanticallySugarfree<
   SomeProduct,
-> extends Attempt_Outcome_Discriminable<
+>
+  extends Attempt_Outcome_Discriminable<
     'success',
     SomeProduct
   > {

--- a/src/library/Attempt/Outcome/Success/definition.declared.ts
+++ b/src/library/Attempt/Outcome/Success/definition.declared.ts
@@ -12,7 +12,8 @@ import type {
 
 interface Attempt_Outcome_Success<
   SomeProduct,
-> extends Attempt_Outcome_Success_SemanticallySugarfree<
+>
+  extends Attempt_Outcome_Success_SemanticallySugarfree<
     SomeProduct
   > {
   /**

--- a/src/library/NonTrivialString/definition.declared.ts
+++ b/src/library/NonTrivialString/definition.declared.ts
@@ -15,7 +15,8 @@ import {
 class NonTrivialString
   extends StringSubset<
     'NonTrivialString'
-  > implements Parsable.String<
+  >
+  implements Parsable.String<
     typeof NonTrivialString,
     /*  */ NonTrivialString_ParsingError
   > {

--- a/src/library/ParsingError.ts
+++ b/src/library/ParsingError.ts
@@ -2,7 +2,8 @@ import Attempt from '@/library/Attempt';
 
 abstract class ParsingError<
   SomeSubject extends string,
-> extends Attempt.Error.Actionable<
+>
+  extends Attempt.Error.Actionable<
     `${SomeSubject}_ParsingError`
   > {
   public constructor(

--- a/src/library/Sequence/Byte/Encoded/Base64/definition.declared.ts
+++ b/src/library/Sequence/Byte/Encoded/Base64/definition.declared.ts
@@ -30,7 +30,8 @@ import {
 class Sequence_Byte_Encoded_Base64
   extends StringSubset<
     'Sequence_Byte_Encoded_Base64'
-  > implements Parsable.String<
+  >
+  implements Parsable.String<
     typeof Sequence_Byte_Encoded_Base64,
     /*  */ Sequence_Byte_Encoded_Base64_ParsingError
   > {

--- a/src/library/StringSubset.ts
+++ b/src/library/StringSubset.ts
@@ -12,7 +12,8 @@ import {
  */
 abstract class StringSubset<
   SomeBrand extends string,
-> extends String
+>
+  extends String
   implements Branded<
     SomeBrand
   > {

--- a/src/library/URLComponent/Origin/definition.declared.ts
+++ b/src/library/URLComponent/Origin/definition.declared.ts
@@ -9,7 +9,8 @@ import {
 class URLComponent_Origin
   extends StringSubset<
     'URLComponent_Origin'
-  > implements Parsable.String<
+  >
+  implements Parsable.String<
     typeof URLComponent_Origin,
     /*  */ URLComponent_Origin_ParsingError
   > {

--- a/src/library/URLComponent/Path/definition.declared.ts
+++ b/src/library/URLComponent/Path/definition.declared.ts
@@ -9,7 +9,8 @@ import {
 class URLComponent_Path
   extends StringSubset<
     'URLComponent_Path'
-  > implements Parsable.String<
+  >
+  implements Parsable.String<
     typeof URLComponent_Path,
     /*  */ URLComponent_Path_ParsingError
   > {


### PR DESCRIPTION
- ensures heritage clauses are disjointed, especially when the previous clause is generic
- reduces diff noise