### PR TITLE
refactor: replaces `Attempt.Adapted` with `effect` equivalent

### DIFF
--- a/src/features/TextToImage/Client/SDXL/generateOutputFrom.ts
+++ b/src/features/TextToImage/Client/SDXL/generateOutputFrom.ts
@@ -1,13 +1,12 @@
 import {
+  Effect,
   Exit,
-  Option,
 } from 'effect';
 
 import type {
   GenerateFromTextRequest,
 } from 'stabilityai-client-typescript/models/operations';
 
-import Attempt from '@/library/Attempt';
 import HTTP from '@/library/HTTP';
 
 import {
@@ -60,15 +59,17 @@ const TextToImage_Client_SDXL_generateOutputFrom = async (
     },
   });
 
-  const exitFromSettlingTextToImageResponse = await Attempt.Adapted.toSettle(promisedTextToImageResponse, {
-    interpretationOf: (caughtError) => {
+  const exitFromSettlingTextToImageResponse = await Effect.runPromiseExit(Effect.tryPromise(() => promisedTextToImageResponse).pipe(
+    Effect.catchAll((someException) => {
+      const caughtError = someException.cause;
+
       if (
         caughtError instanceof HTTP.Endpoint.Error.FailedToSendRequest
-      ) return Option.some(new TextToImage_Server.Error.FailedToConnect(caughtError.endpoint));
+      ) return new TextToImage_Server.Error.FailedToConnect(caughtError.endpoint);
 
-      return Option.none();
-    },
-  });
+      return Effect.die(caughtError);
+    }),
+  ));
 
   const exitFromSettlingSoleTextToImageOutput = Exit.map(
     exitFromSettlingTextToImageResponse,

--- a/src/library/HTTP/Client.ts
+++ b/src/library/HTTP/Client.ts
@@ -1,6 +1,6 @@
 import {
+  Effect,
   Exit,
-  Option,
 } from 'effect';
 
 import Attempt from '@/library/Attempt';
@@ -59,17 +59,18 @@ class HTTP_Client {
         : JSON.stringify(givenRequestBody),
     });
 
-    const exitFromSettlingResponse = await Attempt.Adapted.toSettle(promisedResponse, {
-      interpretationOf: (caughtError) => {
-        const isFailureToReachServer = ($0: Error): boolean => $0.message.includes('Failed to fetch');
+    const exitFromSettlingResponse = await Effect.runPromiseExit(Effect.tryPromise(() => promisedResponse).pipe(
+      Effect.catchAll((someException) => {
+        const caughtError = someException.cause;
+        const isFailureToReachServer = ($0: unknown): boolean => ($0 instanceof Error) && $0.message.includes('Failed to fetch');
 
         if (
           isFailureToReachServer(caughtError)
-        ) return Option.some(new HTTP_Endpoint.Error.FailedToSendRequest(endpointURL));
+        ) return new HTTP_Endpoint.Error.FailedToSendRequest(endpointURL);
 
-        return Option.none();
-      },
-    });
+        return Effect.die(someException);
+      }),
+    ));
 
     if (
       Exit.isFailure(exitFromSettlingResponse)

--- a/src/library/HTTP/Response/bodyOf.ts
+++ b/src/library/HTTP/Response/bodyOf.ts
@@ -1,6 +1,6 @@
 import {
+  Effect,
   Exit,
-  Option,
 } from 'effect';
 
 import Attempt from '@/library/Attempt';
@@ -37,15 +37,17 @@ const bodyOf = (
 
       const promiseForDigestedResponseBody: Promise<unknown> = givenResponse.json();
 
-      const exitFromDigestingResponseBody = await Attempt.Adapted.toSettle(promiseForDigestedResponseBody, {
-        interpretationOf: (caughtError) => {
+      const exitFromDigestingResponseBody = await Effect.runPromiseExit(Effect.tryPromise(() => promiseForDigestedResponseBody).pipe(
+        Effect.catchAll((someException) => {
+          const caughtError = someException.cause;
+
           if (
             caughtError instanceof SyntaxError
-          ) return Option.some(new HTTP_Response_Body.Digestion.Error.InvalidJSONSyntax(caughtError));
+          ) return new HTTP_Response_Body.Digestion.Error.InvalidJSONSyntax(caughtError);
 
-          return Option.none();
-        },
-      });
+          return Effect.die(caughtError);
+        }),
+      ));
 
       return exitFromDigestingResponseBody;
     });

--- a/src/library/ShimmedStabilityAIClient/Version1/Image.ts
+++ b/src/library/ShimmedStabilityAIClient/Version1/Image.ts
@@ -36,7 +36,7 @@ class ShimmedStabilityAIClient_Version1_Image
     const generatedImage = Either.getOrThrowWith(
       resultOfGeneratingImage,
       (someFailure) => {
-        return someFailure.throwAnyway('matches error propagation of actual StabilityAI Client');
+        throw someFailure; // eslint-disable-line no-restricted-syntax -- matches error propagation of actual StabilityAI Client
       },
     );
 


### PR DESCRIPTION
- implements the `effect` version of adapting a call to an external system and interpreting the errors