### PR TITLE
refactor: renames `Attempt.Outcome.fromRewrapping` to `Attempt.Outcome.fromRewrappingBoth`

### DIFF
--- a/src/features/TextToImage/Client/SDXL/generateOutputFrom.ts
+++ b/src/features/TextToImage/Client/SDXL/generateOutputFrom.ts
@@ -69,7 +69,7 @@ const TextToImage_Client_SDXL_generateOutputFrom = async (
     },
   });
 
-  const outcomeOfSettlingSoleTextToImageOutput = Attempt.Outcome.fromRewrapping(outcomeOfSettlingTextToImageResponse, {
+  const outcomeOfSettlingSoleTextToImageOutput = Attempt.Outcome.fromRewrappingBoth(outcomeOfSettlingTextToImageResponse, {
     product: textToImageResponse => toSharkUIOutput.first({
       in          : textToImageResponse,
       inferredFrom: given.textToImageRequestBody.textPrompts,

--- a/src/features/TextToImage/Client/SDXL/initialize.ts
+++ b/src/features/TextToImage/Client/SDXL/initialize.ts
@@ -13,7 +13,7 @@ const TextToImage_Client_SDXL_initialize = async (): Promise<
 > => {
   const outcomeOfRetrievingCurrentServer = await TextToImage_Server.Current.retrieve();
 
-  const outcomeOfInitializingClient = Attempt.Outcome.fromRewrapping(outcomeOfRetrievingCurrentServer, {
+  const outcomeOfInitializingClient = Attempt.Outcome.fromRewrappingBoth(outcomeOfRetrievingCurrentServer, {
     product: textToImageServer => new ShimmedStabilityAIClient({
       serverURL: textToImageServer.origin,
     }),

--- a/src/features/TextToImage/Config/Dynamic/fetch.ts
+++ b/src/features/TextToImage/Config/Dynamic/fetch.ts
@@ -24,7 +24,7 @@ const TextToImage_Config_Dynamic_fetch = (): Promise<
     from: TextToImage_Config_Dynamic_endpoint,
   });
 
-  return Attempt.Outcome.fromRewrapping(outcomeOfFetchingResource, {
+  return Attempt.Outcome.fromRewrappingBoth(outcomeOfFetchingResource, {
     product: $0 => Schema.decodeUnknownSync(TextToImage_Config)($0),
     cause  : $0 => new TextToImage_Config_Dynamic_Fetching.Error(TextToImage_Config_Dynamic_endpoint, $0),
   });

--- a/src/features/TextToImage/Config/Static/read.ts
+++ b/src/features/TextToImage/Config/Static/read.ts
@@ -24,7 +24,7 @@ const TextToImage_Config_Static_read = (): Promise<
     from: TextToImage_Config_Static_file,
   });
 
-  return Attempt.Outcome.fromRewrapping(outcomeOfFetchingFile, {
+  return Attempt.Outcome.fromRewrappingBoth(outcomeOfFetchingFile, {
     product: $0 => Schema.decodeUnknownSync(TextToImage_Config)($0),
     cause  : $0 => new TextToImage_Config_Static_Reading.Error(TextToImage_Config_Static_file, $0),
   });

--- a/src/library/Attempt/Outcome/definition.declared.augmentation.ts
+++ b/src/library/Attempt/Outcome/definition.declared.augmentation.ts
@@ -19,29 +19,29 @@ import {
 } from './failDueTo';
 
 import {
-  Attempt_Outcome_fromRewrapping,
-} from './fromRewrapping';
+  Attempt_Outcome_fromRewrappingBoth,
+} from './fromRewrappingBoth';
 
 import {
   Attempt_Outcome_succeedWith,
 } from './succeedWith';
 
-Attempt_Outcome.succeedWith /*   */ = Attempt_Outcome_succeedWith;
-Attempt_Outcome.failDueTo /*     */ = Attempt_Outcome_failDueTo;
-Attempt_Outcome.abandon /*       */ = Attempt_Outcome_abandon;
-Attempt_Outcome.Failure /*       */ = Attempt_Outcome_Failure;
-Attempt_Outcome.Success /*       */ = Attempt_Outcome_Success;
-Attempt_Outcome.fromRewrapping /**/ = Attempt_Outcome_fromRewrapping;
+Attempt_Outcome.succeedWith /*       */ = Attempt_Outcome_succeedWith;
+Attempt_Outcome.failDueTo /*         */ = Attempt_Outcome_failDueTo;
+Attempt_Outcome.abandon /*           */ = Attempt_Outcome_abandon;
+Attempt_Outcome.Failure /*           */ = Attempt_Outcome_Failure;
+Attempt_Outcome.Success /*           */ = Attempt_Outcome_Success;
+Attempt_Outcome.fromRewrappingBoth /**/ = Attempt_Outcome_fromRewrappingBoth;
 
 declare module './definition.declared.ts' {
   namespace Attempt_Outcome {
     export {
-      Attempt_Outcome_succeedWith /*   */ as succeedWith,
-      Attempt_Outcome_failDueTo /*     */ as failDueTo,
-      Attempt_Outcome_abandon /*       */ as abandon,
-      Attempt_Outcome_Failure /*       */ as Failure,
-      Attempt_Outcome_Success /*       */ as Success,
-      Attempt_Outcome_fromRewrapping /**/ as fromRewrapping,
+      Attempt_Outcome_succeedWith /*       */ as succeedWith,
+      Attempt_Outcome_failDueTo /*         */ as failDueTo,
+      Attempt_Outcome_abandon /*           */ as abandon,
+      Attempt_Outcome_Failure /*           */ as Failure,
+      Attempt_Outcome_Success /*           */ as Success,
+      Attempt_Outcome_fromRewrappingBoth /**/ as fromRewrappingBoth,
     };
   }
 }

--- a/src/library/Attempt/Outcome/fromRewrappingBoth.ts
+++ b/src/library/Attempt/Outcome/fromRewrappingBoth.ts
@@ -26,7 +26,7 @@ import type {
 *
 * Helps avoid boilerplate when transforming outcomes.
 */
-function Attempt_Outcome_fromRewrapping<
+function Attempt_Outcome_fromRewrappingBoth<
   SomeTransformableActionableError extends Attempt_Error.Actionable<string>,
   SomeTransformedActionableError extends Attempt_Error.Actionable<string> = SomeTransformableActionableError,
 >(
@@ -37,7 +37,7 @@ function Attempt_Outcome_fromRewrapping<
   >,
 ): Attempt_Outcome_Failure<SomeTransformedActionableError>;
 
-function Attempt_Outcome_fromRewrapping<
+function Attempt_Outcome_fromRewrappingBoth<
   SomeTransformableProduct,
   SomeTransformedProduct = SomeTransformableProduct,
 >(
@@ -48,7 +48,7 @@ function Attempt_Outcome_fromRewrapping<
   >,
 ): Attempt_Outcome_Success<SomeTransformedProduct>;
 
-function Attempt_Outcome_fromRewrapping<
+function Attempt_Outcome_fromRewrappingBoth<
   SomeTransformableProduct,
   SomeTransformableActionableError extends Attempt_Error.Actionable<string>,
   SomeTransformedProduct = SomeTransformableProduct,
@@ -69,7 +69,7 @@ function Attempt_Outcome_fromRewrapping<
   SomeTransformedActionableError
 >;
 
-function Attempt_Outcome_fromRewrapping<
+function Attempt_Outcome_fromRewrappingBoth<
   SomeTransformableProduct,
   SomeTransformableActionableError extends Attempt_Error.Actionable<string>,
   SomeTransformedProduct = SomeTransformableProduct,
@@ -117,5 +117,5 @@ function Attempt_Outcome_fromRewrapping<
 }
 
 export {
-  Attempt_Outcome_fromRewrapping,
+  Attempt_Outcome_fromRewrappingBoth,
 };

--- a/src/library/HTTP/Client.ts
+++ b/src/library/HTTP/Client.ts
@@ -83,7 +83,7 @@ class HTTP_Client {
 
     const outcomeOfDigestingResponseBody = await bodyOf(response).digestAsUnknown();
 
-    return Attempt.Outcome.fromRewrapping(outcomeOfDigestingResponseBody, {
+    return Attempt.Outcome.fromRewrappingBoth(outcomeOfDigestingResponseBody, {
       cause: $0 => new HTTP_Endpoint.Error.IndigestibleResponseBody(endpointURL, $0),
     });
   });

--- a/src/pages/TextToImagePage.vue
+++ b/src/pages/TextToImagePage.vue
@@ -69,7 +69,7 @@ const imageGeneration = useStatefulAttemptThatEventually(async () => {
     },
   });
 
-  const outcomeOfGeneratingImage = Attempt.Outcome.fromRewrapping(outcomeOfGeneratingOutput, {
+  const outcomeOfGeneratingImage = Attempt.Outcome.fromRewrappingBoth(outcomeOfGeneratingOutput, {
     product: $0 => $0.image,
   });
 


### PR DESCRIPTION
- aligns more with convention established by `effect` in [the`Exit` equivalent](https://effect-ts.github.io/effect/effect/Exit.ts.html#mapboth)

Unblocks #1131