### PR TITLE
prefeature(library/Attempt): adds missing `fromRewrapping*` variants

### DIFF
--- a/src/features/TextToImage/Client/SDXL/generateOutputFrom.ts
+++ b/src/features/TextToImage/Client/SDXL/generateOutputFrom.ts
@@ -69,7 +69,7 @@ const TextToImage_Client_SDXL_generateOutputFrom = async (
     },
   });
 
-  const outcomeOfSettlingSoleTextToImageOutput = Attempt.Outcome.fromRewrappingBoth(outcomeOfSettlingTextToImageResponse, {
+  const outcomeOfSettlingSoleTextToImageOutput = Attempt.Outcome.fromRewrapping(outcomeOfSettlingTextToImageResponse, {
     product: textToImageResponse => toSharkUIOutput.first({
       in          : textToImageResponse,
       inferredFrom: given.textToImageRequestBody.textPrompts,

--- a/src/features/TextToImage/Client/SDXL/initialize.ts
+++ b/src/features/TextToImage/Client/SDXL/initialize.ts
@@ -13,7 +13,7 @@ const TextToImage_Client_SDXL_initialize = async (): Promise<
 > => {
   const outcomeOfRetrievingCurrentServer = await TextToImage_Server.Current.retrieve();
 
-  const outcomeOfInitializingClient = Attempt.Outcome.fromRewrappingBoth(outcomeOfRetrievingCurrentServer, {
+  const outcomeOfInitializingClient = Attempt.Outcome.fromRewrapping(outcomeOfRetrievingCurrentServer, {
     product: textToImageServer => new ShimmedStabilityAIClient({
       serverURL: textToImageServer.origin,
     }),

--- a/src/library/Attempt/Outcome/definition.declared.augmentation.ts
+++ b/src/library/Attempt/Outcome/definition.declared.augmentation.ts
@@ -23,25 +23,31 @@ import {
 } from './fromRewrappingBoth';
 
 import {
+  Attempt_Outcome_fromRewrappingErrorCause,
+} from './fromRewrappingErrorCause';
+
+import {
   Attempt_Outcome_succeedWith,
 } from './succeedWith';
 
-Attempt_Outcome.succeedWith /*       */ = Attempt_Outcome_succeedWith;
-Attempt_Outcome.failDueTo /*         */ = Attempt_Outcome_failDueTo;
-Attempt_Outcome.abandon /*           */ = Attempt_Outcome_abandon;
-Attempt_Outcome.Failure /*           */ = Attempt_Outcome_Failure;
-Attempt_Outcome.Success /*           */ = Attempt_Outcome_Success;
-Attempt_Outcome.fromRewrappingBoth /**/ = Attempt_Outcome_fromRewrappingBoth;
+Attempt_Outcome.succeedWith /*             */ = Attempt_Outcome_succeedWith;
+Attempt_Outcome.failDueTo /*               */ = Attempt_Outcome_failDueTo;
+Attempt_Outcome.abandon /*                 */ = Attempt_Outcome_abandon;
+Attempt_Outcome.Failure /*                 */ = Attempt_Outcome_Failure;
+Attempt_Outcome.Success /*                 */ = Attempt_Outcome_Success;
+Attempt_Outcome.fromRewrappingBoth /*      */ = Attempt_Outcome_fromRewrappingBoth;
+Attempt_Outcome.fromRewrappingErrorCause /**/ = Attempt_Outcome_fromRewrappingErrorCause;
 
 declare module './definition.declared.ts' {
   namespace Attempt_Outcome {
     export {
-      Attempt_Outcome_succeedWith /*       */ as succeedWith,
-      Attempt_Outcome_failDueTo /*         */ as failDueTo,
-      Attempt_Outcome_abandon /*           */ as abandon,
-      Attempt_Outcome_Failure /*           */ as Failure,
-      Attempt_Outcome_Success /*           */ as Success,
-      Attempt_Outcome_fromRewrappingBoth /**/ as fromRewrappingBoth,
+      Attempt_Outcome_succeedWith /*             */ as succeedWith,
+      Attempt_Outcome_failDueTo /*               */ as failDueTo,
+      Attempt_Outcome_abandon /*                 */ as abandon,
+      Attempt_Outcome_Failure /*                 */ as Failure,
+      Attempt_Outcome_Success /*                 */ as Success,
+      Attempt_Outcome_fromRewrappingBoth /*      */ as fromRewrappingBoth,
+      Attempt_Outcome_fromRewrappingErrorCause /**/ as fromRewrappingErrorCause,
     };
   }
 }

--- a/src/library/Attempt/Outcome/definition.declared.augmentation.ts
+++ b/src/library/Attempt/Outcome/definition.declared.augmentation.ts
@@ -19,6 +19,10 @@ import {
 } from './failDueTo';
 
 import {
+  Attempt_Outcome_fromRewrapping,
+} from './fromRewrapping';
+
+import {
   Attempt_Outcome_fromRewrappingBoth,
 } from './fromRewrappingBoth';
 
@@ -35,6 +39,7 @@ Attempt_Outcome.failDueTo /*               */ = Attempt_Outcome_failDueTo;
 Attempt_Outcome.abandon /*                 */ = Attempt_Outcome_abandon;
 Attempt_Outcome.Failure /*                 */ = Attempt_Outcome_Failure;
 Attempt_Outcome.Success /*                 */ = Attempt_Outcome_Success;
+Attempt_Outcome.fromRewrapping /*          */ = Attempt_Outcome_fromRewrapping;
 Attempt_Outcome.fromRewrappingBoth /*      */ = Attempt_Outcome_fromRewrappingBoth;
 Attempt_Outcome.fromRewrappingErrorCause /**/ = Attempt_Outcome_fromRewrappingErrorCause;
 
@@ -46,6 +51,7 @@ declare module './definition.declared.ts' {
       Attempt_Outcome_abandon /*                 */ as abandon,
       Attempt_Outcome_Failure /*                 */ as Failure,
       Attempt_Outcome_Success /*                 */ as Success,
+      Attempt_Outcome_fromRewrapping /*          */ as fromRewrapping,
       Attempt_Outcome_fromRewrappingBoth /*      */ as fromRewrappingBoth,
       Attempt_Outcome_fromRewrappingErrorCause /**/ as fromRewrappingErrorCause,
     };

--- a/src/library/Attempt/Outcome/fromRewrapping.ts
+++ b/src/library/Attempt/Outcome/fromRewrapping.ts
@@ -1,0 +1,56 @@
+import type {
+  Attempt_Error,
+} from '../Error';
+
+import {
+  Attempt_Outcome_Failure,
+} from './Failure';
+
+import type {
+  Attempt_Outcome_Success,
+} from './Success';
+
+import type {
+  Attempt_Outcome,
+} from './definition.declared.ts';
+
+import {
+  Attempt_Outcome_fromRewrappingBoth,
+} from './fromRewrappingBoth';
+
+/**
+ * Convenience method for:
+ * 1. unwrapping the contents of _this_ outcome,
+ * 2. transforming the product, and
+ * 3. wrapping the transformed contents in a _new_ outcome.
+ */
+const Attempt_Outcome_fromRewrapping = <
+  SomeTransformableProduct,
+  SomeTransformableActionableError extends Attempt_Error.Actionable<string>,
+  SomeTransformedProduct = SomeTransformableProduct,
+  SomeTransformedActionableError extends Attempt_Error.Actionable<string> = SomeTransformableActionableError,
+>(
+  givenOutcome: Attempt_Outcome<
+    SomeTransformableProduct,
+    SomeTransformableActionableError
+  >,
+  {
+    product: toTransformedProduct,
+  }: Attempt_Outcome_Success.Transformer<
+    SomeTransformableProduct,
+    SomeTransformedProduct
+  >,
+): Attempt_Outcome<
+  SomeTransformedProduct,
+  SomeTransformedActionableError
+> => Attempt_Outcome_fromRewrappingBoth(givenOutcome, {
+  product: toTransformedProduct,
+  cause  : Attempt_Outcome_Failure.Cause.Transformer.identity<
+    SomeTransformableActionableError,
+    SomeTransformedActionableError
+  >,
+});
+
+export {
+  Attempt_Outcome_fromRewrapping,
+};

--- a/src/library/Attempt/Outcome/fromRewrappingBoth.ts
+++ b/src/library/Attempt/Outcome/fromRewrappingBoth.ts
@@ -27,49 +27,6 @@ import type {
 * Helps avoid boilerplate when transforming outcomes.
 */
 function Attempt_Outcome_fromRewrappingBoth<
-  SomeTransformableActionableError extends Attempt_Error.Actionable<string>,
-  SomeTransformedActionableError extends Attempt_Error.Actionable<string> = SomeTransformableActionableError,
->(
-  givenOutcome: Attempt_Outcome_Failure<SomeTransformableActionableError>,
-  given?: Attempt_Outcome_Failure.Transformer<
-    SomeTransformableActionableError,
-    SomeTransformedActionableError
-  >,
-): Attempt_Outcome_Failure<SomeTransformedActionableError>;
-
-function Attempt_Outcome_fromRewrappingBoth<
-  SomeTransformableProduct,
-  SomeTransformedProduct = SomeTransformableProduct,
->(
-  givenOutcome: Attempt_Outcome_Success<SomeTransformableProduct>,
-  given?: Attempt_Outcome_Success.Transformer<
-    SomeTransformableProduct,
-    SomeTransformedProduct
-  >,
-): Attempt_Outcome_Success<SomeTransformedProduct>;
-
-function Attempt_Outcome_fromRewrappingBoth<
-  SomeTransformableProduct,
-  SomeTransformableActionableError extends Attempt_Error.Actionable<string>,
-  SomeTransformedProduct = SomeTransformableProduct,
-  SomeTransformedActionableError extends Attempt_Error.Actionable<string> = SomeTransformableActionableError,
->(
-  givenOutcome: Attempt_Outcome<
-    SomeTransformableProduct,
-    SomeTransformableActionableError
-  >,
-  given?: Attempt_Outcome_Transformer<
-    SomeTransformableProduct,
-    SomeTransformableActionableError,
-    SomeTransformedProduct,
-    SomeTransformedActionableError
-  >,
-): Attempt_Outcome<
-  SomeTransformedProduct,
-  SomeTransformedActionableError
->;
-
-function Attempt_Outcome_fromRewrappingBoth<
   SomeTransformableProduct,
   SomeTransformableActionableError extends Attempt_Error.Actionable<string>,
   SomeTransformedProduct = SomeTransformableProduct,

--- a/src/library/Attempt/Outcome/fromRewrappingErrorCause.ts
+++ b/src/library/Attempt/Outcome/fromRewrappingErrorCause.ts
@@ -1,0 +1,56 @@
+import type {
+  Attempt_Error,
+} from '../Error';
+
+import type {
+  Attempt_Outcome_Failure,
+} from './Failure';
+
+import {
+  Attempt_Outcome_Success,
+} from './Success';
+
+import type {
+  Attempt_Outcome,
+} from './definition.declared.ts';
+
+import {
+  Attempt_Outcome_fromRewrappingBoth,
+} from './fromRewrappingBoth';
+
+/**
+ * Convenience method for:
+ * 1. unwrapping the contents of _this_ outcome,
+ * 2. transforming the error, and
+ * 3. wrapping the transformed contents in a _new_ outcome.
+ */
+const Attempt_Outcome_fromRewrappingErrorCause = <
+  SomeTransformableProduct,
+  SomeTransformableActionableError extends Attempt_Error.Actionable<string>,
+  SomeTransformedProduct = SomeTransformableProduct,
+  SomeTransformedActionableError extends Attempt_Error.Actionable<string> = SomeTransformableActionableError,
+>(
+  givenOutcome: Attempt_Outcome<
+    SomeTransformableProduct,
+    SomeTransformableActionableError
+  >,
+  {
+    cause: toTransformedCause,
+  }: Attempt_Outcome_Failure.Transformer<
+    SomeTransformableActionableError,
+    SomeTransformedActionableError
+  >,
+): Attempt_Outcome<
+  SomeTransformedProduct,
+  SomeTransformedActionableError
+> => Attempt_Outcome_fromRewrappingBoth(givenOutcome, {
+  product: Attempt_Outcome_Success.Product.Transformer.identity<
+    SomeTransformableProduct,
+    SomeTransformedProduct
+  >,
+  cause: toTransformedCause,
+});
+
+export {
+  Attempt_Outcome_fromRewrappingErrorCause,
+};

--- a/src/library/HTTP/Client.ts
+++ b/src/library/HTTP/Client.ts
@@ -83,7 +83,7 @@ class HTTP_Client {
 
     const outcomeOfDigestingResponseBody = await bodyOf(response).digestAsUnknown();
 
-    return Attempt.Outcome.fromRewrappingBoth(outcomeOfDigestingResponseBody, {
+    return Attempt.Outcome.fromRewrappingErrorCause(outcomeOfDigestingResponseBody, {
       cause: $0 => new HTTP_Endpoint.Error.IndigestibleResponseBody(endpointURL, $0),
     });
   });

--- a/src/pages/TextToImagePage.vue
+++ b/src/pages/TextToImagePage.vue
@@ -69,7 +69,7 @@ const imageGeneration = useStatefulAttemptThatEventually(async () => {
     },
   });
 
-  const outcomeOfGeneratingImage = Attempt.Outcome.fromRewrappingBoth(outcomeOfGeneratingOutput, {
+  const outcomeOfGeneratingImage = Attempt.Outcome.fromRewrapping(outcomeOfGeneratingOutput, {
     product: $0 => $0.image,
   });
 


### PR DESCRIPTION
- ensures migration path for `Exit.map` and `Exit.mapErrorCause`