### PR TITLE
refactor: aligns `Attempt.Outcome` getters with `Either` analogs

### DIFF
--- a/src/features/TextToImage/Server/Current/retrieve.ts
+++ b/src/features/TextToImage/Server/Current/retrieve.ts
@@ -31,13 +31,13 @@ const TextToImage_Server_Current_retrieve = (): Promise<
     Option.isSome(TextToImage_Server_Current_accordingToEnvironment)
   ) return Attempt.Outcome.succeed(Option.getOrThrow(TextToImage_Server_Current_accordingToEnvironment));
 
-  const staticConfig = (await TextToImage_Config.Static.read()).unwrapOrElse(TextToImage_Config.empty);
+  const staticConfig = (await TextToImage_Config.Static.read()).getOrElse(TextToImage_Config.empty);
 
   if (
     Option.isSome(staticConfig.server)
   ) return Attempt.Outcome.succeed(Option.getOrThrow(staticConfig.server));
 
-  const dynamicConfig = (await TextToImage_Config.Dynamic.fetch()).unwrapOrElse(TextToImage_Config.empty);
+  const dynamicConfig = (await TextToImage_Config.Dynamic.fetch()).getOrElse(TextToImage_Config.empty);
 
   if (
     Option.isSome(dynamicConfig.server)

--- a/src/features/TextToImage/Server/Current/retrieve.ts
+++ b/src/features/TextToImage/Server/Current/retrieve.ts
@@ -31,13 +31,13 @@ const TextToImage_Server_Current_retrieve = (): Promise<
     Option.isSome(TextToImage_Server_Current_accordingToEnvironment)
   ) return Attempt.Outcome.succeed(Option.getOrThrow(TextToImage_Server_Current_accordingToEnvironment));
 
-  const staticConfig = (await TextToImage_Config.Static.read()).unwrapOr(TextToImage_Config.empty);
+  const staticConfig = (await TextToImage_Config.Static.read()).unwrapOrElse(TextToImage_Config.empty);
 
   if (
     Option.isSome(staticConfig.server)
   ) return Attempt.Outcome.succeed(Option.getOrThrow(staticConfig.server));
 
