### PR TITLE
refactor: avoids "outcome" regarding `Option<Attempt.Outcome<...>>`

### DIFF
--- a/src/library/Attempt/Progressive.ts
+++ b/src/library/Attempt/Progressive.ts
@@ -16,7 +16,7 @@ interface Attempt_Progressive<
 > {
   initiate: () => Promise<void>;
   isInProgress: boolean;
-  outcome: Option.Option<
+  result: Option.Option<
     Attempt_Outcome<
       SomeProduct,
       SomeActionableError

--- a/src/library/vue/composables/useStatefulAttemptThatEventually.ts
+++ b/src/library/vue/composables/useStatefulAttemptThatEventually.ts
@@ -11,7 +11,7 @@ import {
 
 import Attempt from '@/library/Attempt';
 
-/** Useful when state of UI is dependent on some async operation and the outcome upon completion */
+/** Useful when state of UI is dependent on some async operation and the result upon completion */
 const useStatefulAttemptThatEventually = <
   SomeProduct,
   SomeActionableError extends Attempt.Error.Actionable<string>,
@@ -51,7 +51,7 @@ const useStatefulAttemptThatEventually = <
     get isInProgress() {
       return get(flagIsRaised);
     },
-    get outcome() {
+    get result() {
       if (
         this.isInProgress
       ) return Option.none();

--- a/src/pages/TextToImagePage.vue
+++ b/src/pages/TextToImagePage.vue
@@ -129,7 +129,7 @@ const imageGeneration = useStatefulAttemptThatEventually(async () => {
       class="fill-height"
     >
       <VSkeletonLoader
-        v-if="Option.isNone(imageGeneration.outcome)"
+        v-if="Option.isNone(imageGeneration.result)"
         :boilerplate="!imageGeneration.isInProgress"
         width="100vh"
         :style="{
@@ -137,12 +137,12 @@ const imageGeneration = useStatefulAttemptThatEventually(async () => {
         }"
       />
       <TextToImageOutputImg
-        v-else-if="Attempt.Outcome.isSuccess(imageGeneration.outcome.value)"
-        :model-value="imageGeneration.outcome.value.value"
+        v-else-if="Attempt.Outcome.isSuccess(imageGeneration.result.value)"
+        :model-value="imageGeneration.result.value.value"
       />
       <TextToImageOutputAlert
         v-else
-        :error="imageGeneration.outcome.value.cause"
+        :error="imageGeneration.result.value.cause"
       />
     </VContainer>
   </VMain>


### PR DESCRIPTION
- When an `Attempt.Outcome<...>` is optional, it's as if the outcome "may or may not exist yet" and thus is not considered to be a "pure" outcome until it's unwrapped.

Facilitates #1158