### PR TITLE
refactor(library/Attempt): dissolves extraneous members in `Attempt.Outcome`

### DIFF
--- a/src/library/Attempt/Either/getOrElse.ts
+++ b/src/library/Attempt/Either/getOrElse.ts
@@ -2,7 +2,7 @@ import type {
   Attempt_Error,
 } from '../Error';
 
-import type {
+import {
   Attempt_Outcome,
 } from '../Outcome';
 
@@ -14,7 +14,9 @@ const Attempt_Either_getOrElse = <
   givenOutcome: Attempt_Outcome<SomeProduct, SomeActionableError>,
   givenFallbackGetter: () => SomeFallbackProduct,
 ): SomeProduct | SomeFallbackProduct => {
-  return givenOutcome.getOrElse(givenFallbackGetter);
+  return Attempt_Outcome.isSuccess(givenOutcome)
+    ? givenOutcome.product
+    : givenFallbackGetter();
 };
 
 export {

--- a/src/library/Attempt/Either/getOrElse.ts
+++ b/src/library/Attempt/Either/getOrElse.ts
@@ -15,7 +15,7 @@ const Attempt_Either_getOrElse = <
   givenFallbackGetter: () => SomeFallbackProduct,
 ): SomeProduct | SomeFallbackProduct => {
   return Attempt_Outcome.isSuccess(givenOutcome)
-    ? givenOutcome.product
+    ? givenOutcome.value
     : givenFallbackGetter();
 };
 

--- a/src/library/Attempt/Either/getOrThrow.ts
+++ b/src/library/Attempt/Either/getOrThrow.ts
@@ -13,7 +13,7 @@ const Attempt_Either_getOrThrow = <
   givenOutcome: Attempt_Outcome<SomeProduct, SomeActionableError>,
 ): SomeProduct => {
   return Attempt_Outcome.isSuccess(givenOutcome)
-    ? givenOutcome.product
+    ? givenOutcome.value
     : givenOutcome.cause.throwAnyway('Expected product, got failure instead');
 };
 

--- a/src/library/Attempt/Either/getOrThrow.ts
+++ b/src/library/Attempt/Either/getOrThrow.ts
@@ -2,7 +2,7 @@ import type {
   Attempt_Error,
 } from '../Error';
 