-  const dynamicConfig = (await TextToImage_Config.Dynamic.fetch()).unwrapOr(TextToImage_Config.empty);
+  const dynamicConfig = (await TextToImage_Config.Dynamic.fetch()).unwrapOrElse(TextToImage_Config.empty);
 
   if (
     Option.isSome(dynamicConfig.server)

--- a/src/library/Attempt/Outcome/Discriminable/definition.declared.ts
+++ b/src/library/Attempt/Outcome/Discriminable/definition.declared.ts
@@ -30,7 +30,7 @@ interface Attempt_Outcome_Discriminable<
   readonly isSuccess: Is<this['discriminant'], 'success'>;
   readonly isFailure: Not<this['isSuccess']>;
 
-  unwrapOrElse<
+  getOrElse<
     SomeFallback,
   >(
     givenFallback: SomeFallback,
@@ -39,7 +39,7 @@ interface Attempt_Outcome_Discriminable<
     SomeFallback
   >;
 
-  unwrapOrThrow(): If<this['isSuccess'],
+  getOrThrow(): If<this['isSuccess'],
     SomePayload,
     never
   >;

--- a/src/library/Attempt/Outcome/Discriminable/definition.declared.ts
+++ b/src/library/Attempt/Outcome/Discriminable/definition.declared.ts
@@ -30,7 +30,7 @@ interface Attempt_Outcome_Discriminable<
   readonly isSuccess: Is<this['discriminant'], 'success'>;
   readonly isFailure: Not<this['isSuccess']>;
 
-  unwrapOr<
+  unwrapOrElse<
     SomeFallback,
   >(
     givenFallback: SomeFallback,

--- a/src/library/Attempt/Outcome/Failure/dueTo.ts
+++ b/src/library/Attempt/Outcome/Failure/dueTo.ts
@@ -19,7 +19,7 @@ const Attempt_Outcome_Failure_dueTo = <
   cause        : givenCause,
   isSuccess    : false,
   isFailure    : true,
-  unwrapOr     : <SomeFallback>($0: SomeFallback) => $0,
+  unwrapOrElse : <SomeFallback>($0: SomeFallback) => $0,
   unwrapOrThrow: () => givenCause.throwAnyway('Unexpected forceful unwrap of a failure'),
   rewrappedWith: <
     SomeTransformedActionableError extends Attempt_Error.Actionable<string>,

--- a/src/library/Attempt/Outcome/Failure/dueTo.ts
+++ b/src/library/Attempt/Outcome/Failure/dueTo.ts
@@ -19,8 +19,8 @@ const Attempt_Outcome_Failure_dueTo = <
   cause        : givenCause,
   isSuccess    : false,
   isFailure    : true,
-  unwrapOrElse : <SomeFallback>($0: SomeFallback) => $0,
-  unwrapOrThrow: () => givenCause.throwAnyway('Unexpected forceful unwrap of a failure'),
+  getOrElse    : <SomeFallback>($0: SomeFallback) => $0,
+  getOrThrow   : () => givenCause.throwAnyway('Unexpected forceful unwrap of a failure'),
   rewrappedWith: <
     SomeTransformedActionableError extends Attempt_Error.Actionable<string>,
   >(

--- a/src/library/Attempt/Outcome/Success/definition.declared.ts
+++ b/src/library/Attempt/Outcome/Success/definition.declared.ts
@@ -19,18 +19,18 @@ interface Attempt_Outcome_Success<
   /**
    * Access the product nested within a successful outcome.
    *
-   * Adds a guarded parallel to the `unwrapOrElse` and `unwrapOrThrow` methods:
+   * Adds a guarded parallel to the `getOrElse` and `getOrThrow` methods:
    * ```ts
    * function doRiskyThingUnsafely(
    *   givenOutcome: Attempt.Outcome<CustomProduct, CustomError>,
    * ): void {
-   *   console.log(givenOutcome.unwrapOrThrow());
+   *   console.log(givenOutcome.getOrThrow());
    * }
    *
    * function doRiskyThingSafelyWhileIgnoringErrors(
    *   givenOutcome: Attempt.Outcome<CustomProduct, CustomError>,
    * ): void {
-   *   console.log(givenOutcome.unwrapOrElse('Errors ignored'));
+   *   console.log(givenOutcome.getOrElse('Errors ignored'));
    * }
    *
    * function doRiskyThingSafelyWhileHandlingErrors(

--- a/src/library/Attempt/Outcome/Success/definition.declared.ts
+++ b/src/library/Attempt/Outcome/Success/definition.declared.ts
@@ -19,7 +19,7 @@ interface Attempt_Outcome_Success<
   /**
    * Access the product nested within a successful outcome.
    *
-   * Adds a guarded parallel to the `unwrapOr` and `unwrapOrThrow` methods:
+   * Adds a guarded parallel to the `unwrapOrElse` and `unwrapOrThrow` methods:
    * ```ts
    * function doRiskyThingUnsafely(
    *   givenOutcome: Attempt.Outcome<CustomProduct, CustomError>,
@@ -30,7 +30,7 @@ interface Attempt_Outcome_Success<
    * function doRiskyThingSafelyWhileIgnoringErrors(
    *   givenOutcome: Attempt.Outcome<CustomProduct, CustomError>,
    * ): void {
-   *   console.log(givenOutcome.unwrapOr('Errors ignored'));
+   *   console.log(givenOutcome.unwrapOrElse('Errors ignored'));
    * }
    *
    * function doRiskyThingSafelyWhileHandlingErrors(

--- a/src/library/Attempt/Outcome/Success/thatYielded.ts
+++ b/src/library/Attempt/Outcome/Success/thatYielded.ts
@@ -15,7 +15,7 @@ const Attempt_Outcome_Success_thatYielded = <
   product      : givenProduct,
   isSuccess    : true,
   isFailure    : false,
-  unwrapOr     : () => givenProduct,
+  unwrapOrElse : () => givenProduct,
   unwrapOrThrow: () => givenProduct,
   value        : givenProduct,
   rewrappedWith: <

--- a/src/library/Attempt/Outcome/Success/thatYielded.ts
+++ b/src/library/Attempt/Outcome/Success/thatYielded.ts
@@ -15,8 +15,8 @@ const Attempt_Outcome_Success_thatYielded = <
   product      : givenProduct,
   isSuccess    : true,
   isFailure    : false,
-  unwrapOrElse : () => givenProduct,
-  unwrapOrThrow: () => givenProduct,
+  getOrElse    : () => givenProduct,
+  getOrThrow   : () => givenProduct,
   value        : givenProduct,
   rewrappedWith: <
     SomeTransformedProduct,

--- a/src/library/ShimmedStabilityAIClient/Version1/Image.ts
+++ b/src/library/ShimmedStabilityAIClient/Version1/Image.ts
@@ -26,7 +26,7 @@ class ShimmedStabilityAIClient_Version1_Image
     const textToImageSDXLShortfinClient = new Shortfin.TextToImage.SDXL.Client(this.origin);
 
     const outcomeOfGeneratingImage = await textToImageSDXLShortfinClient.generateImageFrom(derivedBatchedRequestBody);
-    const generatedImage = outcomeOfGeneratingImage.unwrapOrThrow(/* matches error propagation of actual StabilityAI Client */);
+    const generatedImage = outcomeOfGeneratingImage.getOrThrow(/* matches error propagation of actual StabilityAI Client */);
 
     const soleGeneratedArtifact: StabilityAI_TextToImage_Pipeline_Output = {
       base64      : generatedImage.toString(),


### PR DESCRIPTION
- `someOutcome.unwrapOrThrow()` -> [`Either.getOrThrow(someEither)`](https://effect-ts.github.io/effect/effect/Either.ts.html#getorthrow)
- `someOutcome.unwrapOr(...)` -> [`Either.getOrElse(someEither, ...)`](https://effect-ts.github.io/effect/effect/Either.ts.html#getorelse)