### PR TITLE
prefeature(library/Attempt): refreshes `.unwrapOr*(...)` method suite

### DIFF
--- a/src/features/TextToImage/Server/Current/retrieve.ts
+++ b/src/features/TextToImage/Server/Current/retrieve.ts
@@ -27,13 +27,13 @@ const TextToImage_Server_Current_retrieve = (): Promise<
     TextToImage_Server_Current_accordingToEnvironment !== null
   ) return ends.inSuccessWith(TextToImage_Server_Current_accordingToEnvironment);
 
-  const staticConfig = (await TextToImage_Config.Static.read()).unwrapOrNull() ?? TextToImage_Config.empty;
+  const staticConfig = (await TextToImage_Config.Static.read()).unwrapOr(TextToImage_Config.empty);
 
   if (
     staticConfig.server !== null
   ) return ends.inSuccessWith(staticConfig.server);
 
-  const dynamicConfig = (await TextToImage_Config.Dynamic.fetch()).unwrapOrNull() ?? TextToImage_Config.empty;
+  const dynamicConfig = (await TextToImage_Config.Dynamic.fetch()).unwrapOr(TextToImage_Config.empty);
 
   if (
     dynamicConfig.server !== null

--- a/src/features/TextToImage/Server/Current/retrieve.ts
+++ b/src/features/TextToImage/Server/Current/retrieve.ts
@@ -27,13 +27,13 @@ const TextToImage_Server_Current_retrieve = (): Promise<
     TextToImage_Server_Current_accordingToEnvironment !== null
   ) return ends.inSuccessWith(TextToImage_Server_Current_accordingToEnvironment);
 
-  const staticConfig = (await TextToImage_Config.Static.read()).optionallyUnwrap() ?? TextToImage_Config.empty;
+  const staticConfig = (await TextToImage_Config.Static.read()).unwrapOrNull() ?? TextToImage_Config.empty;
 
   if (
     staticConfig.server !== null
   ) return ends.inSuccessWith(staticConfig.server);
 
