### PR TITLE
refactor: adds `Cause` compatibility to `Attempt.Exit`

### DIFF
--- a/src/features/TextToImage/Server/Current/retrieve.ts
+++ b/src/features/TextToImage/Server/Current/retrieve.ts
@@ -49,7 +49,7 @@ const TextToImage_Server_Current_retrieve = (): Promise<
     TextToImage_Config.Dynamic.endpoint,
   );
 
-  return Attempt.Exit.failCause(newSpecificationError);
+  return Attempt.Exit.fail(newSpecificationError);
 });
 
 export {

--- a/src/features/TextToImage/components/TextToImageOutputView.vue
+++ b/src/features/TextToImage/components/TextToImageOutputView.vue
@@ -1,4 +1,8 @@
 <script setup lang="ts">
+import {
+  Cause,
+} from 'effect';
+
 import Attempt from '@/library/Attempt';
 
 import type TextToImage from '@/features/TextToImage';
@@ -20,7 +24,12 @@ defineProps<{
     :model-value="output.value"
   />
   <TextToImageOutputAlert
-    v-else
-    :error="output.cause"
+    v-else-if="Cause.isFailType(output.cause)"
+    :error="output.cause.error"
   />
+  <template
+    v-else
+  >
+    {{ Attempt.Exit.die(Cause.pretty(output.cause)) }}
+  </template>
 </template>

--- a/src/library/Attempt/Adapted/to.ts
+++ b/src/library/Attempt/Adapted/to.ts
@@ -34,7 +34,7 @@ const Attempt_Adapted_to = <
       using: given.interpretationOf,
     });
 
-    return Attempt_Exit.failCause(someActionableError);
+    return Attempt_Exit.fail(someActionableError);
   },
 }));
 

--- a/src/library/Attempt/Adapted/toEventually.ts
+++ b/src/library/Attempt/Adapted/toEventually.ts
@@ -39,7 +39,7 @@ const Attempt_Adapted_toEventually = async <
       using: given.interpretationOf,
     });
 
-    return Attempt_Exit.failCause(someActionableError);
+    return Attempt_Exit.fail(someActionableError);
   },
 }));
 

--- a/src/library/Attempt/Either/getOrThrow.ts
+++ b/src/library/Attempt/Either/getOrThrow.ts
@@ -1,3 +1,7 @@
+import {
+  Cause,
+} from 'effect';
+
 import type {
   Attempt_Error,
 } from '../Error';
