### PR TITLE
refactor(library/utilitiesByType): removes "/string/StringLike" module

### DIFF
--- a/src/library/utilitiesByType/string/StringLike.ts
+++ b/src/library/utilitiesByType/string/StringLike.ts
@@ -1,5 +1,0 @@
-type StringLike = string | String; // eslint-disable-line @typescript-eslint/no-wrapper-object-types -- means "both the auto-boxed and primitive types"
-
-export type {
-  StringLike,
-};

--- a/src/library/utilitiesByType/string/concatenated.ts
+++ b/src/library/utilitiesByType/string/concatenated.ts
@@ -1,9 +1,5 @@
-import type {
-  StringLike,
-} from './StringLike';
-
 const concatenated = (
-  ...givenOperands: (StringLike | null)[]
+  ...givenOperands: (string | null)[]
 ): string => {
   const joinableOperands = givenOperands.map($0 => $0?.toString() ?? '');
   const joinedOperands = joinableOperands.join('');

--- a/src/library/utilitiesByType/string/concatenated.ts
+++ b/src/library/utilitiesByType/string/concatenated.ts
@@ -1,7 +1,7 @@
 const concatenated = (
   ...givenOperands: (string | null)[]
 ): string => {
-  const joinableOperands = givenOperands.map($0 => $0?.toString() ?? '');
+  const joinableOperands = givenOperands.map($0 => $0 ?? '');
   const joinedOperands = joinableOperands.join('');
   return joinedOperands;
 };

--- a/src/library/utilitiesByType/string/exports.toolbox.ts
+++ b/src/library/utilitiesByType/string/exports.toolbox.ts
@@ -1,5 +1,3 @@
-export type * from './StringLike';
-
 export * from './isString';
 
 export * from './asString';


### PR DESCRIPTION
Enabled by #1112 with the removal of `StringSubset`