### PR TITLE
refactor: switches from `someOutcome.getOr*(...)` to `Attempt.Either.getOr*(someOutcome, ...)`

### DIFF
--- a/src/features/TextToImage/Server/Current/retrieve.ts
+++ b/src/features/TextToImage/Server/Current/retrieve.ts
@@ -31,13 +31,13 @@ const TextToImage_Server_Current_retrieve = (): Promise<
     Option.isSome(TextToImage_Server_Current_accordingToEnvironment)
   ) return Attempt.Outcome.succeed(Option.getOrThrow(TextToImage_Server_Current_accordingToEnvironment));
 
-  const staticConfig = (await TextToImage_Config.Static.read()).getOrElse(() => TextToImage_Config.empty);
+  const staticConfig = Attempt.Either.getOrElse(await TextToImage_Config.Static.read(), () => TextToImage_Config.empty);
 
   if (
     Option.isSome(staticConfig.server)
   ) return Attempt.Outcome.succeed(Option.getOrThrow(staticConfig.server));
 
-  const dynamicConfig = (await TextToImage_Config.Dynamic.fetch()).getOrElse(() => TextToImage_Config.empty);
+  const dynamicConfig = Attempt.Either.getOrElse(await TextToImage_Config.Dynamic.fetch(), () => TextToImage_Config.empty);
 
   if (
     Option.isSome(dynamicConfig.server)

--- a/src/features/TextToImage/Server/Current/retrieve.ts
+++ b/src/features/TextToImage/Server/Current/retrieve.ts
@@ -31,13 +31,13 @@ const TextToImage_Server_Current_retrieve = (): Promise<
     Option.isSome(TextToImage_Server_Current_accordingToEnvironment)
   ) return Attempt.Outcome.succeed(Option.getOrThrow(TextToImage_Server_Current_accordingToEnvironment));
 
-  const staticConfig = (await TextToImage_Config.Static.read()).getOrElse(TextToImage_Config.empty);
+  const staticConfig = (await TextToImage_Config.Static.read()).getOrElse(() => TextToImage_Config.empty);
 
   if (
     Option.isSome(staticConfig.server)
   ) return Attempt.Outcome.succeed(Option.getOrThrow(staticConfig.server));
 