@@ -12,9 +16,15 @@ const Attempt_Either_getOrThrow = <
 >(
   givenExit: Attempt_Exit.Exit<SomeProduct, SomeActionableError>,
 ): SomeProduct => {
-  return Attempt_Exit.isSuccess(givenExit)
-    ? givenExit.value
-    : givenExit.cause.throwAnyway('Expected product, got failure instead');
+  if (
+    Attempt_Exit.isSuccess(givenExit)
+  ) return givenExit.value;
+
+  if (
+    !Cause.isFailType(givenExit.cause)
+  ) return Attempt_Exit.die(`Expected failure, got "${givenExit.cause._tag}" instead`);
+
+  return givenExit.cause.error.throwAnyway('Expected product, got failure instead');
 };
 
 export {

--- a/src/library/Attempt/Exit/Failure/SemanticallySugarfree.ts
+++ b/src/library/Attempt/Exit/Failure/SemanticallySugarfree.ts
@@ -1,4 +1,8 @@
 import type {
+  Cause,
+} from 'effect';
+
+import type {
   Attempt_Error,
 } from '../../Error';
 
@@ -12,7 +16,7 @@ interface Attempt_Exit_Failure_SemanticallySugarfree<
   extends Attempt_Exit_Discriminable<
     'failure'
   > {
-  readonly cause: SomeActionableError;
+  readonly cause: Cause.Cause<SomeActionableError>;
 }
 
 export type {

--- a/src/library/Attempt/Exit/Failure/dueTo.ts
+++ b/src/library/Attempt/Exit/Failure/dueTo.ts
@@ -1,4 +1,8 @@
 import type {
+  Cause,
+} from 'effect';
+
+import type {
   Attempt_Error,
 } from '../../Error';
 
@@ -9,7 +13,7 @@ import type {
 const Attempt_Exit_Failure_dueTo = <
   SomeActionableError extends Attempt_Error.Actionable<string>,
 >(
-  givenCause: SomeActionableError,
+  givenCause: Cause.Cause<SomeActionableError>,
 ): Attempt_Exit_Failure<SomeActionableError> => ({
   discriminant: 'failure',
   cause       : givenCause,

--- a/src/library/Attempt/Exit/definition.assembled.members.ts
+++ b/src/library/Attempt/Exit/definition.assembled.members.ts
@@ -15,6 +15,10 @@ export {
 } from './die';
 
 export {
+  Attempt_Exit_fail as fail,
+} from './fail';
+
+export {
   Attempt_Exit_failCause as failCause,
 } from './failCause';
 

--- a/src/library/Attempt/Exit/fail.ts
+++ b/src/library/Attempt/Exit/fail.ts
@@ -1,0 +1,23 @@
+import type {
+  Attempt_Error,
+} from '../Error';
+
+import type {
+  Attempt_Exit_Failure,
+} from './Failure';
+
+import {
+  Attempt_Exit_failCause,
+} from './failCause';
+
+const Attempt_Exit_fail = <
+  SomeActionableError extends Attempt_Error.Actionable<string>,
+>(
+  givenError: SomeActionableError,
+): Attempt_Exit_Failure<SomeActionableError> => Attempt_Exit_failCause(
+  givenError,
+);
+
+export {
+  Attempt_Exit_fail,
+};

--- a/src/library/Attempt/Exit/fail.ts
+++ b/src/library/Attempt/Exit/fail.ts
@@ -1,3 +1,7 @@
+import {
+  Cause,
+} from 'effect';
+
 import type {
   Attempt_Error,
 } from '../Error';
@@ -15,7 +19,7 @@ const Attempt_Exit_fail = <
 >(
   givenError: SomeActionableError,
 ): Attempt_Exit_Failure<SomeActionableError> => Attempt_Exit_failCause(
-  givenError,
+  Cause.fail(givenError),
 );
 
 export {

--- a/src/library/Attempt/Exit/mapBoth.ts
+++ b/src/library/Attempt/Exit/mapBoth.ts
@@ -1,3 +1,7 @@
+import {
+  Cause,
+} from 'effect';
+
 import type {
   Attempt_Error,
 } from '../Error';
@@ -9,6 +13,10 @@ import type {
 import type {
   Attempt_Exit_Transformer,
 } from './Transformer';
+
+import {
+  Attempt_Exit_die,
+} from './die';
 
 import {
   Attempt_Exit_fail,
@@ -42,7 +50,7 @@ const Attempt_Exit_mapBoth = <
   >,
   {
     onSuccess: toTransformedProduct,
-    onFailure: toTransformedCause,
+    onFailure: toTransformedError,
   }: Attempt_Exit_Transformer<
     SomeTransformableProduct,
     SomeTransformableActionableError,
@@ -52,13 +60,21 @@ const Attempt_Exit_mapBoth = <
 ): Attempt_Exit_Exit<
   SomeTransformedProduct,
   SomeTransformedActionableError
-> => Attempt_Exit_isSuccess(givenExit)
-  ? Attempt_Exit_succeed(
-      toTransformedProduct(givenExit.value),
-    )
-  : Attempt_Exit_fail(
-      toTransformedCause(givenExit.cause),
-    );
+> => {
+  if (
+    Attempt_Exit_isSuccess(givenExit)
+  ) return Attempt_Exit_succeed(
+    toTransformedProduct(givenExit.value),
+  );
+
+  if (
+    !Cause.isFailType(givenExit.cause)
+  ) return Attempt_Exit_die(`Expected failure cause, got ${givenExit.cause._tag} instead`);
+
+  return Attempt_Exit_fail(
+    toTransformedError(givenExit.cause.error),
+  );
+};
 
 export {
   Attempt_Exit_mapBoth,

--- a/src/library/Attempt/Exit/mapBoth.ts
+++ b/src/library/Attempt/Exit/mapBoth.ts
@@ -11,8 +11,8 @@ import type {
 } from './Transformer';
 
 import {
-  Attempt_Exit_failCause,
-} from './failCause';
+  Attempt_Exit_fail,
+} from './fail';
 
 import {
   Attempt_Exit_isSuccess,
@@ -56,7 +56,7 @@ const Attempt_Exit_mapBoth = <
   ? Attempt_Exit_succeed(
       toTransformedProduct(givenExit.value),
     )
-  : Attempt_Exit_failCause(
+  : Attempt_Exit_fail(
       toTransformedCause(givenExit.cause),
     );
 

--- a/src/library/HTTP/Client.ts
+++ b/src/library/HTTP/Client.ts
@@ -78,7 +78,7 @@ class HTTP_Client {
 
     if (!response.ok) {
       const newResponseError = new HTTP_Endpoint.Error.RespondedWithFailure(response.statusText, response.status);
-      return Attempt.Exit.failCause(newResponseError);
+      return Attempt.Exit.fail(newResponseError);
     }
 
     const exitFromDigestingResponseBody = await bodyOf(response).digestAsUnknown();

--- a/src/library/HTTP/Response/bodyOf.ts
+++ b/src/library/HTTP/Response/bodyOf.ts
@@ -31,7 +31,7 @@ const bodyOf = (
     return Attempt.Fresh.thatEventually(async () => {
       if (!this.isSuggestedToBeDigestibleAs(ContentDescriptor.json)) {
         const newDescriptorMismatchError = new HTTP_Response_Body.Digestion.Error.DescriptorMismatch(givenResponse, ContentDescriptor.json);
-        return Attempt.Exit.failCause(newDescriptorMismatchError);
+        return Attempt.Exit.fail(newDescriptorMismatchError);
       }
 
       const promiseForDigestedResponseBody: Promise<unknown> = givenResponse.json();


### PR DESCRIPTION
- In `effect`, [`Exit.Failure<A, E>['cause']` is `Cause<E>`](https://effect-ts.github.io/effect/effect/Exit.ts.html#failure-interface)
- These changes adjust the `Attempt` library to match that structure