### PR TITLE
refactor: ensures explicit short circuits rewrap failures

### DIFF
--- a/src/features/TextToImage/Client/SDXL/generateOutputFrom.ts
+++ b/src/features/TextToImage/Client/SDXL/generateOutputFrom.ts
@@ -43,7 +43,7 @@ const TextToImage_Client_SDXL_generateOutputFrom = async (
 
   if (
     Attempt.Exit.isFailure(exitFromInitializingClient)
-  ) return exitFromInitializingClient;
+  ) return Attempt.Exit.failCause(exitFromInitializingClient.cause);
 
   const shimmedStabilityAIClient = exitFromInitializingClient.value;
 

--- a/src/library/HTTP/Client.ts
+++ b/src/library/HTTP/Client.ts
@@ -72,7 +72,7 @@ class HTTP_Client {
 
     if (
       Attempt.Exit.isFailure(exitFromSettlingResponse)
-    ) return exitFromSettlingResponse;
+    ) return Attempt.Exit.failCause(exitFromSettlingResponse.cause);
 
     const response = exitFromSettlingResponse.value;
 

--- a/src/library/Shortfin/TextToImage/SDXL/Client/definition.declared.ts
+++ b/src/library/Shortfin/TextToImage/SDXL/Client/definition.declared.ts
@@ -45,7 +45,7 @@ class Shortfin_TextToImage_SDXL_Client
 
       if (
         Attempt.Exit.isFailure(exitFromSubmittingResource)
-      ) return exitFromSubmittingResource;
+      ) return Attempt.Exit.failCause(exitFromSubmittingResource.cause);
 
       const rawResource = exitFromSubmittingResource.value;
       const decodedResource = Schema.decodeUnknownSync(Shortfin_TextToImage_SDXL_Client_Response.Body)(rawResource);


### PR DESCRIPTION
- `Exit.Failure<A, E>` contains both the success type and the failure type, while `Attempt.Failure<E>` only contains the error type
- For these guards to return `Exit.Failure<never, E>`, the failures need to be extracted and rewrapped
- This is temporary; once `Effect.gen` is put in place, these guards collapse into simple `yield*` statements