### PR TITLE
refactor: aligns all custom errors with `Data.TaggedError<...>`

### DIFF
--- a/src/features/TextToImage/Config/Dynamic/Fetching/Error.ts
+++ b/src/features/TextToImage/Config/Dynamic/Fetching/Error.ts
@@ -2,11 +2,9 @@ import Attempt from '@/library/Attempt';
 import type URLComponent from '@/library/URLComponent';
 
 class TextToImage_Config_Dynamic_Fetching_Error
-  extends Attempt.Error.Actionable<
-    'TextToImage_Config_Dynamic_Fetching_Error'
-  > {
-  public override name = 'TextToImage_Config_Dynamic_Fetching_Error' as const;
-
+  extends Attempt.Error.Tagged(
+    'TextToImage_Config_Dynamic_Fetching_Error',
+  ) {
   public constructor(
     public readonly endpoint: URLComponent.Path,
     givenCause: Error,

--- a/src/features/TextToImage/Config/Static/Reading/Error.ts
+++ b/src/features/TextToImage/Config/Static/Reading/Error.ts
@@ -2,11 +2,9 @@ import Attempt from '@/library/Attempt';
 import type URLComponent from '@/library/URLComponent';
 
 class TextToImage_Config_Static_Reading_Error
-  extends Attempt.Error.Actionable<
-    'TextToImage_Config_Static_Reading_Error'
-  > {
-  public override name = 'TextToImage_Config_Static_Reading_Error' as const;
-
+  extends Attempt.Error.Tagged(
+    'TextToImage_Config_Static_Reading_Error',
+  ) {
   public constructor(
     public readonly filePath: URLComponent.Path,
     givenCause: Error,

--- a/src/features/TextToImage/Server/Error/FailedToConnect.ts
+++ b/src/features/TextToImage/Server/Error/FailedToConnect.ts
@@ -1,11 +1,9 @@
 import Attempt from '@/library/Attempt';
 
 class TextToImage_Server_Error_FailedToConnect
-  extends Attempt.Error.Actionable<
-    'TextToImage_Server_Error_FailedToConnect'
-  > {
-  public override name = 'TextToImage_Server_Error_FailedToConnect' as const;
-
+  extends Attempt.Error.Tagged(
+    'TextToImage_Server_Error_FailedToConnect',
+  ) {
   public constructor(
     public readonly endpoint: URL,
   ) {

--- a/src/features/TextToImage/Server/Error/MissingSpecification.ts
+++ b/src/features/TextToImage/Server/Error/MissingSpecification.ts
@@ -2,11 +2,9 @@ import Attempt from '@/library/Attempt';
 import type URLComponent from '@/library/URLComponent';
 
 class TextToImage_Server_Error_MissingSpecification
-  extends Attempt.Error.Actionable<
-    'TextToImage_Server_Error_MissingSpecification'
-  > {
-  public override name = 'TextToImage_Server_Error_MissingSpecification' as const;
-
+  extends Attempt.Error.Tagged(
+    'TextToImage_Server_Error_MissingSpecification',
+  ) {
   public constructor(
     public readonly environmentKey: string,
     public readonly file: URLComponent.Path,

--- a/src/library/Attempt/Error/Tagged.ts
+++ b/src/library/Attempt/Error/Tagged.ts
@@ -1,0 +1,17 @@
+import {
+  Attempt_Error_Actionable,
+} from './Actionable';
+
+const Attempt_Error_Tagged = <
+  SomeBrand extends string,
+>(
+  givenBrand: SomeBrand,
+) => { // eslint-disable-line @typescript-eslint/explicit-function-return-type
+  return class extends Attempt_Error_Actionable<SomeBrand> {
+    public override readonly name = givenBrand;
+  };
+};
+
+export {
+  Attempt_Error_Tagged,
+};

--- a/src/library/Attempt/Error/definition.assembled.members.ts
+++ b/src/library/Attempt/Error/definition.assembled.members.ts
@@ -10,6 +10,10 @@ export {
   Attempt_Error_Actionable as Actionable,
 } from './Actionable';
 
+export {
+  Attempt_Error_Tagged as Tagged,
+} from './Tagged';
+
 export type {
   Attempt_Error_Interpreter as Interpreter,
 } from './Interpreter';

--- a/src/library/HTTP/Endpoint/Error/FailedToSendRequest.ts
+++ b/src/library/HTTP/Endpoint/Error/FailedToSendRequest.ts
@@ -1,11 +1,9 @@
 import Attempt from '@/library/Attempt';
 
 class HTTP_Endpoint_Error_FailedToSendRequest
-  extends Attempt.Error.Actionable<
-    'HTTP_Endpoint_Error_FailedToSendRequest'
-  > {
-  public override name = 'HTTP_Endpoint_Error_FailedToSendRequest' as const;
-
+  extends Attempt.Error.Tagged(
+    'HTTP_Endpoint_Error_FailedToSendRequest',
+  ) {
   public constructor(
     public readonly endpoint: URL,
   ) {

--- a/src/library/HTTP/Endpoint/Error/IndigestibleResponseBody.ts
+++ b/src/library/HTTP/Endpoint/Error/IndigestibleResponseBody.ts
@@ -1,11 +1,9 @@
 import Attempt from '@/library/Attempt';
 
 class HTTP_Endpoint_Error_IndigestibleResponseBody
-  extends Attempt.Error.Actionable<
-    'HTTP_Endpoint_Error_IndigestibleResponseBody'
-  > {
-  public override name = 'HTTP_Endpoint_Error_IndigestibleResponseBody' as const;
-
+  extends Attempt.Error.Tagged(
+    'HTTP_Endpoint_Error_IndigestibleResponseBody',
+  ) {
   public constructor(
     public readonly endpoint: URL,
     givenCause: Error,

--- a/src/library/HTTP/Endpoint/Error/RespondedWithFailure.ts
+++ b/src/library/HTTP/Endpoint/Error/RespondedWithFailure.ts
@@ -5,11 +5,9 @@ import type {
 } from '../../Response';
 
 class HTTP_Endpoint_Error_RespondedWithFailure
-  extends Attempt.Error.Actionable<
-    'HTTP_Endpoint_Error_RespondedWithFailure'
-  > {
-  public override name = 'HTTP_Endpoint_Error_RespondedWithFailure' as const;
-
+  extends Attempt.Error.Tagged(
+    'HTTP_Endpoint_Error_RespondedWithFailure',
+  ) {
   public constructor(
     givenMessage: string,
     public readonly status: HTTP_Response.StatusCode.Error.Any,

--- a/src/library/HTTP/Response/Body/Digestion/Error/DescriptorMismatch.ts
+++ b/src/library/HTTP/Response/Body/Digestion/Error/DescriptorMismatch.ts
@@ -6,11 +6,9 @@ import {
 } from '@/library/HTTP/Header'; // eslint-disable-line import/no-internal-modules -- avoids long relative path
 
 class HTTP_Response_Body_Digestion_Error_DescriptorMismatch
-  extends Attempt.Error.Actionable<
-    'HTTP_Response_Body_Digestion_Error_DescriptorMismatch'
-  > {
-  public override readonly name = 'HTTP_Response_Body_Digestion_Error_DescriptorMismatch' as const;
-
+  extends Attempt.Error.Tagged(
+    'HTTP_Response_Body_Digestion_Error_DescriptorMismatch',
+  ) {
   public constructor(
     public readonly response: Response,
     public readonly expectedDescriptor: ContentDescriptor,

--- a/src/library/HTTP/Response/Body/Digestion/Error/InvalidJSONSyntax.ts
+++ b/src/library/HTTP/Response/Body/Digestion/Error/InvalidJSONSyntax.ts
@@ -1,11 +1,9 @@
 import Attempt from '@/library/Attempt';
 
 class HTTP_Response_Body_Digestion_Error_InvalidJSONSyntax
-  extends Attempt.Error.Actionable<
-    'HTTP_Response_Body_Digestion_Error_InvalidJSONSyntax'
-  > {
-  public override readonly name = 'HTTP_Response_Body_Digestion_Error_InvalidJSONSyntax' as const;
-
+  extends Attempt.Error.Tagged(
+    'HTTP_Response_Body_Digestion_Error_InvalidJSONSyntax',
+  ) {
   public constructor(
     givenCause: Error,
   ) {


### PR DESCRIPTION
- `effect` [has errors types](https://effect.website/docs/data-types/data/#errors) that make it trivial to add extra members without boilerplate
- migrating to this will help reduce existing boilerplate
- `Attempt.Error.Actionable<'SomeBrand'>` -> `Attempt.Error.Tagged('SomeBrand')`