### PR TITLE
linter: enforces no unused modules

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,8 @@
+{
+  "ignorePatterns": [
+    "*.d.ts",
+    "*.config.ts",
+    "eslint.*.ts",
+    "definition.declared.augmentation.ts"
+  ]
+}

--- a/eslint.import.ts
+++ b/eslint.import.ts
@@ -97,8 +97,26 @@ const extendedConfig: ConfigWithExtends = {
   },
 };
 
+const ruleForNoUnusedModules: ConfigWithExtends = {
+  ignores: [
+    '*.d.ts',
+    '*.config.ts',
+    'eslint.*.ts',
+    'definition.declared.augmentation.ts',
+  ],
+  rules: {
+    'import/no-unused-modules': [
+      'error',
+      {
+        unusedExports: true,
+      },
+    ],
+  },
+};
+
 const pluginImport: ConfigWithExtends[] = [
   extendedConfig,
+  ruleForNoUnusedModules,
 ];
 
 export {


### PR DESCRIPTION
- .eslintrc was required as discussed in [this issue](https://github.com/import-js/eslint-plugin-import/issues/3079)