-  const dynamicConfig = (await TextToImage_Config.Dynamic.fetch()).optionallyUnwrap() ?? TextToImage_Config.empty;
+  const dynamicConfig = (await TextToImage_Config.Dynamic.fetch()).unwrapOrNull() ?? TextToImage_Config.empty;
 
   if (
     dynamicConfig.server !== null

--- a/src/library/Attempt/Outcome/Discriminable/definition.declared.ts
+++ b/src/library/Attempt/Outcome/Discriminable/definition.declared.ts
@@ -30,6 +30,15 @@ interface Attempt_Outcome_Discriminable<
   readonly isSuccess: Is<this['discriminant'], 'success'>;
   readonly isFailure: Not<this['isSuccess']>;
 
+  unwrapOr<
+    SomeFallback,
+  >(
+    givenFallback: SomeFallback,
+  ): If<this['isSuccess'],
+    SomePayload,
+    SomeFallback
+  >;
+
   unwrapOrNull(): If<this['isSuccess'],
     SomePayload,
     null

--- a/src/library/Attempt/Outcome/Discriminable/definition.declared.ts
+++ b/src/library/Attempt/Outcome/Discriminable/definition.declared.ts
@@ -39,11 +39,6 @@ interface Attempt_Outcome_Discriminable<
     SomeFallback
   >;
 
-  unwrapOrNull(): If<this['isSuccess'],
-    SomePayload,
-    null
-  >;
-
   unwrapOrThrow(): If<this['isSuccess'],
     SomePayload,
     never

--- a/src/library/Attempt/Outcome/Discriminable/definition.declared.ts
+++ b/src/library/Attempt/Outcome/Discriminable/definition.declared.ts
@@ -35,7 +35,7 @@ interface Attempt_Outcome_Discriminable<
     null
   >;
 
-  forciblyUnwrap(): If<this['isSuccess'],
+  unwrapOrThrow(): If<this['isSuccess'],
     SomePayload,
     never
   >;

--- a/src/library/Attempt/Outcome/Discriminable/definition.declared.ts
+++ b/src/library/Attempt/Outcome/Discriminable/definition.declared.ts
@@ -30,7 +30,7 @@ interface Attempt_Outcome_Discriminable<
   readonly isSuccess: Is<this['discriminant'], 'success'>;
   readonly isFailure: Not<this['isSuccess']>;
 
-  optionallyUnwrap(): If<this['isSuccess'],
+  unwrapOrNull(): If<this['isSuccess'],
     SomePayload,
     null
   >;

--- a/src/library/Attempt/Outcome/Failure/dueTo.ts
+++ b/src/library/Attempt/Outcome/Failure/dueTo.ts
@@ -19,6 +19,7 @@ const Attempt_Outcome_Failure_dueTo = <
   cause         : givenCause,
   isSuccess     : false,
   isFailure     : true,
+  unwrapOr      : <SomeFallback>($0: SomeFallback) => $0,
   unwrapOrNull  : () => null,
   unwrapOrThrow : () => givenCause.throwAnyway('Unexpected forceful unwrap of a failure'),
   causeOfFailure: givenCause,

--- a/src/library/Attempt/Outcome/Failure/dueTo.ts
+++ b/src/library/Attempt/Outcome/Failure/dueTo.ts
@@ -20,7 +20,6 @@ const Attempt_Outcome_Failure_dueTo = <
   isSuccess     : false,
   isFailure     : true,
   unwrapOr      : <SomeFallback>($0: SomeFallback) => $0,
-  unwrapOrNull  : () => null,
   unwrapOrThrow : () => givenCause.throwAnyway('Unexpected forceful unwrap of a failure'),
   causeOfFailure: givenCause,
   rewrappedWith : <

--- a/src/library/Attempt/Outcome/Failure/dueTo.ts
+++ b/src/library/Attempt/Outcome/Failure/dueTo.ts
@@ -20,7 +20,7 @@ const Attempt_Outcome_Failure_dueTo = <
   isSuccess     : false,
   isFailure     : true,
   unwrapOrNull  : () => null,
-  forciblyUnwrap: () => givenCause.throwAnyway('Unexpected forceful unwrap of a failure'),
+  unwrapOrThrow : () => givenCause.throwAnyway('Unexpected forceful unwrap of a failure'),
   causeOfFailure: givenCause,
   rewrappedWith : <
     SomeTransformedActionableError extends Attempt_Error.Actionable<string>,

--- a/src/library/Attempt/Outcome/Failure/dueTo.ts
+++ b/src/library/Attempt/Outcome/Failure/dueTo.ts
@@ -15,14 +15,14 @@ const Attempt_Outcome_Failure_dueTo = <
 >(
   givenCause: SomeActionableError,
 ): Attempt_Outcome_Failure<SomeActionableError> => ({
-  discriminant    : 'failure',
-  cause           : givenCause,
-  isSuccess       : false,
-  isFailure       : true,
-  optionallyUnwrap: () => null,
-  forciblyUnwrap  : () => givenCause.throwAnyway('Unexpected forceful unwrap of a failure'),
-  causeOfFailure  : givenCause,
-  rewrappedWith   : <
+  discriminant  : 'failure',
+  cause         : givenCause,
+  isSuccess     : false,
+  isFailure     : true,
+  unwrapOrNull  : () => null,
+  forciblyUnwrap: () => givenCause.throwAnyway('Unexpected forceful unwrap of a failure'),
+  causeOfFailure: givenCause,
+  rewrappedWith : <
     SomeTransformedActionableError extends Attempt_Error.Actionable<string>,
   >(
     {

--- a/src/library/Attempt/Outcome/Success/definition.declared.ts
+++ b/src/library/Attempt/Outcome/Success/definition.declared.ts
@@ -19,7 +19,7 @@ interface Attempt_Outcome_Success<
   /**
    * Access the product nested within a successful outcome.
    *
-   * Adds a guarded parallel to the `unwrapOrNull` and `unwrapOrThrow` methods:
+   * Adds a guarded parallel to the `unwrapOr` and `unwrapOrThrow` methods:
    * ```ts
    * function doRiskyThingUnsafely(
    *   givenOutcome: Attempt.Outcome<CustomProduct, CustomError>,
@@ -30,7 +30,7 @@ interface Attempt_Outcome_Success<
    * function doRiskyThingSafelyWhileIgnoringErrors(
    *   givenOutcome: Attempt.Outcome<CustomProduct, CustomError>,
    * ): void {
-   *   console.log(givenOutcome.unwrapOrNull());
+   *   console.log(givenOutcome.unwrapOr('Errors ignored'));
    * }
    *
    * function doRiskyThingSafelyWhileHandlingErrors(

--- a/src/library/Attempt/Outcome/Success/definition.declared.ts
+++ b/src/library/Attempt/Outcome/Success/definition.declared.ts
@@ -19,7 +19,7 @@ interface Attempt_Outcome_Success<
   /**
    * Access the product nested within a successful outcome.
    *
-   * Adds a guarded parallel to the `optionallyUnwrap` and `forciblyUnwrapped` methods:
+   * Adds a guarded parallel to the `unwrapOrNull` and `forciblyUnwrapped` methods:
    * ```ts
    * function doRiskyThingUnsafely(
    *   givenOutcome: Attempt.Outcome<CustomProduct, CustomError>,
@@ -30,7 +30,7 @@ interface Attempt_Outcome_Success<
    * function doRiskyThingSafelyWhileIgnoringErrors(
    *   givenOutcome: Attempt.Outcome<CustomProduct, CustomError>,
    * ): void {
-   *   console.log(givenOutcome.optionallyUnwrap());
+   *   console.log(givenOutcome.unwrapOrNull());
    * }
    *
    * function doRiskyThingSafelyWhileHandlingErrors(

--- a/src/library/Attempt/Outcome/Success/definition.declared.ts
+++ b/src/library/Attempt/Outcome/Success/definition.declared.ts
@@ -19,12 +19,12 @@ interface Attempt_Outcome_Success<
   /**
    * Access the product nested within a successful outcome.
    *
-   * Adds a guarded parallel to the `unwrapOrNull` and `forciblyUnwrapped` methods:
+   * Adds a guarded parallel to the `unwrapOrNull` and `unwrapOrThrow` methods:
    * ```ts
    * function doRiskyThingUnsafely(
    *   givenOutcome: Attempt.Outcome<CustomProduct, CustomError>,
    * ): void {
-   *   console.log(givenOutcome.forciblyUnwrap());
+   *   console.log(givenOutcome.unwrapOrThrow());
    * }
    *
    * function doRiskyThingSafelyWhileIgnoringErrors(

--- a/src/library/Attempt/Outcome/Success/thatYielded.ts
+++ b/src/library/Attempt/Outcome/Success/thatYielded.ts
@@ -11,14 +11,14 @@ const Attempt_Outcome_Success_thatYielded = <
 >(
   givenProduct: SomeProduct,
 ): Attempt_Outcome_Success<SomeProduct> => ({
-  discriminant  : 'success',
-  product       : givenProduct,
-  isSuccess     : true,
-  isFailure     : false,
-  unwrapOrNull  : () => givenProduct,
-  forciblyUnwrap: () => givenProduct,
-  unwrapped     : givenProduct,
-  rewrappedWith : <
+  discriminant : 'success',
+  product      : givenProduct,
+  isSuccess    : true,
+  isFailure    : false,
+  unwrapOrNull : () => givenProduct,
+  unwrapOrThrow: () => givenProduct,
+  unwrapped    : givenProduct,
+  rewrappedWith: <
     SomeTransformedProduct,
   >(
     {

--- a/src/library/Attempt/Outcome/Success/thatYielded.ts
+++ b/src/library/Attempt/Outcome/Success/thatYielded.ts
@@ -11,14 +11,14 @@ const Attempt_Outcome_Success_thatYielded = <
 >(
   givenProduct: SomeProduct,
 ): Attempt_Outcome_Success<SomeProduct> => ({
-  discriminant    : 'success',
-  product         : givenProduct,
-  isSuccess       : true,
-  isFailure       : false,
-  optionallyUnwrap: () => givenProduct,
-  forciblyUnwrap  : () => givenProduct,
-  unwrapped       : givenProduct,
-  rewrappedWith   : <
+  discriminant  : 'success',
+  product       : givenProduct,
+  isSuccess     : true,
+  isFailure     : false,
+  unwrapOrNull  : () => givenProduct,
+  forciblyUnwrap: () => givenProduct,
+  unwrapped     : givenProduct,
+  rewrappedWith : <
     SomeTransformedProduct,
   >(
     {

--- a/src/library/Attempt/Outcome/Success/thatYielded.ts
+++ b/src/library/Attempt/Outcome/Success/thatYielded.ts
@@ -16,7 +16,6 @@ const Attempt_Outcome_Success_thatYielded = <
   isSuccess    : true,
   isFailure    : false,
   unwrapOr     : () => givenProduct,
-  unwrapOrNull : () => givenProduct,
   unwrapOrThrow: () => givenProduct,
   unwrapped    : givenProduct,
   rewrappedWith: <

--- a/src/library/Attempt/Outcome/Success/thatYielded.ts
+++ b/src/library/Attempt/Outcome/Success/thatYielded.ts
@@ -15,6 +15,7 @@ const Attempt_Outcome_Success_thatYielded = <
   product      : givenProduct,
   isSuccess    : true,
   isFailure    : false,
+  unwrapOr     : () => givenProduct,
   unwrapOrNull : () => givenProduct,
   unwrapOrThrow: () => givenProduct,
   unwrapped    : givenProduct,

--- a/src/library/ShimmedStabilityAIClient/Version1/Image.ts
+++ b/src/library/ShimmedStabilityAIClient/Version1/Image.ts
@@ -26,7 +26,7 @@ class ShimmedStabilityAIClient_Version1_Image
     const textToImageSDXLShortfinClient = new Shortfin.TextToImage.SDXL.Client(this.origin);
 
     const outcomeOfGeneratingImage = await textToImageSDXLShortfinClient.generateImageFrom(derivedBatchedRequestBody);
-    const generatedImage = outcomeOfGeneratingImage.forciblyUnwrap(/* matches error propagation of actual StabilityAI Client */);
+    const generatedImage = outcomeOfGeneratingImage.unwrapOrThrow(/* matches error propagation of actual StabilityAI Client */);
 
     const soleGeneratedArtifact: StabilityAI_TextToImage_Pipeline_Output = {
       base64      : generatedImage.toString(),


### PR DESCRIPTION
- aligns suites closer to `Either.getOr*(...)` suite [provided by effect](https://effect-ts.github.io/effect/effect/Either.ts.html#getters)