### PR TITLE
refactor: avoids misnaming of `Attempt.Exit.mapErrorCause`

### DIFF
--- a/src/library/Attempt/Exit/definition.assembled.members.ts
+++ b/src/library/Attempt/Exit/definition.assembled.members.ts
@@ -35,8 +35,8 @@ export {
 } from './mapBoth';
 
 export {
-  Attempt_Exit_mapErrorCause as mapErrorCause,
-} from './mapErrorCause';
+  Attempt_Exit_mapError as mapError,
+} from './mapError';
 
 export {
   Attempt_Exit_succeed as succeed,

--- a/src/library/Attempt/Exit/mapError.ts
+++ b/src/library/Attempt/Exit/mapError.ts
@@ -24,7 +24,7 @@ import {
  * 2. transforming the error, and
  * 3. wrapping the transformed contents in a _new_ exit.
  */
-const Attempt_Exit_mapErrorCause = <
+const Attempt_Exit_mapError = <
   SomeTransformableProduct,
   SomeTransformableActionableError extends Attempt_Error.Actionable,
   SomeTransformedProduct = SomeTransformableProduct,
@@ -50,5 +50,5 @@ const Attempt_Exit_mapErrorCause = <
 });
 
 export {
-  Attempt_Exit_mapErrorCause,
+  Attempt_Exit_mapError,
 };

--- a/src/library/HTTP/Client.ts
+++ b/src/library/HTTP/Client.ts
@@ -83,7 +83,7 @@ class HTTP_Client {
 
     const exitFromDigestingResponseBody = await bodyOf(response).digestAsUnknown();
 
-    return Attempt.Exit.mapErrorCause(
+    return Attempt.Exit.mapError(
       exitFromDigestingResponseBody,
       $0 => new HTTP_Endpoint.Error.IndigestibleResponseBody(endpointURL, $0),
     );


### PR DESCRIPTION
- `Exit.mapErrorCause` provides a callback of with parameter `Cause<E>`, but  the parameter in `Attempt.Exit.mapErrorCause` is just `E`
- Ergo, its function is more aligned with `Exit.mapError`

Follows up on #1137