### PR TITLE
linter: enforces return types

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -74,6 +74,13 @@ const extraConfigForTypeScriptESLint: ConfigWithExtends = {
         fixStyle: 'inline-type-imports', // allows for more compact imports and tees up problematic imports to '@typescript-eslint/no-import-type-side-effects'
       },
     ],
+    '@typescript-eslint/explicit-function-return-type': [
+      'error', // encourages developers to state the desired interface up front
+      {
+        allowExpressions             : true, // for situations where the function consuming the expression as an argument defines the interface
+        allowTypedFunctionExpressions: true, // for situations where the variable or property receiving the function defines the interface
+      },
+    ],
     '@typescript-eslint/explicit-member-accessibility': [
       'error', // Easier to see dead code in situations where a member is marked `private`
     ],

--- a/src/components/DiscreteSlider.vue
+++ b/src/components/DiscreteSlider.vue
@@ -32,7 +32,7 @@ const given = defineProps<{
   tickStep: Range.Discrete['stepSize'];
 }>();
 
-const incrementCurrentValueBy = (givenStepCount: number) => {
+const incrementCurrentValueBy = (givenStepCount: number): void => {
   const changeInValue = givenStepCount * given.range.stepSize;
   const nextValue = get(currentValue) + changeInValue;
   set(currentValue, nextValue);

--- a/src/features/Reporting/promptUserWith.ts
+++ b/src/features/Reporting/promptUserWith.ts
@@ -8,7 +8,7 @@ import {
   Reporting_formatFor,
 } from './formatFor';
 
-const Reporting_promptUserWith = (givenError: Error) => {
+const Reporting_promptUserWith = (givenError: Error): void => {
   const unexpectedError = Contextualized.cast(givenError, 'Unexpected Error');
   console.debug(givenError);
   const formattedErrorDetails = Reporting_formatFor(unexpectedError);

--- a/src/features/TextToImage/Client/SDXL/toSharkUIOutput/Image/Description/singular.ts
+++ b/src/features/TextToImage/Client/SDXL/toSharkUIOutput/Image/Description/singular.ts
@@ -11,7 +11,7 @@ const toSharkUIOutput_Image_Description_singular = (
 ): TextToImage_Pipeline.Output['image']['description'] => {
   const isDefault = (
     givenWeight: TextPrompt['weight'],
-  ) => {
+  ): givenWeight is 1 | undefined => {
     return (givenWeight === undefined) || (givenWeight === 1);
   };
 

--- a/src/features/TextToImage/Pipeline/Output/definition.declared.ts
+++ b/src/features/TextToImage/Pipeline/Output/definition.declared.ts
@@ -13,7 +13,7 @@ function TextToImage_Pipeline_Output(
   namespaceOnly: never = Attempt.Error.NonActionable.throw(
     `Unexpected call of module augmentation provision for ${TextToImage_Pipeline_Output.name}.`,
   ),
-) {
+): never {
   return namespaceOnly;
 }
 

--- a/src/library/Attempt/Adapted/toSettle.ts
+++ b/src/library/Attempt/Adapted/toSettle.ts
@@ -26,7 +26,7 @@ const Attempt_Adapted_toSettle = async <
     SomeActionableError
   >
 > => {
-  const getPromisedProduct = () => promisedProduct;
+  const getPromisedProduct = (): Promise<SomeProduct> => promisedProduct;
   return Attempt_Adapted_toEventually(getPromisedProduct, givenConfig);
 };
 

--- a/src/library/Attempt/Fresh/that.ts
+++ b/src/library/Attempt/Fresh/that.ts
@@ -22,17 +22,20 @@ import {
 
 const Attempt_Fresh_that = <
   SomeInferredOutcome extends Attempt_Outcome<unknown, Attempt_Error.Actionable<string>>,
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-parameters
+  SomeEquivalentOutcome extends Attempt_Outcome<
+    ProductOf<SomeInferredOutcome>,
+    CauseOf<SomeInferredOutcome>
+  > = Attempt_Outcome<
+    ProductOf<SomeInferredOutcome>,
+    CauseOf<SomeInferredOutcome>
+  >,
 >(
   endsAccordingTo: Attempt_End.Getter<SomeInferredOutcome>,
 ) => {
-  type EquivalentOutcome = Attempt_Outcome<
-    ProductOf<SomeInferredOutcome>,
-    CauseOf<SomeInferredOutcome>
-  >;
-
   return safe({
     try() {
-      return endsAccordingTo(handles) as EquivalentOutcome;
+      return endsAccordingTo(handles) as unknown as SomeEquivalentOutcome;
     },
     catch(someError) {
       return Attempt_Error.Creation.rethrow(someError);

--- a/src/library/Attempt/Fresh/that.ts
+++ b/src/library/Attempt/Fresh/that.ts
@@ -32,7 +32,7 @@ const Attempt_Fresh_that = <
   >,
 >(
   endsAccordingTo: Attempt_End.Getter<SomeInferredOutcome>,
-) => {
+): SomeEquivalentOutcome => {
   return safe({
     try() {
       return endsAccordingTo(handles) as unknown as SomeEquivalentOutcome;

--- a/src/library/Attempt/Fresh/thatEventually.ts
+++ b/src/library/Attempt/Fresh/thatEventually.ts
@@ -31,7 +31,7 @@ const Attempt_Fresh_thatEventually = async <
   >,
 >(
   endsAccordingTo: Attempt_End.Retriever<SomeInferredOutcome>,
-) => {
+): Promise<SomeEquivalentOutcome> => {
   return safeAsync({
     async try() {
       return await endsAccordingTo(handles) as unknown as SomeEquivalentOutcome;

--- a/src/library/Attempt/Fresh/thatEventually.ts
+++ b/src/library/Attempt/Fresh/thatEventually.ts
@@ -22,17 +22,19 @@ import {
 
 const Attempt_Fresh_thatEventually = async <
   SomeInferredOutcome extends Attempt_Outcome<unknown, Attempt_Error.Actionable<string>>,
+  SomeEquivalentOutcome extends Attempt_Outcome<
+    ProductOf<SomeInferredOutcome>,
+    CauseOf<SomeInferredOutcome>
+  > = Attempt_Outcome<
+    ProductOf<SomeInferredOutcome>,
+    CauseOf<SomeInferredOutcome>
+  >,
 >(
   endsAccordingTo: Attempt_End.Retriever<SomeInferredOutcome>,
 ) => {
-  type EquivalentOutcome = Attempt_Outcome<
-    ProductOf<SomeInferredOutcome>,
-    CauseOf<SomeInferredOutcome>
-  >;
-
   return safeAsync({
     async try() {
-      return await endsAccordingTo(handles) as EquivalentOutcome;
+      return await endsAccordingTo(handles) as unknown as SomeEquivalentOutcome;
     },
     catch(someError) {
       return Attempt_Error.Creation.rethrow(someError);

--- a/src/library/Attempt/Outcome/Failure/definition.declared.ts
+++ b/src/library/Attempt/Outcome/Failure/definition.declared.ts
@@ -49,7 +49,7 @@ function Attempt_Outcome_Failure(
   namespaceOnly: never = Attempt_Error.NonActionable.throw(
     `Unexpected call of module augmentation provision for "${Attempt_Outcome_Failure.name}".`,
   ),
-) {
+): never {
   return namespaceOnly;
 }
 

--- a/src/library/Attempt/Outcome/Success/definition.declared.ts
+++ b/src/library/Attempt/Outcome/Success/definition.declared.ts
@@ -61,7 +61,7 @@ function Attempt_Outcome_Success(
   namespaceOnly: never = Attempt_Error.NonActionable.throw(
     `Unexpected call of module augmentation provision for "${Attempt_Outcome_Success.name}".`,
   ),
-) {
+): never {
   return namespaceOnly;
 }
 

--- a/src/library/Attempt/Outcome/definition.declared.ts
+++ b/src/library/Attempt/Outcome/definition.declared.ts
@@ -22,7 +22,7 @@ function Attempt_Outcome(
   namespaceOnly: never = Attempt_Error.NonActionable.throw(
     `Unexpected call of module augmentation provision for ${Attempt_Outcome.name}.`,
   ),
-) {
+): never {
   return namespaceOnly;
 }
 

--- a/src/library/Attempt/tryCatchStatements/safeAsync.ts
+++ b/src/library/Attempt/tryCatchStatements/safeAsync.ts
@@ -20,7 +20,7 @@ const safeAsync = async <
 ): Promise<
   SomeOutputOfResolvedPromise | SomeOutputOfRejectedPromise
 > => {
-  const safelyCatch = (whateverThatWasThrown: unknown) => safe({
+  const safelyCatch = (whateverThatWasThrown: unknown): SomeOutputOfRejectedPromise => safe({
     try: () => {
       throw whateverThatWasThrown; // eslint-disable-line no-restricted-syntax -- puts the error back through the safe catch
     },

--- a/src/library/GitHub/Repository/Issue/Draftable.ts
+++ b/src/library/GitHub/Repository/Issue/Draftable.ts
@@ -2,6 +2,7 @@ import {
   GitHub_Repository_Issue,
 } from './definition.declared.ts';
 
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type -- needed to create mixin
 function GitHub_Repository_Issue_Draftable(
   givenSite: URL,
 ) {

--- a/src/library/GitHub/Repository/definition.declared.ts
+++ b/src/library/GitHub/Repository/definition.declared.ts
@@ -25,7 +25,7 @@ class GitHub_Repository<
     return new URL(GitHub_site.toString().concat(this.path.toString()));
   }
 
-  public get Issue() {
+  public get Issue(): ReturnType<typeof GitHub_Repository_Issue.Draftable> {
     return GitHub_Repository_Issue.Draftable(this.site);
   }
 }

--- a/src/library/Range/Discrete.ts
+++ b/src/library/Range/Discrete.ts
@@ -62,7 +62,7 @@ class Range_Discrete
     return (overstep === 0) && super.exclusivelyContains(givenValue);
   }
 
-  private* generateExclusiveSteps() {
+  private* generateExclusiveSteps(): Generator<number, void, unknown> {
     let eachExclusiveStep = this.lowerBound + this.stepSize;
 
     while (eachExclusiveStep < this.upperBound) {
@@ -71,7 +71,7 @@ class Range_Discrete
     }
   }
 
-  private* generateInclusiveSteps() {
+  private* generateInclusiveSteps(): Generator<number, void, unknown> {
     yield this.lowerBound;
 
     if (


### PR DESCRIPTION
- helps compiler performance by minimizing the amount of type inference that needs to be performed
- also helps with refactoring implementation while keeping function interfaces stable
- `effect` relies on explicit return types to aggregate `Effect.Effect<A, never> | Effect.Effect<never, E>` into `Effect.Effect<A, E>`