### PR TITLE
refactor: avoids aliases within units

### DIFF
--- a/src/library/Attempt/Outcome/failDueTo.ts
+++ b/src/library/Attempt/Outcome/failDueTo.ts
@@ -2,8 +2,8 @@ import {
   Attempt_Outcome_Failure,
 } from './Failure';
 
-const Attempt_failDueTo = Attempt_Outcome_Failure.dueTo;
+const Attempt_Outcome_failDueTo = Attempt_Outcome_Failure.dueTo;
 
 export {
-  Attempt_failDueTo as Attempt_Outcome_failDueTo,
+  Attempt_Outcome_failDueTo,
 };

--- a/src/library/Attempt/Outcome/succeedWith.ts
+++ b/src/library/Attempt/Outcome/succeedWith.ts
@@ -2,8 +2,8 @@ import {
   Attempt_Outcome_Success,
 } from './Success';
 
-const Attempt_succeedWith = Attempt_Outcome_Success.thatYielded;
+const Attempt_Outcome_succeedWith = Attempt_Outcome_Success.thatYielded;
 
 export {
-  Attempt_succeedWith as Attempt_Outcome_succeedWith,
+  Attempt_Outcome_succeedWith,
 };


### PR DESCRIPTION
Overlooked when introduced in #1126