### PR TITLE
refactor: avoids unnecessary transformer nesting in `Attempt.Outcome.fromRewrapping*(...)` methods

### DIFF
--- a/src/features/TextToImage/Client/SDXL/generateOutputFrom.ts
+++ b/src/features/TextToImage/Client/SDXL/generateOutputFrom.ts
@@ -69,12 +69,13 @@ const TextToImage_Client_SDXL_generateOutputFrom = async (
     },
   });
 
-  const outcomeOfSettlingSoleTextToImageOutput = Attempt.Outcome.fromRewrapping(outcomeOfSettlingTextToImageResponse, {
-    product: textToImageResponse => toSharkUIOutput.first({
+  const outcomeOfSettlingSoleTextToImageOutput = Attempt.Outcome.fromRewrapping(
+    outcomeOfSettlingTextToImageResponse,
+    textToImageResponse => toSharkUIOutput.first({
       in          : textToImageResponse,
       inferredFrom: given.textToImageRequestBody.textPrompts,
     }),
-  });
+  );
 
   return outcomeOfSettlingSoleTextToImageOutput;
 };

--- a/src/features/TextToImage/Client/SDXL/initialize.ts
+++ b/src/features/TextToImage/Client/SDXL/initialize.ts
@@ -13,11 +13,12 @@ const TextToImage_Client_SDXL_initialize = async (): Promise<
 > => {
   const outcomeOfRetrievingCurrentServer = await TextToImage_Server.Current.retrieve();
 
-  const outcomeOfInitializingClient = Attempt.Outcome.fromRewrapping(outcomeOfRetrievingCurrentServer, {
-    product: textToImageServer => new ShimmedStabilityAIClient({
+  const outcomeOfInitializingClient = Attempt.Outcome.fromRewrapping(
+    outcomeOfRetrievingCurrentServer,
+    textToImageServer => new ShimmedStabilityAIClient({
       serverURL: textToImageServer.origin,
     }),
-  });
+  );
 
   return outcomeOfInitializingClient;
 };

--- a/src/library/Attempt/Outcome/Failure/definition.declared.ts
+++ b/src/library/Attempt/Outcome/Failure/definition.declared.ts
@@ -3,12 +3,12 @@ import {
 } from '../../Error';
 
 import type {
-  Attempt_Outcome_Failure_SemanticallySugarfree,
-} from './SemanticallySugarfree';
+  Attempt_Outcome_Failure_Cause,
+} from './Cause';
 
 import type {
-  Attempt_Outcome_Failure_Transformer,
-} from './Transformer';
+  Attempt_Outcome_Failure_SemanticallySugarfree,
+} from './SemanticallySugarfree';
 
 interface Attempt_Outcome_Failure<
   SomeActionableError extends Attempt_Error.Actionable<string>,
@@ -38,7 +38,7 @@ interface Attempt_Outcome_Failure<
   rewrappedWith<
     SomeTransformedActionableError extends Attempt_Error.Actionable<string> = SomeActionableError,
   >(
-    given?: Attempt_Outcome_Failure_Transformer<
+    given?: Attempt_Outcome_Failure_Cause.Transformer<
       SomeActionableError,
       SomeTransformedActionableError
     >

--- a/src/library/Attempt/Outcome/Failure/dueTo.ts
+++ b/src/library/Attempt/Outcome/Failure/dueTo.ts
@@ -25,14 +25,10 @@ const Attempt_Outcome_Failure_dueTo = <
   rewrappedWith : <
     SomeTransformedActionableError extends Attempt_Error.Actionable<string>,
   >(
-    {
-      cause: transformed,
-    } = {
-      cause: Attempt_Outcome_Failure_Cause.Transformer.identity<
-        SomeActionableError,
-        SomeTransformedActionableError
-      >,
-    },
+    transformed = Attempt_Outcome_Failure_Cause.Transformer.identity<
+      SomeActionableError,
+      SomeTransformedActionableError
+    >,
   ) => {
     const transformedCause = transformed(givenCause);
     const transformedFailure = Attempt_Outcome_Failure_dueTo(transformedCause);

--- a/src/library/Attempt/Outcome/Success/definition.declared.ts
+++ b/src/library/Attempt/Outcome/Success/definition.declared.ts
@@ -3,12 +3,12 @@ import {
 } from '../../Error';
 
 import type {
-  Attempt_Outcome_Success_SemanticallySugarfree,
-} from './SemanticallySugarfree';
+  Attempt_Outcome_Success_Product,
+} from './Product';
 
 import type {
-  Attempt_Outcome_Success_Transformer,
-} from './Transformer';
+  Attempt_Outcome_Success_SemanticallySugarfree,
+} from './SemanticallySugarfree';
 
 interface Attempt_Outcome_Success<
   SomeProduct,
@@ -50,7 +50,7 @@ interface Attempt_Outcome_Success<
   rewrappedWith<
     SomeTransformedProduct = SomeProduct,
   >(
-    given?: Attempt_Outcome_Success_Transformer<
+    given?: Attempt_Outcome_Success_Product.Transformer<
       SomeProduct,
       SomeTransformedProduct
     >

--- a/src/library/Attempt/Outcome/Success/thatYielded.ts
+++ b/src/library/Attempt/Outcome/Success/thatYielded.ts
@@ -21,14 +21,10 @@ const Attempt_Outcome_Success_thatYielded = <
   rewrappedWith: <
     SomeTransformedProduct,
   >(
-    {
-      product: transformed,
-    } = {
-      product: Attempt_Outcome_Success_Product.Transformer.identity<
-        SomeProduct,
-        SomeTransformedProduct
-      >,
-    },
+    transformed = Attempt_Outcome_Success_Product.Transformer.identity<
+      SomeProduct,
+      SomeTransformedProduct
+    >,
   ) => {
     const transformedProduct = transformed(givenProduct);
     const transformedSuccess = Attempt_Outcome_Success_thatYielded(transformedProduct);

--- a/src/library/Attempt/Outcome/fromRewrapping.ts
+++ b/src/library/Attempt/Outcome/fromRewrapping.ts
@@ -34,9 +34,7 @@ const Attempt_Outcome_fromRewrapping = <
     SomeTransformableProduct,
     SomeTransformableActionableError
   >,
-  {
-    product: toTransformedProduct,
-  }: Attempt_Outcome_Success.Transformer<
+  givenProductTransformer: Attempt_Outcome_Success.Product.Transformer<
     SomeTransformableProduct,
     SomeTransformedProduct
   >,
@@ -44,7 +42,7 @@ const Attempt_Outcome_fromRewrapping = <
   SomeTransformedProduct,
   SomeTransformedActionableError
 > => Attempt_Outcome_fromRewrappingBoth(givenOutcome, {
-  product: toTransformedProduct,
+  product: givenProductTransformer,
   cause  : Attempt_Outcome_Failure.Cause.Transformer.identity<
     SomeTransformableActionableError,
     SomeTransformedActionableError

--- a/src/library/Attempt/Outcome/fromRewrappingBoth.ts
+++ b/src/library/Attempt/Outcome/fromRewrappingBoth.ts
@@ -64,12 +64,8 @@ const Attempt_Outcome_fromRewrappingBoth = <
   SomeTransformedProduct,
   SomeTransformedActionableError
 > => givenOutcome.isSuccess
-  ? givenOutcome.rewrappedWith({
-      product: toTransformedProduct,
-    })
-  : givenOutcome.rewrappedWith({
-      cause: toTransformedCause,
-    });
+  ? givenOutcome.rewrappedWith(toTransformedProduct)
+  : givenOutcome.rewrappedWith(toTransformedCause);
 
 export {
   Attempt_Outcome_fromRewrappingBoth,

--- a/src/library/Attempt/Outcome/fromRewrappingErrorCause.ts
+++ b/src/library/Attempt/Outcome/fromRewrappingErrorCause.ts
@@ -34,9 +34,7 @@ const Attempt_Outcome_fromRewrappingErrorCause = <
     SomeTransformableProduct,
     SomeTransformableActionableError
   >,
-  {
-    cause: toTransformedCause,
-  }: Attempt_Outcome_Failure.Transformer<
+  givenCauseTransformer: Attempt_Outcome_Failure.Cause.Transformer<
     SomeTransformableActionableError,
     SomeTransformedActionableError
   >,
@@ -48,7 +46,7 @@ const Attempt_Outcome_fromRewrappingErrorCause = <
     SomeTransformableProduct,
     SomeTransformedProduct
   >,
-  cause: toTransformedCause,
+  cause: givenCauseTransformer,
 });
 
 export {

--- a/src/library/HTTP/Client.ts
+++ b/src/library/HTTP/Client.ts
@@ -83,9 +83,10 @@ class HTTP_Client {
 
     const outcomeOfDigestingResponseBody = await bodyOf(response).digestAsUnknown();
 
-    return Attempt.Outcome.fromRewrappingErrorCause(outcomeOfDigestingResponseBody, {
-      cause: $0 => new HTTP_Endpoint.Error.IndigestibleResponseBody(endpointURL, $0),
-    });
+    return Attempt.Outcome.fromRewrappingErrorCause(
+      outcomeOfDigestingResponseBody,
+      $0 => new HTTP_Endpoint.Error.IndigestibleResponseBody(endpointURL, $0),
+    );
   });
 
   public async fetchResource(

--- a/src/pages/TextToImagePage.vue
+++ b/src/pages/TextToImagePage.vue
@@ -69,9 +69,10 @@ const imageGeneration = useStatefulAttemptThatEventually(async () => {
     },
   });
 
-  const outcomeOfGeneratingImage = Attempt.Outcome.fromRewrapping(outcomeOfGeneratingOutput, {
-    product: $0 => $0.image,
-  });
+  const outcomeOfGeneratingImage = Attempt.Outcome.fromRewrapping(
+    outcomeOfGeneratingOutput,
+    $0 => $0.image,
+  );
 
   return outcomeOfGeneratingImage;
 });


### PR DESCRIPTION
- approaches closer match to `Exit` signatures for [`.map(...)`](https://effect-ts.github.io/effect/effect/Exit.ts.html#map) and [`.mapErrorCause(...)`](https://effect-ts.github.io/effect/effect/Exit.ts.html#maperrorcause)

Enabled by #1131 