### PR TITLE
refactor: avoids redundant parameter defaults in `Attempt.Outcome.fromRewrappingBoth(...)`

### DIFF
--- a/src/library/Attempt/Outcome/Transformer.ts
+++ b/src/library/Attempt/Outcome/Transformer.ts
@@ -16,14 +16,18 @@ type Attempt_Outcome_Transformer<
   SomeTransformedProduct,
   SomeTransformedActionableError extends Attempt_Error.Actionable<string>,
 > =
-  & Attempt_Outcome_Success.Transformer<
-    SomeTransformableProduct,
-    SomeTransformedProduct
-  >
-  & Attempt_Outcome_Failure.Transformer<
-    SomeTransformableActionableError,
-    SomeTransformedActionableError
-  >
+  & {
+    product: Attempt_Outcome_Success.Product.Transformer<
+      SomeTransformableProduct,
+      SomeTransformedProduct
+    >;
+  }
+  & {
+    cause: Attempt_Outcome_Failure.Cause.Transformer<
+      SomeTransformableActionableError,
+      SomeTransformedActionableError
+    >;
+  }
 ;
 
 export type {

--- a/src/library/Attempt/Outcome/Transformer.ts
+++ b/src/library/Attempt/Outcome/Transformer.ts
@@ -10,25 +10,21 @@ import type {
   Attempt_Outcome_Success,
 } from './Success';
 
-type Attempt_Outcome_Transformer<
+interface Attempt_Outcome_Transformer<
   SomeTransformableProduct,
   SomeTransformableActionableError extends Attempt_Error.Actionable<string>,
   SomeTransformedProduct,
   SomeTransformedActionableError extends Attempt_Error.Actionable<string>,
-> =
-  & {
-    product: Attempt_Outcome_Success.Product.Transformer<
-      SomeTransformableProduct,
-      SomeTransformedProduct
-    >;
-  }
-  & {
-    cause: Attempt_Outcome_Failure.Cause.Transformer<
-      SomeTransformableActionableError,
-      SomeTransformedActionableError
-    >;
-  }
-;
+> {
+  product: Attempt_Outcome_Success.Product.Transformer<
+    SomeTransformableProduct,
+    SomeTransformedProduct
+  >;
+  cause: Attempt_Outcome_Failure.Cause.Transformer<
+    SomeTransformableActionableError,
+    SomeTransformedActionableError
+  >;
+}
 
 export type {
   Attempt_Outcome_Transformer,

--- a/src/library/Attempt/Outcome/Transformer.ts
+++ b/src/library/Attempt/Outcome/Transformer.ts
@@ -16,34 +16,14 @@ type Attempt_Outcome_Transformer<
   SomeTransformedProduct,
   SomeTransformedActionableError extends Attempt_Error.Actionable<string>,
 > =
-  | (
-    & Required<
-      Attempt_Outcome_Success.Transformer<
-        SomeTransformableProduct,
-        SomeTransformedProduct
-      >
-    >
-    & Partial<
-      Attempt_Outcome_Failure.Transformer<
-        SomeTransformableActionableError,
-        SomeTransformedActionableError
-      >
-    >
-  )
-  | (
-    & Partial<
-      Attempt_Outcome_Success.Transformer<
-        SomeTransformableProduct,
-        SomeTransformedProduct
-      >
-    >
-    & Required<
-      Attempt_Outcome_Failure.Transformer<
-        SomeTransformableActionableError,
-        SomeTransformedActionableError
-      >
-    >
-  )
+  & Attempt_Outcome_Success.Transformer<
+    SomeTransformableProduct,
+    SomeTransformedProduct
+  >
+  & Attempt_Outcome_Failure.Transformer<
+    SomeTransformableActionableError,
+    SomeTransformedActionableError
+  >
 ;
 
 export type {

--- a/src/library/Attempt/Outcome/fromRewrappingBoth.ts
+++ b/src/library/Attempt/Outcome/fromRewrappingBoth.ts
@@ -2,14 +2,6 @@ import type {
   Attempt_Error,
 } from '../Error';
 
-import {
-  Attempt_Outcome_Failure,
-} from './Failure';
-
-import {
-  Attempt_Outcome_Success,
-} from './Success';
-
 import type {
   Attempt_Outcome_Transformer,
 } from './Transformer';
@@ -44,16 +36,7 @@ const Attempt_Outcome_fromRewrappingBoth = <
     SomeTransformableActionableError,
     SomeTransformedProduct,
     SomeTransformedActionableError
-  > = {
-    product: Attempt_Outcome_Success.Product.Transformer.identity<
-      SomeTransformableProduct,
-      SomeTransformedProduct
-    >,
-    cause: Attempt_Outcome_Failure.Cause.Transformer.identity<
-      SomeTransformableActionableError,
-      SomeTransformedActionableError
-    >,
-  },
+  >,
 ): Attempt_Outcome<
   SomeTransformedProduct,
   SomeTransformedActionableError

--- a/src/library/Attempt/Outcome/fromRewrappingBoth.ts
+++ b/src/library/Attempt/Outcome/fromRewrappingBoth.ts
@@ -37,14 +37,8 @@ const Attempt_Outcome_fromRewrappingBoth = <
     SomeTransformableActionableError
   >,
   {
-    product: toTransformedProduct = Attempt_Outcome_Success.Product.Transformer.identity<
-      SomeTransformableProduct,
-      SomeTransformedProduct
-    >,
-    cause: toTransformedCause = Attempt_Outcome_Failure.Cause.Transformer.identity<
-      SomeTransformableActionableError,
-      SomeTransformedActionableError
-    >,
+    product: toTransformedProduct,
+    cause: toTransformedCause,
   }: Attempt_Outcome_Transformer<
     SomeTransformableProduct,
     SomeTransformableActionableError,


### PR DESCRIPTION
Enabled by #1131, #1135