### PR TITLE
refactor: removes redundant branding from `Attempt.Error.Actionable`

### DIFF
--- a/src/library/Attempt/Adapted/Config.ts
+++ b/src/library/Attempt/Adapted/Config.ts
@@ -3,7 +3,7 @@ import type {
 } from '../Error';
 
 interface Attempt_Adapted_Config<
-  SomeActionableError extends Attempt_Error.Actionable<string>,
+  SomeActionableError extends Attempt_Error.Actionable,
 > {
   interpretationOf: Attempt_Error.Interpreter<SomeActionableError>;
 }

--- a/src/library/Attempt/Adapted/to.ts
+++ b/src/library/Attempt/Adapted/to.ts
@@ -20,7 +20,7 @@ import type {
 
 const Attempt_Adapted_to = <
   SomeProduct,
-  SomeActionableError extends Attempt_Error.Actionable<string>,
+  SomeActionableError extends Attempt_Error.Actionable,
 >(
   forciblyGetProduct: () => SomeProduct,
   given: Attempt_Adapted_Config<SomeActionableError>,

--- a/src/library/Attempt/Adapted/toEventually.ts
+++ b/src/library/Attempt/Adapted/toEventually.ts
@@ -20,7 +20,7 @@ import type {
 
 const Attempt_Adapted_toEventually = async <
   SomeProduct,
-  SomeActionableError extends Attempt_Error.Actionable<string>,
+  SomeActionableError extends Attempt_Error.Actionable,
 >(
   forciblyRetrieveProduct: () => Promise<SomeProduct>,
   given: Attempt_Adapted_Config<SomeActionableError>,

--- a/src/library/Attempt/Adapted/toSettle.ts
+++ b/src/library/Attempt/Adapted/toSettle.ts
@@ -16,7 +16,7 @@ import {
 
 const Attempt_Adapted_toSettle = async <
   SomeProduct,
-  SomeActionableError extends Attempt_Error.Actionable<string>,
+  SomeActionableError extends Attempt_Error.Actionable,
 >(
   promisedProduct: Promise<SomeProduct>,
   givenConfig: Attempt_Adapted_Config<SomeActionableError>,

--- a/src/library/Attempt/Either/getOrElse.ts
+++ b/src/library/Attempt/Either/getOrElse.ts
@@ -8,7 +8,7 @@ import {
 
 const Attempt_Either_getOrElse = <
   SomeProduct,
-  SomeActionableError extends Attempt_Error.Actionable<string>,
+  SomeActionableError extends Attempt_Error.Actionable,
   SomeFallbackProduct,
 >(
   givenExit: Attempt_Exit.Exit<SomeProduct, SomeActionableError>,

--- a/src/library/Attempt/Either/getOrThrow.ts
+++ b/src/library/Attempt/Either/getOrThrow.ts
@@ -12,7 +12,7 @@ import {
 
 const Attempt_Either_getOrThrow = <
   SomeProduct,
-  SomeActionableError extends Attempt_Error.Actionable<string>,
+  SomeActionableError extends Attempt_Error.Actionable,
 >(
   givenExit: Attempt_Exit.Exit<SomeProduct, SomeActionableError>,
 ): SomeProduct => {

--- a/src/library/Attempt/End/Getter.ts
+++ b/src/library/Attempt/End/Getter.ts
@@ -7,7 +7,7 @@ import type {
 } from '../Exit';
 
 type Attempt_End_Getter<
-  SomeInferredExit extends Attempt_Exit.Exit<unknown, Attempt_Error.Actionable<string>>,
+  SomeInferredExit extends Attempt_Exit.Exit<unknown, Attempt_Error.Actionable>,
 > = () => SomeInferredExit;
 
 export type {

--- a/src/library/Attempt/End/Retriever.ts
+++ b/src/library/Attempt/End/Retriever.ts
@@ -7,7 +7,7 @@ import type {
 } from '../Exit';
 
 type Attempt_End_Retriever<
-  SomeInferredExit extends Attempt_Exit.Exit<unknown, Attempt_Error.Actionable<string>>,
+  SomeInferredExit extends Attempt_Exit.Exit<unknown, Attempt_Error.Actionable>,
 > = () => Promise<SomeInferredExit>;
 
 export type {

--- a/src/library/Attempt/Error/Actionable.ts
+++ b/src/library/Attempt/Error/Actionable.ts
@@ -3,10 +3,6 @@ import {
 } from 'effect';
 
 import type {
-  Branded,
-} from '@/library/typeUtilities';
-
-import type {
   Attempt_Error_Interpreter,
 } from './Interpreter';
 
@@ -24,15 +20,8 @@ import {
 } from './modifiers';
 
 /** Extend this class to describe errors from which callers ought to recover */
-abstract class Attempt_Error_Actionable<
-  SomeBrand extends string,
->
-  extends Error
-  implements Branded<
-    SomeBrand
-  > {
-  public readonly brand!: SomeBrand;
-
+abstract class Attempt_Error_Actionable
+  extends Error {
   public throwAnyway = (
     givenJustification: string,
   ): never => {
@@ -43,7 +32,7 @@ abstract class Attempt_Error_Actionable<
   };
 
   public static from<
-    SomeActionableError extends Attempt_Error_Actionable<string>,
+    SomeActionableError extends Attempt_Error_Actionable,
   >(
     givenError: AppropriatelyThrown<Error>,
     {

--- a/src/library/Attempt/Error/Interpreter.ts
+++ b/src/library/Attempt/Error/Interpreter.ts
@@ -11,7 +11,7 @@ import type {
 } from './modifiers';
 
 type Attempt_Error_Interpreter<
-  SomeActionableError extends Attempt_Error_Actionable<string>,
+  SomeActionableError extends Attempt_Error_Actionable,
 > = (
   caughtError: PotentiallyActionable<Error>
 ) => Option.Option<SomeActionableError>;

--- a/src/library/Attempt/Error/Tagged.ts
+++ b/src/library/Attempt/Error/Tagged.ts
@@ -7,7 +7,7 @@ const Attempt_Error_Tagged = <
 >(
   givenBrand: SomeBrand,
 ) => { // eslint-disable-line @typescript-eslint/explicit-function-return-type
-  return class extends Attempt_Error_Actionable<SomeBrand> {
+  return class extends Attempt_Error_Actionable {
     public override readonly name = givenBrand;
   };
 };

--- a/src/library/Attempt/Error/modifiers/AppropriatelyThrown/definition.declared.ts
+++ b/src/library/Attempt/Error/modifiers/AppropriatelyThrown/definition.declared.ts
@@ -10,7 +10,7 @@ type AppropriatelyThrown<
   SomeError extends Error,
 > = Exclude<
   SomeError,
-  Attempt_Error_Actionable<string>
+  Attempt_Error_Actionable
 >;
 
 const AppropriatelyThrown = {

--- a/src/library/Attempt/Exit/Exit.ts
+++ b/src/library/Attempt/Exit/Exit.ts
@@ -12,7 +12,7 @@ import type {
 
 type Attempt_Exit_Exit<
   SomeProduct,
-  SomeActionableError extends Attempt_Error.Actionable<string>,
+  SomeActionableError extends Attempt_Error.Actionable,
 > =
   | Attempt_Exit_Success<SomeProduct>
   | Attempt_Exit_Failure<SomeActionableError>

--- a/src/library/Attempt/Exit/Failure/Cause/Transformer/definition.declared.ts
+++ b/src/library/Attempt/Exit/Failure/Cause/Transformer/definition.declared.ts
@@ -7,8 +7,8 @@ import {
 } from './identity';
 
 type Attempt_Exit_Failure_Cause_Transformer<
-  SomeTransformableActionableError extends Attempt_Error.Actionable<string>,
-  SomeTransformedActionableError extends Attempt_Error.Actionable<string>,
+  SomeTransformableActionableError extends Attempt_Error.Actionable,
+  SomeTransformedActionableError extends Attempt_Error.Actionable,
 > = (
   transformableCause: SomeTransformableActionableError,
 ) => SomeTransformedActionableError;

--- a/src/library/Attempt/Exit/Failure/Cause/Transformer/identity.ts
+++ b/src/library/Attempt/Exit/Failure/Cause/Transformer/identity.ts
@@ -3,8 +3,8 @@ import type {
 } from '@/library/Attempt/Error'; // eslint-disable-line import/no-internal-modules -- avoids lengthy relative paths
 
 const Attempt_Exit_Failure_Cause_Transformer_identity = <
-  SomeTransformableActionableError extends Attempt_Error.Actionable<string>,
-  SomeTransformedActionableError extends Attempt_Error.Actionable<string>,
+  SomeTransformableActionableError extends Attempt_Error.Actionable,
+  SomeTransformedActionableError extends Attempt_Error.Actionable,
 >(
   transformableCause: NoInfer<SomeTransformableActionableError>,
 ): NoInfer<SomeTransformedActionableError> => {

--- a/src/library/Attempt/Exit/Failure/SemanticallySugarfree.ts
+++ b/src/library/Attempt/Exit/Failure/SemanticallySugarfree.ts
@@ -11,7 +11,7 @@ import type {
 } from '../Discriminable';
 
 interface Attempt_Exit_Failure_SemanticallySugarfree<
-  SomeActionableError extends Attempt_Error.Actionable<string>,
+  SomeActionableError extends Attempt_Error.Actionable,
 >
   extends Attempt_Exit_Discriminable<
     'failure'

--- a/src/library/Attempt/Exit/Failure/definition.declared.ts
+++ b/src/library/Attempt/Exit/Failure/definition.declared.ts
@@ -7,7 +7,7 @@ import type {
 } from './SemanticallySugarfree';
 
 type Attempt_Exit_Failure<
-  SomeActionableError extends Attempt_Error.Actionable<string>,
+  SomeActionableError extends Attempt_Error.Actionable,
 > = Attempt_Exit_Failure_SemanticallySugarfree<
   SomeActionableError
 >;

--- a/src/library/Attempt/Exit/Failure/dueTo.ts
+++ b/src/library/Attempt/Exit/Failure/dueTo.ts
@@ -11,7 +11,7 @@ import type {
 } from './definition.declared.ts';
 
 const Attempt_Exit_Failure_dueTo = <
-  SomeActionableError extends Attempt_Error.Actionable<string>,
+  SomeActionableError extends Attempt_Error.Actionable,
 >(
   givenCause: Cause.Cause<SomeActionableError>,
 ): Attempt_Exit_Failure<SomeActionableError> => ({

--- a/src/library/Attempt/Exit/Transformer.ts
+++ b/src/library/Attempt/Exit/Transformer.ts
@@ -12,9 +12,9 @@ import type {
 
 interface Attempt_Exit_Transformer<
   SomeTransformableProduct,
-  SomeTransformableActionableError extends Attempt_Error.Actionable<string>,
+  SomeTransformableActionableError extends Attempt_Error.Actionable,
   SomeTransformedProduct,
-  SomeTransformedActionableError extends Attempt_Error.Actionable<string>,
+  SomeTransformedActionableError extends Attempt_Error.Actionable,
 > {
   onSuccess: Attempt_Exit_Success.Product.Transformer<
     SomeTransformableProduct,

--- a/src/library/Attempt/Exit/fail.ts
+++ b/src/library/Attempt/Exit/fail.ts
@@ -15,7 +15,7 @@ import {
 } from './failCause';
 
 const Attempt_Exit_fail = <
-  SomeActionableError extends Attempt_Error.Actionable<string>,
+  SomeActionableError extends Attempt_Error.Actionable,
 >(
   givenError: SomeActionableError,
 ): Attempt_Exit_Failure<SomeActionableError> => Attempt_Exit_failCause(

--- a/src/library/Attempt/Exit/isFailure.ts
+++ b/src/library/Attempt/Exit/isFailure.ts
@@ -12,7 +12,7 @@ import type {
 
 const Attempt_Exit_isFailure = <
   SomeProduct,
-  SomeActionableError extends Attempt_Error.Actionable<string>,
+  SomeActionableError extends Attempt_Error.Actionable,
 >(
   givenExit: Attempt_Exit_Exit<
     SomeProduct,

--- a/src/library/Attempt/Exit/isSuccess.ts
+++ b/src/library/Attempt/Exit/isSuccess.ts
@@ -12,7 +12,7 @@ import type {
 
 const Attempt_Exit_isSuccess = <
   SomeProduct,
-  SomeActionableError extends Attempt_Error.Actionable<string>,
+  SomeActionableError extends Attempt_Error.Actionable,
 >(
   givenExit: Attempt_Exit_Exit<
     SomeProduct,

--- a/src/library/Attempt/Exit/map.ts
+++ b/src/library/Attempt/Exit/map.ts
@@ -26,9 +26,9 @@ import {
  */
 const Attempt_Exit_map = <
   SomeTransformableProduct,
-  SomeTransformableActionableError extends Attempt_Error.Actionable<string>,
+  SomeTransformableActionableError extends Attempt_Error.Actionable,
   SomeTransformedProduct = SomeTransformableProduct,
-  SomeTransformedActionableError extends Attempt_Error.Actionable<string> = SomeTransformableActionableError,
+  SomeTransformedActionableError extends Attempt_Error.Actionable = SomeTransformableActionableError,
 >(
   givenExit: Attempt_Exit_Exit<
     SomeTransformableProduct,

--- a/src/library/Attempt/Exit/mapBoth.ts
+++ b/src/library/Attempt/Exit/mapBoth.ts
@@ -40,9 +40,9 @@ import {
 */
 const Attempt_Exit_mapBoth = <
   SomeTransformableProduct,
-  SomeTransformableActionableError extends Attempt_Error.Actionable<string>,
+  SomeTransformableActionableError extends Attempt_Error.Actionable,
   SomeTransformedProduct = SomeTransformableProduct,
-  SomeTransformedActionableError extends Attempt_Error.Actionable<string> = SomeTransformableActionableError,
+  SomeTransformedActionableError extends Attempt_Error.Actionable = SomeTransformableActionableError,
 >(
   givenExit: Attempt_Exit_Exit<
     SomeTransformableProduct,

--- a/src/library/Attempt/Exit/mapErrorCause.ts
+++ b/src/library/Attempt/Exit/mapErrorCause.ts
@@ -26,9 +26,9 @@ import {
  */
 const Attempt_Exit_mapErrorCause = <
   SomeTransformableProduct,
-  SomeTransformableActionableError extends Attempt_Error.Actionable<string>,
+  SomeTransformableActionableError extends Attempt_Error.Actionable,
   SomeTransformedProduct = SomeTransformableProduct,
-  SomeTransformedActionableError extends Attempt_Error.Actionable<string> = SomeTransformableActionableError,
+  SomeTransformedActionableError extends Attempt_Error.Actionable = SomeTransformableActionableError,
 >(
   givenExit: Attempt_Exit_Exit<
     SomeTransformableProduct,

--- a/src/library/Attempt/Exit/typeParameters/CauseOf.ts
+++ b/src/library/Attempt/Exit/typeParameters/CauseOf.ts
@@ -11,7 +11,7 @@ import type {
 } from '../Failure';
 
 type CauseOf<
-  SomeExit extends Attempt_Exit_Exit<unknown, Attempt_Error.Actionable<string>>,
+  SomeExit extends Attempt_Exit_Exit<unknown, Attempt_Error.Actionable>,
 > = SomeExit extends Attempt_Exit_Failure<infer NestedError>
   ? NestedError
   : never;

--- a/src/library/Attempt/Exit/typeParameters/ProductOf.ts
+++ b/src/library/Attempt/Exit/typeParameters/ProductOf.ts
@@ -11,7 +11,7 @@ import type {
 } from '../Success';
 
 type ProductOf<
-  SomeExit extends Attempt_Exit_Exit<unknown, Attempt_Error.Actionable<string>>,
+  SomeExit extends Attempt_Exit_Exit<unknown, Attempt_Error.Actionable>,
 > = SomeExit extends Attempt_Exit_Success<infer NestedProduct>
   ? NestedProduct
   : never;

--- a/src/library/Attempt/Fresh/that.ts
+++ b/src/library/Attempt/Fresh/that.ts
@@ -17,7 +17,7 @@ import {
 } from '../tryCatchStatements';
 
 const Attempt_Fresh_that = <
-  SomeInferredExit extends Attempt_Exit.Exit<unknown, Attempt_Error.Actionable<string>>,
+  SomeInferredExit extends Attempt_Exit.Exit<unknown, Attempt_Error.Actionable>,
   // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-parameters
   SomeEquivalentExit extends Attempt_Exit.Exit<
     ProductOf<SomeInferredExit>,

--- a/src/library/Attempt/Fresh/thatEventually.ts
+++ b/src/library/Attempt/Fresh/thatEventually.ts
@@ -17,7 +17,7 @@ import {
 } from '../tryCatchStatements';
 
 const Attempt_Fresh_thatEventually = async <
-  SomeInferredExit extends Attempt_Exit.Exit<unknown, Attempt_Error.Actionable<string>>,
+  SomeInferredExit extends Attempt_Exit.Exit<unknown, Attempt_Error.Actionable>,
   SomeEquivalentExit extends Attempt_Exit.Exit<
     ProductOf<SomeInferredExit>,
     CauseOf<SomeInferredExit>

--- a/src/library/Attempt/Progressive.ts
+++ b/src/library/Attempt/Progressive.ts
@@ -12,7 +12,7 @@ import type {
 
 interface Attempt_Progressive<
   SomeProduct,
-  SomeActionableError extends Attempt_Error.Actionable<string>,
+  SomeActionableError extends Attempt_Error.Actionable,
 > {
   initiate: () => Promise<void>;
   isInProgress: boolean;

--- a/src/library/vue/composables/useStatefulAttemptThatEventually.ts
+++ b/src/library/vue/composables/useStatefulAttemptThatEventually.ts
@@ -14,7 +14,7 @@ import Attempt from '@/library/Attempt';
 /** Useful when state of UI is dependent on some async operation and the result upon completion */
 const useStatefulAttemptThatEventually = <
   SomeProduct,
-  SomeActionableError extends Attempt.Error.Actionable<string>,
+  SomeActionableError extends Attempt.Error.Actionable,
 >(
   retrieveExit: Attempt.End.Retriever<
     Attempt.Exit.Exit<SomeProduct, SomeActionableError>


### PR DESCRIPTION
Enabled by #1162