### PR TITLE
refactor: swaps `Attempt.Exit.die(...)` with `effect` equivalent

### DIFF
--- a/src/features/TextToImage/Client/SDXL/toSharkUIOutput/first.ts
+++ b/src/features/TextToImage/Client/SDXL/toSharkUIOutput/first.ts
@@ -1,12 +1,11 @@
 import {
+  Effect,
   Option,
 } from 'effect';
 
 import type {
   GenerateFromTextResponse,
 } from 'stabilityai-client-typescript/models/operations';
-
-import Attempt from '@/library/Attempt';
 
 import {
   hasAtLeastOne,
@@ -41,7 +40,7 @@ const toSharkUIOutput_first = (
 
   if (
     !hasAtLeastOne(inferredOutputs)
-  ) return Attempt.Exit.die('Expected at least one text-to-image output in response');
+  ) return Effect.runSync(Effect.dieMessage('Expected at least one text-to-image output in response'));
 
   const [firstPotentialOutput] = inferredOutputs;
 

--- a/src/features/TextToImage/Client/SDXL/toSharkUIOutput/plural.ts
+++ b/src/features/TextToImage/Client/SDXL/toSharkUIOutput/plural.ts
@@ -1,12 +1,11 @@
 import {
+  Effect,
   Option,
 } from 'effect';
 
 import type {
   GenerateFromTextResponse,
 } from 'stabilityai-client-typescript/models/operations';
-
-import Attempt from '@/library/Attempt';
 
 import {
   TextToImage_Pipeline,
@@ -27,7 +26,7 @@ const toSharkUIOutput_plural = (
 ): Option.Option<Option.Option<TextToImage_Pipeline.Output>[]> => {
   if (
     !('artifacts' in givenResponse.result)
-  ) return Attempt.Exit.die('Expected response body rather than readable stream');
+  ) return Effect.runSync(Effect.dieMessage('Expected response body rather than readable stream'));
 
   const inferredRawImages = Option.fromNullable(givenResponse.result.artifacts);
 

--- a/src/features/TextToImage/components/TextToImageOutputView.vue
+++ b/src/features/TextToImage/components/TextToImageOutputView.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import {
   Cause,
+  Effect,
 } from 'effect';
 
 import Attempt from '@/library/Attempt';
@@ -30,6 +31,6 @@ defineProps<{
   <template
     v-else
   >
-    {{ Attempt.Exit.die(Cause.pretty(output.cause)) }}
+    {{ Effect.runSync(Effect.dieMessage(Cause.pretty(output.cause))) }}
   </template>
 </template>

--- a/src/library/Attempt/Either/getOrThrow.ts
+++ b/src/library/Attempt/Either/getOrThrow.ts
@@ -1,5 +1,6 @@
 import {
   Cause,
+  Effect,
 } from 'effect';
 
 import type {
@@ -22,7 +23,7 @@ const Attempt_Either_getOrThrow = <
 
   if (
     !Cause.isFailType(givenExit.cause)
-  ) return Attempt_Exit.die(`Expected failure, got "${givenExit.cause._tag}" instead`);
+  ) return Effect.runSync(Effect.dieMessage(`Expected failure, got "${givenExit.cause._tag}" instead`));
 
   return givenExit.cause.error.throwAnyway('Expected product, got failure instead');
 };

--- a/src/library/Attempt/Exit/definition.assembled.members.ts
+++ b/src/library/Attempt/Exit/definition.assembled.members.ts
@@ -11,10 +11,6 @@ export {
 } from './Success';
 
 export {
-  Attempt_Exit_die as die,
-} from './die';
-
-export {
   Attempt_Exit_fail as fail,
 } from './fail';
 

--- a/src/library/Attempt/Exit/die.ts
+++ b/src/library/Attempt/Exit/die.ts
@@ -1,9 +1,0 @@
-import {
-  Attempt_Error,
-} from '../Error';
-
-const Attempt_Exit_die = Attempt_Error.NonActionable.throw.bind(Attempt_Error.NonActionable);
-
-export {
-  Attempt_Exit_die,
-};

--- a/src/library/Attempt/Exit/mapBoth.ts
+++ b/src/library/Attempt/Exit/mapBoth.ts
@@ -1,5 +1,6 @@
 import {
   Cause,
+  Effect,
 } from 'effect';
 
 import type {
@@ -13,10 +14,6 @@ import type {
 import type {
   Attempt_Exit_Transformer,
 } from './Transformer';
-
-import {
-  Attempt_Exit_die,
-} from './die';
 
 import {
   Attempt_Exit_fail,
@@ -69,7 +66,7 @@ const Attempt_Exit_mapBoth = <
 
   if (
     !Cause.isFailType(givenExit.cause)
-  ) return Attempt_Exit_die(`Expected failure cause, got ${givenExit.cause._tag} instead`);
+  ) return Effect.runSync(Effect.dieMessage(`Expected failure cause, got ${givenExit.cause._tag} instead`));
 
   return Attempt_Exit_fail(
     toTransformedError(givenExit.cause.error),

--- a/src/library/Range/Discrete.ts
+++ b/src/library/Range/Discrete.ts
@@ -1,4 +1,6 @@
-import Attempt from '@/library/Attempt';
+import {
+  Effect,
+} from 'effect';
 
 import {
   isNegative,
@@ -39,13 +41,13 @@ class Range_Discrete
 
     if (
       isNegative(givenStepSize)
-    ) return Attempt.Exit.die('Step size must be non-negative');
+    ) return Effect.runSync(Effect.dieMessage('Step size must be non-negative'));
 
     const overstep = validRange.width % givenStepSize;
 
     if (
       overstep !== 0
-    ) return Attempt.Exit.die('Step size must fit evenly into the range');
+    ) return Effect.runSync(Effect.dieMessage('Step size must fit evenly into the range'));
 
     const validDiscreteRange = new this(
       validRange.lowerBound,

--- a/src/library/Range/definition.declared.ts
+++ b/src/library/Range/definition.declared.ts
@@ -1,4 +1,6 @@
-import Attempt from '@/library/Attempt';
+import {
+  Effect,
+} from 'effect';
 
 import {
   arithmeticMeanOf,
@@ -25,7 +27,7 @@ class Range {
   ): Range {
     if (
       givenUpperBound < givenLowerBound
-    ) return Attempt.Exit.die('Upper bound must not be lower than lower bound');
+    ) return Effect.runSync(Effect.dieMessage('Upper bound must not be lower than lower bound'));
 
     const validRange = new this(
       givenLowerBound,

--- a/src/library/math/operators/predicate/isNegative.test.ts
+++ b/src/library/math/operators/predicate/isNegative.test.ts
@@ -1,10 +1,12 @@
 import {
+  Runtime,
+} from 'effect';
+
+import {
   describe,
   it,
   expect,
 } from 'vitest';
-
-import Attempt from '@/library/Attempt';
 
 import {
   numberTaxonomy,
@@ -42,7 +44,15 @@ describe(isNegative, () => {
       it('should safely propagate the error', () => {
         expect.assertions(1);
 
-        expect(() => isNegative(soleInoperableNumber)).toThrow(Attempt.Error.NonActionable);
+        expect((() => {
+          // eslint-disable-next-line no-restricted-syntax
+          try {
+            isNegative(soleInoperableNumber);
+          }
+          catch (error) {
+            return Runtime.isFiberFailure(error);
+          }
+        })()).toBe(true);
       });
 
       it('should communicate clearly with developers', () => {

--- a/src/library/math/operators/predicate/isNegative.ts
+++ b/src/library/math/operators/predicate/isNegative.ts
@@ -1,4 +1,6 @@
-import Attempt from '@/library/Attempt';
+import {
+  Effect,
+} from 'effect';
 
 import {
   isOperable,
@@ -9,7 +11,7 @@ const isNegative = (
 ): boolean => {
   if (
     !isOperable(givenOperand)
-  ) return Attempt.Exit.die('Operand must be operable');
+  ) return Effect.runSync(Effect.dieMessage('Operand must be operable'));
 
   return (givenOperand < 0);
 };

--- a/src/library/modifiersByType/error/Contextualized/assume.ts
+++ b/src/library/modifiersByType/error/Contextualized/assume.ts
@@ -1,4 +1,6 @@
-import Attempt from '@/library/Attempt';
+import {
+  Effect,
+} from 'effect';
 
 import type {
   Instantiable,
@@ -23,7 +25,7 @@ const Contextualized_assume = <
     Contextualized_describes<SomeError, SomeCause>(givenError, GivenCause)
   ) return givenError;
 
-  return Attempt.Exit.die('Expected error to have a cause');
+  return Effect.runSync(Effect.dieMessage('Expected error to have a cause'));
 };
 
 export {


### PR DESCRIPTION
- running a synchronous `Effect` that contains nothing but a defect is the same as raw `throw`ing an error
- after the migration to the `effect` library is complete, the use of `Effect.run*` should be bubbled up to the edges of the app