### PR TITLE
refactor: aligns `Attempt.Outcome` narrowing with `Exit` analogs

### DIFF
--- a/src/features/TextToImage/Client/SDXL/generateOutputFrom.ts
+++ b/src/features/TextToImage/Client/SDXL/generateOutputFrom.ts
@@ -42,7 +42,7 @@ const TextToImage_Client_SDXL_generateOutputFrom = async (
   const outcomeOfInitializingClient = await TextToImage_Client_SDXL_initialize();
 
   if (
-    outcomeOfInitializingClient.isFailure
+    Attempt.Outcome.isFailure(outcomeOfInitializingClient)
   ) return outcomeOfInitializingClient;
 
   const shimmedStabilityAIClient = outcomeOfInitializingClient.value;

--- a/src/library/Attempt/Outcome/Success/definition.declared.ts
+++ b/src/library/Attempt/Outcome/Success/definition.declared.ts
@@ -38,7 +38,7 @@ interface Attempt_Outcome_Success<
    *   recoverFrom: (expectedError: CustomError) => void,
    * ): void {
    *   if (
-   *     givenOutcome.isFailure
+   *     Attempt.Outcome.isFailure(givenOutcome)
    *   ) recoverFrom(givenOutcome.cause);
    *
    *   console.log(givenOutcome.value);

--- a/src/library/Attempt/Outcome/definition.declared.augmentation.ts
+++ b/src/library/Attempt/Outcome/definition.declared.augmentation.ts
@@ -19,6 +19,10 @@ import {
 } from './failCause';
 
 import {
+  Attempt_Outcome_isFailure,
+} from './isFailure';
+
+import {
   Attempt_Outcome_isSuccess,
 } from './isSuccess';
 
@@ -39,6 +43,7 @@ import {
 } from './succeed';
 
 Attempt_Outcome.isSuccess /*    */ = Attempt_Outcome_isSuccess;
+Attempt_Outcome.isFailure /*    */ = Attempt_Outcome_isFailure;
 Attempt_Outcome.succeed /*      */ = Attempt_Outcome_succeed;
 Attempt_Outcome.failCause /*    */ = Attempt_Outcome_failCause;
 Attempt_Outcome.die /*          */ = Attempt_Outcome_die;
@@ -52,6 +57,7 @@ declare module './definition.declared.ts' {
   namespace Attempt_Outcome {
     export {
       Attempt_Outcome_isSuccess /*    */ as isSuccess,
+      Attempt_Outcome_isFailure /*    */ as isFailure,
       Attempt_Outcome_succeed /*      */ as succeed,
       Attempt_Outcome_failCause /*    */ as failCause,
       Attempt_Outcome_die /*          */ as die,

--- a/src/library/Attempt/Outcome/definition.declared.augmentation.ts
+++ b/src/library/Attempt/Outcome/definition.declared.augmentation.ts
@@ -19,6 +19,10 @@ import {
 } from './failCause';
 
 import {
+  Attempt_Outcome_isSuccess,
+} from './isSuccess';
+
+import {
   Attempt_Outcome_map,
 } from './map';
 
@@ -34,6 +38,7 @@ import {
   Attempt_Outcome_succeed,
 } from './succeed';
 
+Attempt_Outcome.isSuccess /*    */ = Attempt_Outcome_isSuccess;
 Attempt_Outcome.succeed /*      */ = Attempt_Outcome_succeed;
 Attempt_Outcome.failCause /*    */ = Attempt_Outcome_failCause;
 Attempt_Outcome.die /*          */ = Attempt_Outcome_die;
@@ -46,6 +51,7 @@ Attempt_Outcome.mapErrorCause /**/ = Attempt_Outcome_mapErrorCause;
 declare module './definition.declared.ts' {
   namespace Attempt_Outcome {
     export {
+      Attempt_Outcome_isSuccess /*    */ as isSuccess,
       Attempt_Outcome_succeed /*      */ as succeed,
       Attempt_Outcome_failCause /*    */ as failCause,
       Attempt_Outcome_die /*          */ as die,

--- a/src/library/Attempt/Outcome/isFailure.ts
+++ b/src/library/Attempt/Outcome/isFailure.ts
@@ -1,0 +1,27 @@
+import type {
+  Attempt_Error,
+} from '../Error';
+
+import type {
+  Attempt_Outcome_Failure,
+} from './Failure';
+
+import type {
+  Attempt_Outcome,
+} from './definition.declared.ts';
+
+const Attempt_Outcome_isFailure = <
+  SomeProduct,
+  SomeActionableError extends Attempt_Error.Actionable<string>,
+>(
+  givenOutcome: Attempt_Outcome<
+    SomeProduct,
+    SomeActionableError
+  >,
+): givenOutcome is Attempt_Outcome_Failure<SomeActionableError> => {
+  return givenOutcome.isFailure;
+};
+
+export {
+  Attempt_Outcome_isFailure,
+};

--- a/src/library/Attempt/Outcome/isSuccess.ts
+++ b/src/library/Attempt/Outcome/isSuccess.ts
@@ -1,0 +1,27 @@
+import type {
+  Attempt_Error,
+} from '../Error';
+
+import type {
+  Attempt_Outcome_Success,
+} from './Success';
+
+import type {
+  Attempt_Outcome,
+} from './definition.declared.ts';
+
+const Attempt_Outcome_isSuccess = <
+  SomeProduct,
+  SomeActionableError extends Attempt_Error.Actionable<string>,
+>(
+  givenOutcome: Attempt_Outcome<
+    SomeProduct,
+    SomeActionableError
+  >,
+): givenOutcome is Attempt_Outcome_Success<SomeProduct> => {
+  return givenOutcome.isSuccess;
+};
+
+export {
+  Attempt_Outcome_isSuccess,
+};

--- a/src/library/Attempt/Outcome/mapBoth.ts
+++ b/src/library/Attempt/Outcome/mapBoth.ts
@@ -10,6 +10,10 @@ import type {
   Attempt_Outcome,
 } from './definition.declared.ts';
 
+import {
+  Attempt_Outcome_isSuccess,
+} from './isSuccess';
+
 /**
  * Convenience method for:
  * 1. unwrapping the contents of _this_ outcome,
@@ -40,7 +44,7 @@ const Attempt_Outcome_mapBoth = <
 ): Attempt_Outcome<
   SomeTransformedProduct,
   SomeTransformedActionableError
-> => givenOutcome.isSuccess
+> => Attempt_Outcome_isSuccess(givenOutcome)
   ? givenOutcome.rewrappedWith(toTransformedProduct)
   : givenOutcome.rewrappedWith(toTransformedCause);
 

--- a/src/library/HTTP/Client.ts
+++ b/src/library/HTTP/Client.ts
@@ -71,7 +71,7 @@ class HTTP_Client {
     });
 
     if (
-      outcomeOfSettlingResponse.isFailure
+      Attempt.Outcome.isFailure(outcomeOfSettlingResponse)
     ) return outcomeOfSettlingResponse;
 
     const response = outcomeOfSettlingResponse.value;

--- a/src/library/Shortfin/TextToImage/SDXL/Client/definition.declared.ts
+++ b/src/library/Shortfin/TextToImage/SDXL/Client/definition.declared.ts
@@ -44,7 +44,7 @@ class Shortfin_TextToImage_SDXL_Client
       });
 
       if (
-        outcomeOfSubmittingResource.isFailure
+        Attempt.Outcome.isFailure(outcomeOfSubmittingResource)
       ) return outcomeOfSubmittingResource;
 
       const rawResource = outcomeOfSubmittingResource.value;

--- a/src/pages/TextToImagePage.vue
+++ b/src/pages/TextToImagePage.vue
@@ -137,7 +137,7 @@ const imageGeneration = useStatefulAttemptThatEventually(async () => {
         }"
       />
       <TextToImageOutputImg
-        v-else-if="imageGeneration.outcome.value.isSuccess"
+        v-else-if="Attempt.Outcome.isSuccess(imageGeneration.outcome.value)"
         :model-value="imageGeneration.outcome.value.value"
       />
       <TextToImageOutputAlert


### PR DESCRIPTION
- the analogs are [`Exit.isSuccess`](https://effect-ts.github.io/effect/effect/Exit.ts.html#issuccess) and [`Exit.isFailure`](https://effect-ts.github.io/effect/effect/Exit.ts.html#isfailure)