### PR TITLE
refactor: aligns `Attempt.Outcome` payloads with `Exit` analogs

### DIFF
--- a/src/features/TextToImage/Client/SDXL/generateOutputFrom.ts
+++ b/src/features/TextToImage/Client/SDXL/generateOutputFrom.ts
@@ -45,7 +45,7 @@ const TextToImage_Client_SDXL_generateOutputFrom = async (
     outcomeOfInitializingClient.isFailure
   ) return outcomeOfInitializingClient;
 
-  const shimmedStabilityAIClient = outcomeOfInitializingClient.unwrapped;
+  const shimmedStabilityAIClient = outcomeOfInitializingClient.value;
 
   const promisedTextToImageResponse = shimmedStabilityAIClient.version1.image.forciblyGenerateFromText({
     engineId              : 'stable-diffusion-xl-1024-v1-0',

--- a/src/library/Attempt/Outcome/Failure/definition.declared.ts
+++ b/src/library/Attempt/Outcome/Failure/definition.declared.ts
@@ -16,25 +16,6 @@ interface Attempt_Outcome_Failure<
   extends Attempt_Outcome_Failure_SemanticallySugarfree<
     SomeActionableError
   > {
-  /**
-   * Semantic sugar for `cause`; useful for juxtaposition against early exits:
-   * ```ts
-   * function safelyGetProductWhileHandlingErrors(
-   *   givenOutcome: Attempt.Outcome<CustomProduct, CustomError>,
-   *   recoverFrom: (expectedError: CustomError) => void,
-   * ): CustomProduct {
-   *   if (
-   *     givenOutcome.isSuccess
-   *   ) return givenOutcome.value;
-   *
-   *   ...
-   *
-   *   recoverFrom(givenOutcome.causeOfFailure);
-   * }
-   * ```
-   */
-  readonly causeOfFailure: this['cause'];
-
   rewrappedWith<
     SomeTransformedActionableError extends Attempt_Error.Actionable<string> = SomeActionableError,
   >(

--- a/src/library/Attempt/Outcome/Failure/definition.declared.ts
+++ b/src/library/Attempt/Outcome/Failure/definition.declared.ts
@@ -25,7 +25,7 @@ interface Attempt_Outcome_Failure<
    * ): CustomProduct {
    *   if (
    *     givenOutcome.isSuccess
-   *   ) return givenOutcome.unwrapped;
+   *   ) return givenOutcome.value;
    *
    *   ...
    *

--- a/src/library/Attempt/Outcome/Failure/dueTo.ts
+++ b/src/library/Attempt/Outcome/Failure/dueTo.ts
@@ -15,14 +15,13 @@ const Attempt_Outcome_Failure_dueTo = <
 >(
   givenCause: SomeActionableError,
 ): Attempt_Outcome_Failure<SomeActionableError> => ({
-  discriminant  : 'failure',
-  cause         : givenCause,
-  isSuccess     : false,
-  isFailure     : true,
-  unwrapOr      : <SomeFallback>($0: SomeFallback) => $0,
-  unwrapOrThrow : () => givenCause.throwAnyway('Unexpected forceful unwrap of a failure'),
-  causeOfFailure: givenCause,
-  rewrappedWith : <
+  discriminant : 'failure',
+  cause        : givenCause,
+  isSuccess    : false,
+  isFailure    : true,
+  unwrapOr     : <SomeFallback>($0: SomeFallback) => $0,
+  unwrapOrThrow: () => givenCause.throwAnyway('Unexpected forceful unwrap of a failure'),
+  rewrappedWith: <
     SomeTransformedActionableError extends Attempt_Error.Actionable<string>,
   >(
     transformed = Attempt_Outcome_Failure_Cause.Transformer.identity<

--- a/src/library/Attempt/Outcome/Success/definition.declared.ts
+++ b/src/library/Attempt/Outcome/Success/definition.declared.ts
@@ -39,7 +39,7 @@ interface Attempt_Outcome_Success<
    * ): void {
    *   if (
    *     givenOutcome.isFailure
-   *   ) recoverFrom(givenOutcome.causeOfFailure);
+   *   ) recoverFrom(givenOutcome.cause);
    *
    *   console.log(givenOutcome.value);
    * }

--- a/src/library/Attempt/Outcome/Success/definition.declared.ts
+++ b/src/library/Attempt/Outcome/Success/definition.declared.ts
@@ -41,11 +41,11 @@ interface Attempt_Outcome_Success<
    *     givenOutcome.isFailure
    *   ) recoverFrom(givenOutcome.causeOfFailure);
    *
-   *   console.log(givenOutcome.unwrapped);
+   *   console.log(givenOutcome.value);
    * }
    * ```
    */
-  readonly unwrapped: this['product'];
+  readonly value: this['product'];
 
   rewrappedWith<
     SomeTransformedProduct = SomeProduct,

--- a/src/library/Attempt/Outcome/Success/thatYielded.ts
+++ b/src/library/Attempt/Outcome/Success/thatYielded.ts
@@ -17,7 +17,7 @@ const Attempt_Outcome_Success_thatYielded = <
   isFailure    : false,
   unwrapOr     : () => givenProduct,
   unwrapOrThrow: () => givenProduct,
-  unwrapped    : givenProduct,
+  value        : givenProduct,
   rewrappedWith: <
     SomeTransformedProduct,
   >(

--- a/src/library/HTTP/Client.ts
+++ b/src/library/HTTP/Client.ts
@@ -74,7 +74,7 @@ class HTTP_Client {
       outcomeOfSettlingResponse.isFailure
     ) return outcomeOfSettlingResponse;
 
-    const response = outcomeOfSettlingResponse.unwrapped;
+    const response = outcomeOfSettlingResponse.value;
 
     if (!response.ok) {
       const newResponseError = new HTTP_Endpoint.Error.RespondedWithFailure(response.statusText, response.status);

--- a/src/library/Shortfin/TextToImage/SDXL/Client/definition.declared.ts
+++ b/src/library/Shortfin/TextToImage/SDXL/Client/definition.declared.ts
@@ -47,7 +47,7 @@ class Shortfin_TextToImage_SDXL_Client
         outcomeOfSubmittingResource.isFailure
       ) return outcomeOfSubmittingResource;
 
-      const rawResource = outcomeOfSubmittingResource.unwrapped;
+      const rawResource = outcomeOfSubmittingResource.value;
       const decodedResource = Schema.decodeUnknownSync(Shortfin_TextToImage_SDXL_Client_Response.Body)(rawResource);
       const [soleGeneratedImage] = decodedResource.images;
       return Attempt.Outcome.succeed(soleGeneratedImage);

--- a/src/pages/TextToImagePage.vue
+++ b/src/pages/TextToImagePage.vue
@@ -138,7 +138,7 @@ const imageGeneration = useStatefulAttemptThatEventually(async () => {
       />
       <TextToImageOutputImg
         v-else-if="imageGeneration.outcome.value.isSuccess"
-        :model-value="imageGeneration.outcome.value.unwrapped"
+        :model-value="imageGeneration.outcome.value.value"
       />
       <TextToImageOutputAlert
         v-else

--- a/src/pages/TextToImagePage.vue
+++ b/src/pages/TextToImagePage.vue
@@ -142,7 +142,7 @@ const imageGeneration = useStatefulAttemptThatEventually(async () => {
       />
       <TextToImageOutputAlert
         v-else
-        :error="imageGeneration.outcome.value.causeOfFailure"
+        :error="imageGeneration.outcome.value.cause"
       />
     </VContainer>
   </VMain>


### PR DESCRIPTION
- `someOutcome.unwrapped` -> `someExit.value`
- `someOutcome.causeOfFailure` -> `someExit.cause`