-  const dynamicConfig = (await TextToImage_Config.Dynamic.fetch()).getOrElse(TextToImage_Config.empty);
+  const dynamicConfig = (await TextToImage_Config.Dynamic.fetch()).getOrElse(() => TextToImage_Config.empty);
 
   if (
     Option.isSome(dynamicConfig.server)

--- a/src/library/Attempt/Either/definition.assembled.members.ts
+++ b/src/library/Attempt/Either/definition.assembled.members.ts
@@ -1,0 +1,7 @@
+export {
+  Attempt_Either_getOrElse as getOrElse,
+} from './getOrElse';
+
+export {
+  Attempt_Either_getOrThrow as getOrThrow,
+} from './getOrThrow';

--- a/src/library/Attempt/Either/definition.assembled.ts
+++ b/src/library/Attempt/Either/definition.assembled.ts
@@ -1,0 +1,1 @@
+export * as Attempt_Either from './definition.assembled.members.ts';

--- a/src/library/Attempt/Either/exports.object.primary.ts
+++ b/src/library/Attempt/Either/exports.object.primary.ts
@@ -1,0 +1,1 @@
+export * from './definition.assembled.ts';

--- a/src/library/Attempt/Either/getOrElse.ts
+++ b/src/library/Attempt/Either/getOrElse.ts
@@ -1,0 +1,22 @@
+import type {
+  Attempt_Error,
+} from '../Error';
+
+import type {
+  Attempt_Outcome,
+} from '../Outcome';
+
+const Attempt_Either_getOrElse = <
+  SomeProduct,
+  SomeActionableError extends Attempt_Error.Actionable<string>,
+  SomeFallbackProduct,
+>(
+  givenOutcome: Attempt_Outcome<SomeProduct, SomeActionableError>,
+  givenFallbackGetter: () => SomeFallbackProduct,
+): SomeProduct | SomeFallbackProduct => {
+  return givenOutcome.getOrElse(givenFallbackGetter);
+};
+
+export {
+  Attempt_Either_getOrElse,
+};

--- a/src/library/Attempt/Either/getOrThrow.ts
+++ b/src/library/Attempt/Either/getOrThrow.ts
@@ -1,0 +1,20 @@
+import type {
+  Attempt_Error,
+} from '../Error';
+
+import type {
+  Attempt_Outcome,
+} from '../Outcome';
+
+const Attempt_Either_getOrThrow = <
+  SomeProduct,
+  SomeActionableError extends Attempt_Error.Actionable<string>,
+>(
+  givenOutcome: Attempt_Outcome<SomeProduct, SomeActionableError>,
+): SomeProduct => {
+  return givenOutcome.getOrThrow();
+};
+
+export {
+  Attempt_Either_getOrThrow,
+};

--- a/src/library/Attempt/Either/index.ts
+++ b/src/library/Attempt/Either/index.ts
@@ -1,0 +1,1 @@
+export * from './exports.object.primary.ts';

--- a/src/library/Attempt/Outcome/Discriminable/definition.declared.ts
+++ b/src/library/Attempt/Outcome/Discriminable/definition.declared.ts
@@ -33,7 +33,7 @@ interface Attempt_Outcome_Discriminable<
   getOrElse<
     SomeFallback,
   >(
-    givenFallback: SomeFallback,
+    givenFallbackGetter: () => SomeFallback,
   ): If<this['isSuccess'],
     SomePayload,
     SomeFallback

--- a/src/library/Attempt/Outcome/Failure/dueTo.ts
+++ b/src/library/Attempt/Outcome/Failure/dueTo.ts
@@ -19,7 +19,7 @@ const Attempt_Outcome_Failure_dueTo = <
   cause        : givenCause,
   isSuccess    : false,
   isFailure    : true,
-  getOrElse    : <SomeFallback>($0: SomeFallback) => $0,
+  getOrElse    : <SomeFallback>($0: () => SomeFallback) => $0(),
   getOrThrow   : () => givenCause.throwAnyway('Unexpected forceful unwrap of a failure'),
   rewrappedWith: <
     SomeTransformedActionableError extends Attempt_Error.Actionable<string>,

--- a/src/library/Attempt/Outcome/Success/definition.declared.ts
+++ b/src/library/Attempt/Outcome/Success/definition.declared.ts
@@ -30,7 +30,7 @@ interface Attempt_Outcome_Success<
    * function doRiskyThingSafelyWhileIgnoringErrors(
    *   givenOutcome: Attempt.Outcome<CustomProduct, CustomError>,
    * ): void {
-   *   console.log(givenOutcome.getOrElse('Errors ignored'));
+   *   console.log(givenOutcome.getOrElse(() => 'Errors ignored'));
    * }
    *
    * function doRiskyThingSafelyWhileHandlingErrors(

--- a/src/library/Attempt/Outcome/Success/definition.declared.ts
+++ b/src/library/Attempt/Outcome/Success/definition.declared.ts
@@ -24,13 +24,13 @@ interface Attempt_Outcome_Success<
    * function doRiskyThingUnsafely(
    *   givenOutcome: Attempt.Outcome<CustomProduct, CustomError>,
    * ): void {
-   *   console.log(givenOutcome.getOrThrow());
+   *   console.log(Attempt.Either.getOrThrow(givenOutcome));
    * }
    *
    * function doRiskyThingSafelyWhileIgnoringErrors(
    *   givenOutcome: Attempt.Outcome<CustomProduct, CustomError>,
    * ): void {
-   *   console.log(givenOutcome.getOrElse(() => 'Errors ignored'));
+   *   console.log(Attempt.Either.getOrElse(givenOutcome, () => 'Errors ignored'));
    * }
    *
    * function doRiskyThingSafelyWhileHandlingErrors(

--- a/src/library/Attempt/definition.assembled.members.ts
+++ b/src/library/Attempt/definition.assembled.members.ts
@@ -1,4 +1,8 @@
 export {
+  Attempt_Either as Either,
+} from './Either';
+
+export {
   Attempt_Outcome as Outcome,
 } from './Outcome';
 

--- a/src/library/ShimmedStabilityAIClient/Version1/Image.ts
+++ b/src/library/ShimmedStabilityAIClient/Version1/Image.ts
@@ -7,6 +7,7 @@ import type {
   GenerateFromTextResponse,
 } from 'stabilityai-client-typescript/models/operations';
 
+import Attempt from '@/library/Attempt';
 import HTTP from '@/library/HTTP';
 import Shortfin from '@/library/Shortfin';
 
@@ -26,7 +27,7 @@ class ShimmedStabilityAIClient_Version1_Image
     const textToImageSDXLShortfinClient = new Shortfin.TextToImage.SDXL.Client(this.origin);
 
     const outcomeOfGeneratingImage = await textToImageSDXLShortfinClient.generateImageFrom(derivedBatchedRequestBody);
-    const generatedImage = outcomeOfGeneratingImage.getOrThrow(/* matches error propagation of actual StabilityAI Client */);
+    const generatedImage = Attempt.Either.getOrThrow(outcomeOfGeneratingImage); // matches error propagation of actual StabilityAI Client
 
     const soleGeneratedArtifact: StabilityAI_TextToImage_Pipeline_Output = {
       base64      : generatedImage.toString(),


### PR DESCRIPTION
Follows up on #1141