### PR TITLE
refactor: replaces use of "fresh attempt" handler with functional equivalent

### DIFF
--- a/src/features/TextToImage/Config/Dynamic/fetch.ts
+++ b/src/features/TextToImage/Config/Dynamic/fetch.ts
@@ -19,12 +19,12 @@ import {
 
 const TextToImage_Config_Dynamic_fetch = (): Promise<
   TextToImage_Config_Dynamic_Fetching.Outcome
-> => Attempt.Fresh.thatEventually(async (ends) => {
+> => Attempt.Fresh.thatEventually(async () => {
   const outcomeOfFetchingResource = await HTTP.Client.local.fetchResource({
     from: TextToImage_Config_Dynamic_endpoint,
   });
 
-  return ends.inTermsOf(outcomeOfFetchingResource, {
+  return Attempt.Outcome.fromRewrapping(outcomeOfFetchingResource, {
     product: $0 => Schema.decodeUnknownSync(TextToImage_Config)($0),
     cause  : $0 => new TextToImage_Config_Dynamic_Fetching.Error(TextToImage_Config_Dynamic_endpoint, $0),
   });

--- a/src/features/TextToImage/Config/Static/read.ts
+++ b/src/features/TextToImage/Config/Static/read.ts
@@ -19,12 +19,12 @@ import {
 
 const TextToImage_Config_Static_read = (): Promise<
   TextToImage_Config_Static_Reading.Outcome
-> => Attempt.Fresh.thatEventually(async (ends) => {
+> => Attempt.Fresh.thatEventually(async () => {
   const outcomeOfFetchingFile = await HTTP.Client.local.fetchResource({
     from: TextToImage_Config_Static_file,
   });
 
-  return ends.inTermsOf(outcomeOfFetchingFile, {
+  return Attempt.Outcome.fromRewrapping(outcomeOfFetchingFile, {
     product: $0 => Schema.decodeUnknownSync(TextToImage_Config)($0),
     cause  : $0 => new TextToImage_Config_Static_Reading.Error(TextToImage_Config_Static_file, $0),
   });

--- a/src/features/TextToImage/Server/Current/retrieve.ts
+++ b/src/features/TextToImage/Server/Current/retrieve.ts
@@ -26,22 +26,22 @@ const TextToImage_Server_Current_retrieve = (): Promise<
     WebAPI.Server,
     TextToImage_Server_Error.MissingSpecification
   >
-> => Attempt.Fresh.thatEventually(async (ends) => {
+> => Attempt.Fresh.thatEventually(async () => {
   if (
     Option.isSome(TextToImage_Server_Current_accordingToEnvironment)
-  ) return ends.inSuccessWith(Option.getOrThrow(TextToImage_Server_Current_accordingToEnvironment));
+  ) return Attempt.Outcome.succeedWith(Option.getOrThrow(TextToImage_Server_Current_accordingToEnvironment));
 
   const staticConfig = (await TextToImage_Config.Static.read()).unwrapOr(TextToImage_Config.empty);
 
   if (
     Option.isSome(staticConfig.server)
-  ) return ends.inSuccessWith(Option.getOrThrow(staticConfig.server));
+  ) return Attempt.Outcome.succeedWith(Option.getOrThrow(staticConfig.server));
 
   const dynamicConfig = (await TextToImage_Config.Dynamic.fetch()).unwrapOr(TextToImage_Config.empty);
 
   if (
     Option.isSome(dynamicConfig.server)
-  ) return ends.inSuccessWith(Option.getOrThrow(dynamicConfig.server));
+  ) return Attempt.Outcome.succeedWith(Option.getOrThrow(dynamicConfig.server));
 
   const newSpecificationError = new TextToImage_Server_Error.MissingSpecification(
     TextToImage_Server_Origin.environmentKey,

--- a/src/features/TextToImage/Server/Current/retrieve.ts
+++ b/src/features/TextToImage/Server/Current/retrieve.ts
@@ -49,7 +49,7 @@ const TextToImage_Server_Current_retrieve = (): Promise<
     TextToImage_Config.Dynamic.endpoint,
   );
 
-  return ends.inFailureDueTo(newSpecificationError);
+  return Attempt.Outcome.failDueTo(newSpecificationError);
 });
 
 export {

--- a/src/library/Attempt/Adapted/to.ts
+++ b/src/library/Attempt/Adapted/to.ts
@@ -6,7 +6,7 @@ import {
   Attempt_Fresh,
 } from '../Fresh';
 
-import type {
+import {
   Attempt_Outcome,
 } from '../Outcome';
 
@@ -34,7 +34,7 @@ const Attempt_Adapted_to = <
       using: given.interpretationOf,
     });
 
-    return ends.inFailureDueTo(someActionableError);
+    return Attempt_Outcome.failDueTo(someActionableError);
   },
 }));
 

--- a/src/library/Attempt/Adapted/to.ts
+++ b/src/library/Attempt/Adapted/to.ts
@@ -24,10 +24,10 @@ const Attempt_Adapted_to = <
 >(
   forciblyGetProduct: () => SomeProduct,
   given: Attempt_Adapted_Config<SomeActionableError>,
-): Attempt_Outcome<SomeProduct, SomeActionableError> => Attempt_Fresh.that(ends => safe({
+): Attempt_Outcome<SomeProduct, SomeActionableError> => Attempt_Fresh.that(() => safe({
   try() {
     const gottenProduct = forciblyGetProduct();
-    return ends.inSuccessWith(gottenProduct);
+    return Attempt_Outcome.succeedWith(gottenProduct);
   },
   catch(someError) {
     const someActionableError = Attempt_Error.Actionable.from(someError, {

--- a/src/library/Attempt/Adapted/toEventually.ts
+++ b/src/library/Attempt/Adapted/toEventually.ts
@@ -29,10 +29,10 @@ const Attempt_Adapted_toEventually = async <
     SomeProduct,
     SomeActionableError
   >
-> => Attempt_Fresh.thatEventually(ends => safeAsync({
+> => Attempt_Fresh.thatEventually(() => safeAsync({
   async try() {
     const retrievedProduct: SomeProduct = await forciblyRetrieveProduct();
-    return ends.inSuccessWith(retrievedProduct);
+    return Attempt_Outcome.succeedWith(retrievedProduct);
   },
   catch(someError) {
     const someActionableError = Attempt_Error.Actionable.from(someError, {

--- a/src/library/Attempt/Adapted/toEventually.ts
+++ b/src/library/Attempt/Adapted/toEventually.ts
@@ -6,7 +6,7 @@ import {
   Attempt_Fresh,
 } from '../Fresh';
 
-import type {
+import {
   Attempt_Outcome,
 } from '../Outcome';
 
@@ -39,7 +39,7 @@ const Attempt_Adapted_toEventually = async <
       using: given.interpretationOf,
     });
 
-    return ends.inFailureDueTo(someActionableError);
+    return Attempt_Outcome.failDueTo(someActionableError);
   },
 }));
 

--- a/src/library/Attempt/Outcome/definition.declared.augmentation.ts
+++ b/src/library/Attempt/Outcome/definition.declared.augmentation.ts
@@ -15,21 +15,33 @@ import {
 } from './definition.declared.ts';
 
 import {
+  Attempt_Outcome_failDueTo,
+} from './failDueTo';
+
+import {
   Attempt_Outcome_fromRewrapping,
 } from './fromRewrapping';
 
-Attempt_Outcome.abandon /*  */ = Attempt_Outcome_abandon;
-Attempt_Outcome.Failure /*  */ = Attempt_Outcome_Failure;
-Attempt_Outcome.Success /*  */ = Attempt_Outcome_Success;
-Attempt_Outcome.fromRewrapping = Attempt_Outcome_fromRewrapping;
+import {
+  Attempt_Outcome_succeedWith,
+} from './succeedWith';
+
+Attempt_Outcome.succeedWith /*   */ = Attempt_Outcome_succeedWith;
+Attempt_Outcome.failDueTo /*     */ = Attempt_Outcome_failDueTo;
+Attempt_Outcome.abandon /*       */ = Attempt_Outcome_abandon;
+Attempt_Outcome.Failure /*       */ = Attempt_Outcome_Failure;
+Attempt_Outcome.Success /*       */ = Attempt_Outcome_Success;
+Attempt_Outcome.fromRewrapping /**/ = Attempt_Outcome_fromRewrapping;
 
 declare module './definition.declared.ts' {
   namespace Attempt_Outcome {
     export {
-      Attempt_Outcome_abandon /*  */ as abandon,
-      Attempt_Outcome_Failure /*  */ as Failure,
-      Attempt_Outcome_Success /*  */ as Success,
-      Attempt_Outcome_fromRewrapping as fromRewrapping,
+      Attempt_Outcome_succeedWith /*   */ as succeedWith,
+      Attempt_Outcome_failDueTo /*     */ as failDueTo,
+      Attempt_Outcome_abandon /*       */ as abandon,
+      Attempt_Outcome_Failure /*       */ as Failure,
+      Attempt_Outcome_Success /*       */ as Success,
+      Attempt_Outcome_fromRewrapping /**/ as fromRewrapping,
     };
   }
 }

--- a/src/library/Attempt/Outcome/failDueTo.ts
+++ b/src/library/Attempt/Outcome/failDueTo.ts
@@ -1,0 +1,9 @@
+import {
+  Attempt_Outcome_Failure,
+} from './Failure';
+
+const Attempt_failDueTo = Attempt_Outcome_Failure.dueTo;
+
+export {
+  Attempt_failDueTo as Attempt_Outcome_failDueTo,
+};

--- a/src/library/Attempt/Outcome/succeedWith.ts
+++ b/src/library/Attempt/Outcome/succeedWith.ts
@@ -1,0 +1,9 @@
+import {
+  Attempt_Outcome_Success,
+} from './Success';
+
+const Attempt_succeedWith = Attempt_Outcome_Success.thatYielded;
+
+export {
+  Attempt_succeedWith as Attempt_Outcome_succeedWith,
+};

--- a/src/library/HTTP/Client.ts
+++ b/src/library/HTTP/Client.ts
@@ -47,7 +47,7 @@ class HTTP_Client {
       to: URLComponent.Path;
       using: HTTP_Request.Method;
     },
-  ): Promise<HTTP_Endpoint.Outcome> => Attempt.Fresh.thatEventually(async (ends) => {
+  ): Promise<HTTP_Endpoint.Outcome> => Attempt.Fresh.thatEventually(async () => {
     const endpointURL = this.originAt(givenPath);
 
     const promisedResponse = fetch(endpointURL, {
@@ -78,7 +78,7 @@ class HTTP_Client {
 
     if (!response.ok) {
       const newResponseError = new HTTP_Endpoint.Error.RespondedWithFailure(response.statusText, response.status);
-      return ends.inFailureDueTo(newResponseError);
+      return Attempt.Outcome.failDueTo(newResponseError);
     }
 
     const outcomeOfDigestingResponseBody = await bodyOf(response).digestAsUnknown();

--- a/src/library/HTTP/Client.ts
+++ b/src/library/HTTP/Client.ts
@@ -83,7 +83,7 @@ class HTTP_Client {
 
     const outcomeOfDigestingResponseBody = await bodyOf(response).digestAsUnknown();
 
-    return ends.inTermsOf(outcomeOfDigestingResponseBody, {
+    return Attempt.Outcome.fromRewrapping(outcomeOfDigestingResponseBody, {
       cause: $0 => new HTTP_Endpoint.Error.IndigestibleResponseBody(endpointURL, $0),
     });
   });

--- a/src/library/HTTP/Response/bodyOf.ts
+++ b/src/library/HTTP/Response/bodyOf.ts
@@ -28,10 +28,10 @@ const bodyOf = (
     return actualRawDescriptor.includes(givenDescriptor.serialized.toString());
   },
   async digestAsUnknown() {
-    return Attempt.Fresh.thatEventually(async (ends) => {
+    return Attempt.Fresh.thatEventually(async () => {
       if (!this.isSuggestedToBeDigestibleAs(ContentDescriptor.json)) {
         const newDescriptorMismatchError = new HTTP_Response_Body.Digestion.Error.DescriptorMismatch(givenResponse, ContentDescriptor.json);
-        return ends.inFailureDueTo(newDescriptorMismatchError);
+        return Attempt.Outcome.failDueTo(newDescriptorMismatchError);
       }
 
       const promiseForDigestedResponseBody: Promise<unknown> = givenResponse.json();

--- a/src/library/Shortfin/TextToImage/SDXL/Client/definition.declared.ts
+++ b/src/library/Shortfin/TextToImage/SDXL/Client/definition.declared.ts
@@ -37,7 +37,7 @@ class Shortfin_TextToImage_SDXL_Client
   > {
     const generationEndpoint = URLComponent.Path('/generate');
 
-    return Attempt.Fresh.thatEventually(async (ends) => {
+    return Attempt.Fresh.thatEventually(async () => {
       const outcomeOfSubmittingResource = await this.submitResource({
         bySending: givenBatchedRequestBody,
         to       : generationEndpoint,
@@ -50,7 +50,7 @@ class Shortfin_TextToImage_SDXL_Client
       const rawResource = outcomeOfSubmittingResource.unwrapped;
       const decodedResource = Schema.decodeUnknownSync(Shortfin_TextToImage_SDXL_Client_Response.Body)(rawResource);
       const [soleGeneratedImage] = decodedResource.images;
-      return ends.inSuccessWith(soleGeneratedImage);
+      return Attempt.Outcome.succeedWith(soleGeneratedImage);
     });
   }
 }

--- a/src/pages/TextToImagePage.vue
+++ b/src/pages/TextToImagePage.vue
@@ -30,6 +30,8 @@ import {
   VSkeletonLoader,
 } from 'vuetify/components/VSkeletonLoader';
 
+import Attempt from '@/library/Attempt';
+
 import {
   SDXL,
 } from '@/library/ShimmedStabilityAIClient';
@@ -50,7 +52,7 @@ const {
 
 const currentNumberOfDiffusionSteps = ref<number>(range.midpoint);
 
-const imageGeneration = useStatefulAttemptThatEventually(async (ends) => {
+const imageGeneration = useStatefulAttemptThatEventually(async () => {
   const proposedPrompt = Option.getOrThrowWith(
     get(currentPrompt),
     () => new Error('Prompt was not set before submission'),
@@ -67,7 +69,7 @@ const imageGeneration = useStatefulAttemptThatEventually(async (ends) => {
     },
   });
 
-  const outcomeOfGeneratingImage = ends.inTermsOf(outcomeOfGeneratingOutput, {
+  const outcomeOfGeneratingImage = Attempt.Outcome.fromRewrapping(outcomeOfGeneratingOutput, {
     product: $0 => $0.image,
   });
 


### PR DESCRIPTION
- aligns `Attempt.Outcome` creation with how `Exit`s are created when using `effect`