-import type {
+import {
   Attempt_Outcome,
 } from '../Outcome';
 
@@ -12,7 +12,9 @@ const Attempt_Either_getOrThrow = <
 >(
   givenOutcome: Attempt_Outcome<SomeProduct, SomeActionableError>,
 ): SomeProduct => {
-  return givenOutcome.getOrThrow();
+  return Attempt_Outcome.isSuccess(givenOutcome)
+    ? givenOutcome.product
+    : givenOutcome.cause.throwAnyway('Expected product, got failure instead');
 };
 
 export {

--- a/src/library/Attempt/Outcome/Discriminable/definition.declared.ts
+++ b/src/library/Attempt/Outcome/Discriminable/definition.declared.ts
@@ -1,9 +1,4 @@
 import type {
-  Is,
-  Not,
-} from '@/library/typeUtilities';
-
-import type {
   Attempt_Outcome_Discriminant,
 } from '../Discriminant';
 
@@ -11,15 +6,11 @@ import type {
   Attempt_Outcome_Discriminable_SyntacticallySugarfree,
 } from './SyntacticallySugarfree';
 
-interface Attempt_Outcome_Discriminable<
+type Attempt_Outcome_Discriminable<
   SomeDiscriminant extends Attempt_Outcome_Discriminant,
->
-  extends Attempt_Outcome_Discriminable_SyntacticallySugarfree<
-    SomeDiscriminant
-  > {
-  readonly isSuccess: Is<this['discriminant'], 'success'>;
-  readonly isFailure: Not<this['isSuccess']>;
-}
+> = Attempt_Outcome_Discriminable_SyntacticallySugarfree<
+  SomeDiscriminant
+>;
 
 export type {
   Attempt_Outcome_Discriminable,

--- a/src/library/Attempt/Outcome/Discriminable/definition.declared.ts
+++ b/src/library/Attempt/Outcome/Discriminable/definition.declared.ts
@@ -43,14 +43,6 @@ interface Attempt_Outcome_Discriminable<
     SomePayload,
     never
   >;
-
-  rewrappedWith<
-    SomeTransformedPayload extends (
-      SomeDiscriminant extends 'success'
-        ? unknown
-        : Attempt_Error.Actionable<string>
-    ) = SomePayload,
-  >(): Attempt_Outcome_Discriminable<SomeDiscriminant, SomeTransformedPayload>;
 }
 
 export type {

--- a/src/library/Attempt/Outcome/Discriminable/definition.declared.ts
+++ b/src/library/Attempt/Outcome/Discriminable/definition.declared.ts
@@ -4,10 +4,6 @@ import type {
 } from '@/library/typeUtilities';
 
 import type {
-  Attempt_Error,
-} from '../../Error';
-
-import type {
   Attempt_Outcome_Discriminant,
 } from '../Discriminant';
 
@@ -17,12 +13,6 @@ import type {
 
 interface Attempt_Outcome_Discriminable<
   SomeDiscriminant extends Attempt_Outcome_Discriminant,
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  SomePayload extends (
-    SomeDiscriminant extends 'success'
-      ? unknown
-      : Attempt_Error.Actionable<string>
-  ),
 >
   extends Attempt_Outcome_Discriminable_SyntacticallySugarfree<
     SomeDiscriminant

--- a/src/library/Attempt/Outcome/Discriminable/definition.declared.ts
+++ b/src/library/Attempt/Outcome/Discriminable/definition.declared.ts
@@ -1,6 +1,5 @@
 import type {
   Is,
-  If,
   Not,
 } from '@/library/typeUtilities';
 
@@ -18,6 +17,7 @@ import type {
 
 interface Attempt_Outcome_Discriminable<
   SomeDiscriminant extends Attempt_Outcome_Discriminant,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   SomePayload extends (
     SomeDiscriminant extends 'success'
       ? unknown
@@ -29,15 +29,6 @@ interface Attempt_Outcome_Discriminable<
   > {
   readonly isSuccess: Is<this['discriminant'], 'success'>;
   readonly isFailure: Not<this['isSuccess']>;
-
-  getOrElse<
-    SomeFallback,
-  >(
-    givenFallbackGetter: () => SomeFallback,
-  ): If<this['isSuccess'],
-    SomePayload,
-    SomeFallback
-  >;
 }
 
 export type {

--- a/src/library/Attempt/Outcome/Discriminable/definition.declared.ts
+++ b/src/library/Attempt/Outcome/Discriminable/definition.declared.ts
@@ -38,11 +38,6 @@ interface Attempt_Outcome_Discriminable<
     SomePayload,
     SomeFallback
   >;
-
-  getOrThrow(): If<this['isSuccess'],
-    SomePayload,
-    never
-  >;
 }
 
 export type {

--- a/src/library/Attempt/Outcome/Failure/SemanticallySugarfree.ts
+++ b/src/library/Attempt/Outcome/Failure/SemanticallySugarfree.ts
@@ -10,8 +10,7 @@ interface Attempt_Outcome_Failure_SemanticallySugarfree<
   SomeActionableError extends Attempt_Error.Actionable<string>,
 >
   extends Attempt_Outcome_Discriminable<
-    'failure',
-    SomeActionableError
+    'failure'
   > {
   readonly cause: SomeActionableError;
 }

--- a/src/library/Attempt/Outcome/Failure/definition.declared.ts
+++ b/src/library/Attempt/Outcome/Failure/definition.declared.ts
@@ -3,28 +3,14 @@ import {
 } from '../../Error';
 
 import type {
-  Attempt_Outcome_Failure_Cause,
-} from './Cause';
-
-import type {
   Attempt_Outcome_Failure_SemanticallySugarfree,
 } from './SemanticallySugarfree';
 
-interface Attempt_Outcome_Failure<
+type Attempt_Outcome_Failure<
   SomeActionableError extends Attempt_Error.Actionable<string>,
->
-  extends Attempt_Outcome_Failure_SemanticallySugarfree<
-    SomeActionableError
-  > {
-  rewrappedWith<
-    SomeTransformedActionableError extends Attempt_Error.Actionable<string> = SomeActionableError,
-  >(
-    given?: Attempt_Outcome_Failure_Cause.Transformer<
-      SomeActionableError,
-      SomeTransformedActionableError
-    >
-  ): Attempt_Outcome_Failure<SomeTransformedActionableError>;
-}
+> = Attempt_Outcome_Failure_SemanticallySugarfree<
+  SomeActionableError
+>;
 
 function Attempt_Outcome_Failure(
   namespaceOnly: never = Attempt_Error.NonActionable.throw(

--- a/src/library/Attempt/Outcome/Failure/dueTo.ts
+++ b/src/library/Attempt/Outcome/Failure/dueTo.ts
@@ -2,7 +2,7 @@ import type {
   Attempt_Error,
 } from '../../Error';
 
-import {
+import type {
   Attempt_Outcome_Failure_Cause,
 } from './Cause';
 
@@ -24,7 +24,7 @@ const Attempt_Outcome_Failure_dueTo = <
   rewrappedWith: <
     SomeTransformedActionableError extends Attempt_Error.Actionable<string>,
   >(
-    transformed = Attempt_Outcome_Failure_Cause.Transformer.identity<
+    transformed: Attempt_Outcome_Failure_Cause.Transformer<
       SomeActionableError,
       SomeTransformedActionableError
     >,

--- a/src/library/Attempt/Outcome/Failure/dueTo.ts
+++ b/src/library/Attempt/Outcome/Failure/dueTo.ts
@@ -16,7 +16,6 @@ const Attempt_Outcome_Failure_dueTo = <
   isSuccess   : false,
   isFailure   : true,
   getOrElse   : <SomeFallback>($0: () => SomeFallback) => $0(),
-  getOrThrow  : () => givenCause.throwAnyway('Unexpected forceful unwrap of a failure'),
 });
 
 export {

--- a/src/library/Attempt/Outcome/Failure/dueTo.ts
+++ b/src/library/Attempt/Outcome/Failure/dueTo.ts
@@ -3,10 +3,6 @@ import type {
 } from '../../Error';
 
 import type {
-  Attempt_Outcome_Failure_Cause,
-} from './Cause';
-
-import type {
   Attempt_Outcome_Failure,
 } from './definition.declared.ts';
 
@@ -15,24 +11,12 @@ const Attempt_Outcome_Failure_dueTo = <
 >(
   givenCause: SomeActionableError,
 ): Attempt_Outcome_Failure<SomeActionableError> => ({
-  discriminant : 'failure',
-  cause        : givenCause,
-  isSuccess    : false,
-  isFailure    : true,
-  getOrElse    : <SomeFallback>($0: () => SomeFallback) => $0(),
-  getOrThrow   : () => givenCause.throwAnyway('Unexpected forceful unwrap of a failure'),
-  rewrappedWith: <
-    SomeTransformedActionableError extends Attempt_Error.Actionable<string>,
-  >(
-    transformed: Attempt_Outcome_Failure_Cause.Transformer<
-      SomeActionableError,
-      SomeTransformedActionableError
-    >,
-  ) => {
-    const transformedCause = transformed(givenCause);
-    const transformedFailure = Attempt_Outcome_Failure_dueTo(transformedCause);
-    return transformedFailure;
-  },
+  discriminant: 'failure',
+  cause       : givenCause,
+  isSuccess   : false,
+  isFailure   : true,
+  getOrElse   : <SomeFallback>($0: () => SomeFallback) => $0(),
+  getOrThrow  : () => givenCause.throwAnyway('Unexpected forceful unwrap of a failure'),
 });
 
 export {

--- a/src/library/Attempt/Outcome/Failure/dueTo.ts
+++ b/src/library/Attempt/Outcome/Failure/dueTo.ts
@@ -13,8 +13,6 @@ const Attempt_Outcome_Failure_dueTo = <
 ): Attempt_Outcome_Failure<SomeActionableError> => ({
   discriminant: 'failure',
   cause       : givenCause,
-  isSuccess   : false,
-  isFailure   : true,
 });
 
 export {

--- a/src/library/Attempt/Outcome/Failure/dueTo.ts
+++ b/src/library/Attempt/Outcome/Failure/dueTo.ts
@@ -15,7 +15,6 @@ const Attempt_Outcome_Failure_dueTo = <
   cause       : givenCause,
   isSuccess   : false,
   isFailure   : true,
-  getOrElse   : <SomeFallback>($0: () => SomeFallback) => $0(),
 });
 
 export {

--- a/src/library/Attempt/Outcome/Success/SemanticallySugarfree.ts
+++ b/src/library/Attempt/Outcome/Success/SemanticallySugarfree.ts
@@ -6,8 +6,7 @@ interface Attempt_Outcome_Success_SemanticallySugarfree<
   SomeProduct,
 >
   extends Attempt_Outcome_Discriminable<
-    'success',
-    SomeProduct
+    'success'
   > {
   readonly product: SomeProduct;
 }

--- a/src/library/Attempt/Outcome/Success/SemanticallySugarfree.ts
+++ b/src/library/Attempt/Outcome/Success/SemanticallySugarfree.ts
@@ -8,7 +8,7 @@ interface Attempt_Outcome_Success_SemanticallySugarfree<
   extends Attempt_Outcome_Discriminable<
     'success'
   > {
-  readonly product: SomeProduct;
+  readonly value: SomeProduct;
 }
 
 export type {

--- a/src/library/Attempt/Outcome/Success/definition.declared.ts
+++ b/src/library/Attempt/Outcome/Success/definition.declared.ts
@@ -6,43 +6,11 @@ import type {
   Attempt_Outcome_Success_SemanticallySugarfree,
 } from './SemanticallySugarfree';
 
-interface Attempt_Outcome_Success<
+type Attempt_Outcome_Success<
   SomeProduct,
->
-  extends Attempt_Outcome_Success_SemanticallySugarfree<
-    SomeProduct
-  > {
-  /**
-   * Access the product nested within a successful outcome.
-   *
-   * Adds a guarded parallel to the `getOrElse` and `getOrThrow` methods:
-   * ```ts
-   * function doRiskyThingUnsafely(
-   *   givenOutcome: Attempt.Outcome<CustomProduct, CustomError>,
-   * ): void {
-   *   console.log(Attempt.Either.getOrThrow(givenOutcome));
-   * }
-   *
-   * function doRiskyThingSafelyWhileIgnoringErrors(
-   *   givenOutcome: Attempt.Outcome<CustomProduct, CustomError>,
-   * ): void {
-   *   console.log(Attempt.Either.getOrElse(givenOutcome, () => 'Errors ignored'));
-   * }
-   *
-   * function doRiskyThingSafelyWhileHandlingErrors(
-   *   givenOutcome: Attempt.Outcome<CustomProduct, CustomError>,
-   *   recoverFrom: (expectedError: CustomError) => void,
-   * ): void {
-   *   if (
-   *     Attempt.Outcome.isFailure(givenOutcome)
-   *   ) recoverFrom(givenOutcome.cause);
-   *
-   *   console.log(givenOutcome.value);
-   * }
-   * ```
-   */
-  readonly value: this['product'];
-}
+> = Attempt_Outcome_Success_SemanticallySugarfree<
+  SomeProduct
+>;
 
 function Attempt_Outcome_Success(
   namespaceOnly: never = Attempt_Error.NonActionable.throw(

--- a/src/library/Attempt/Outcome/Success/definition.declared.ts
+++ b/src/library/Attempt/Outcome/Success/definition.declared.ts
@@ -3,10 +3,6 @@ import {
 } from '../../Error';
 
 import type {
-  Attempt_Outcome_Success_Product,
-} from './Product';
-
-import type {
   Attempt_Outcome_Success_SemanticallySugarfree,
 } from './SemanticallySugarfree';
 
@@ -46,15 +42,6 @@ interface Attempt_Outcome_Success<
    * ```
    */
   readonly value: this['product'];
-
-  rewrappedWith<
-    SomeTransformedProduct = SomeProduct,
-  >(
-    given?: Attempt_Outcome_Success_Product.Transformer<
-      SomeProduct,
-      SomeTransformedProduct
-    >
-  ): Attempt_Outcome_Success<SomeTransformedProduct>;
 }
 
 function Attempt_Outcome_Success(

--- a/src/library/Attempt/Outcome/Success/thatYielded.ts
+++ b/src/library/Attempt/Outcome/Success/thatYielded.ts
@@ -8,7 +8,6 @@ const Attempt_Outcome_Success_thatYielded = <
   givenProduct: SomeProduct,
 ): Attempt_Outcome_Success<SomeProduct> => ({
   discriminant: 'success',
-  product     : givenProduct,
   value       : givenProduct,
 });
 

--- a/src/library/Attempt/Outcome/Success/thatYielded.ts
+++ b/src/library/Attempt/Outcome/Success/thatYielded.ts
@@ -11,7 +11,6 @@ const Attempt_Outcome_Success_thatYielded = <
   product     : givenProduct,
   isSuccess   : true,
   isFailure   : false,
-  getOrElse   : () => givenProduct,
   value       : givenProduct,
 });
 

--- a/src/library/Attempt/Outcome/Success/thatYielded.ts
+++ b/src/library/Attempt/Outcome/Success/thatYielded.ts
@@ -1,8 +1,4 @@
 import type {
-  Attempt_Outcome_Success_Product,
-} from './Product';
-
-import type {
   Attempt_Outcome_Success,
 } from './definition.declared.ts';
 
@@ -11,25 +7,13 @@ const Attempt_Outcome_Success_thatYielded = <
 >(
   givenProduct: SomeProduct,
 ): Attempt_Outcome_Success<SomeProduct> => ({
-  discriminant : 'success',
-  product      : givenProduct,
-  isSuccess    : true,
-  isFailure    : false,
-  getOrElse    : () => givenProduct,
-  getOrThrow   : () => givenProduct,
-  value        : givenProduct,
-  rewrappedWith: <
-    SomeTransformedProduct,
-  >(
-    transformed: Attempt_Outcome_Success_Product.Transformer<
-      SomeProduct,
-      SomeTransformedProduct
-    >,
-  ) => {
-    const transformedProduct = transformed(givenProduct);
-    const transformedSuccess = Attempt_Outcome_Success_thatYielded(transformedProduct);
-    return transformedSuccess;
-  },
+  discriminant: 'success',
+  product     : givenProduct,
+  isSuccess   : true,
+  isFailure   : false,
+  getOrElse   : () => givenProduct,
+  getOrThrow  : () => givenProduct,
+  value       : givenProduct,
 });
 
 export {

--- a/src/library/Attempt/Outcome/Success/thatYielded.ts
+++ b/src/library/Attempt/Outcome/Success/thatYielded.ts
@@ -9,8 +9,6 @@ const Attempt_Outcome_Success_thatYielded = <
 ): Attempt_Outcome_Success<SomeProduct> => ({
   discriminant: 'success',
   product     : givenProduct,
-  isSuccess   : true,
-  isFailure   : false,
   value       : givenProduct,
 });
 

--- a/src/library/Attempt/Outcome/Success/thatYielded.ts
+++ b/src/library/Attempt/Outcome/Success/thatYielded.ts
@@ -12,7 +12,6 @@ const Attempt_Outcome_Success_thatYielded = <
   isSuccess   : true,
   isFailure   : false,
   getOrElse   : () => givenProduct,
-  getOrThrow  : () => givenProduct,
   value       : givenProduct,
 });
 

--- a/src/library/Attempt/Outcome/Success/thatYielded.ts
+++ b/src/library/Attempt/Outcome/Success/thatYielded.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   Attempt_Outcome_Success_Product,
 } from './Product';
 
@@ -21,7 +21,7 @@ const Attempt_Outcome_Success_thatYielded = <
   rewrappedWith: <
     SomeTransformedProduct,
   >(
-    transformed = Attempt_Outcome_Success_Product.Transformer.identity<
+    transformed: Attempt_Outcome_Success_Product.Transformer<
       SomeProduct,
       SomeTransformedProduct
     >,

--- a/src/library/Attempt/Outcome/isFailure.ts
+++ b/src/library/Attempt/Outcome/isFailure.ts
@@ -19,7 +19,7 @@ const Attempt_Outcome_isFailure = <
     SomeActionableError
   >,
 ): givenOutcome is Attempt_Outcome_Failure<SomeActionableError> => {
-  return givenOutcome.isFailure;
+  return givenOutcome.discriminant === 'failure';
 };
 
 export {

--- a/src/library/Attempt/Outcome/isSuccess.ts
+++ b/src/library/Attempt/Outcome/isSuccess.ts
@@ -19,7 +19,7 @@ const Attempt_Outcome_isSuccess = <
     SomeActionableError
   >,
 ): givenOutcome is Attempt_Outcome_Success<SomeProduct> => {
-  return givenOutcome.isSuccess;
+  return givenOutcome.discriminant === 'success';
 };
 
 export {

--- a/src/library/Attempt/Outcome/mapBoth.ts
+++ b/src/library/Attempt/Outcome/mapBoth.ts
@@ -54,7 +54,7 @@ const Attempt_Outcome_mapBoth = <
   SomeTransformedActionableError
 > => Attempt_Outcome_isSuccess(givenOutcome)
   ? Attempt_Outcome_succeed(
-      toTransformedProduct(givenOutcome.product),
+      toTransformedProduct(givenOutcome.value),
     )
   : Attempt_Outcome_failCause(
       toTransformedCause(givenOutcome.cause),

--- a/src/library/Attempt/Outcome/mapBoth.ts
+++ b/src/library/Attempt/Outcome/mapBoth.ts
@@ -11,8 +11,16 @@ import type {
 } from './definition.declared.ts';
 
 import {
+  Attempt_Outcome_failCause,
+} from './failCause';
+
+import {
   Attempt_Outcome_isSuccess,
 } from './isSuccess';
+
+import {
+  Attempt_Outcome_succeed,
+} from './succeed';
 
 /**
  * Convenience method for:
@@ -45,8 +53,12 @@ const Attempt_Outcome_mapBoth = <
   SomeTransformedProduct,
   SomeTransformedActionableError
 > => Attempt_Outcome_isSuccess(givenOutcome)
-  ? givenOutcome.rewrappedWith(toTransformedProduct)
-  : givenOutcome.rewrappedWith(toTransformedCause);
+  ? Attempt_Outcome_succeed(
+      toTransformedProduct(givenOutcome.product),
+    )
+  : Attempt_Outcome_failCause(
+      toTransformedCause(givenOutcome.cause),
+    );
 
 export {
   Attempt_Outcome_mapBoth,


### PR DESCRIPTION
- all extra instance members have already been replaced by their functional analogs