### PR TITLE
refactor: replaces use of `Attempt.Fresh` with `effect` equivalent

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -52,7 +52,7 @@ const extraConfigForESLint: ConfigWithExtends = {
       },
       {
         selector: 'ThrowStatement',
-        message : 'Prefer `Attempt.that` callback for error propagation over `throw`.',
+        message : 'Prefer `Effect.gen` callback for error propagation over `throw`.',
       },
     ],
     'no-useless-rename': [

--- a/src/features/TextToImage/Config/Dynamic/fetch.ts
+++ b/src/features/TextToImage/Config/Dynamic/fetch.ts
@@ -1,9 +1,9 @@
 import {
+  Effect,
   Exit,
   Schema,
 } from 'effect';
 
-import Attempt from '@/library/Attempt';
 import HTTP from '@/library/HTTP';
 
 import {
@@ -20,7 +20,7 @@ import {
 
 const TextToImage_Config_Dynamic_fetch = (): Promise<
   TextToImage_Config_Dynamic_Fetching.Exit
-> => Attempt.Fresh.thatEventually(async () => {
+> => Effect.runPromise(Effect.promise(async () => {
   const exitFromFetchingResource = await HTTP.Client.local.fetchResource({
     from: TextToImage_Config_Dynamic_endpoint,
   });
@@ -29,7 +29,7 @@ const TextToImage_Config_Dynamic_fetch = (): Promise<
     onSuccess: $0 => Schema.decodeUnknownSync(TextToImage_Config)($0),
     onFailure: $0 => new TextToImage_Config_Dynamic_Fetching.Error(TextToImage_Config_Dynamic_endpoint, $0),
   });
-});
+}));
 
 export {
   TextToImage_Config_Dynamic_fetch,

--- a/src/features/TextToImage/Config/Static/read.ts
+++ b/src/features/TextToImage/Config/Static/read.ts
@@ -1,9 +1,9 @@
 import {
+  Effect,
   Exit,
   Schema,
 } from 'effect';
 
-import Attempt from '@/library/Attempt';
 import HTTP from '@/library/HTTP';
 
 import {
@@ -20,7 +20,7 @@ import {
 
 const TextToImage_Config_Static_read = (): Promise<
   TextToImage_Config_Static_Reading.Exit
-> => Attempt.Fresh.thatEventually(async () => {
+> => Effect.runPromise(Effect.promise(async () => {
   const exitFromFetchingFile = await HTTP.Client.local.fetchResource({
     from: TextToImage_Config_Static_file,
   });
@@ -29,7 +29,7 @@ const TextToImage_Config_Static_read = (): Promise<
     onSuccess: $0 => Schema.decodeUnknownSync(TextToImage_Config)($0),
     onFailure: $0 => new TextToImage_Config_Static_Reading.Error(TextToImage_Config_Static_file, $0),
   });
-});
+}));
 
 export {
   TextToImage_Config_Static_read,

--- a/src/features/TextToImage/Server/Current/retrieve.ts
+++ b/src/features/TextToImage/Server/Current/retrieve.ts
@@ -4,7 +4,6 @@ import {
   Option,
 } from 'effect';
 
-import Attempt from '@/library/Attempt';
 import type WebAPI from '@/library/WebAPI';
 
 import {
@@ -28,7 +27,7 @@ const TextToImage_Server_Current_retrieve = (): Promise<
     WebAPI.Server,
     TextToImage_Server_Error.MissingSpecification
   >
-> => Attempt.Fresh.thatEventually(async () => {
+> => Effect.runPromise(Effect.promise(async () => {
   if (
     Option.isSome(TextToImage_Server_Current_accordingToEnvironment)
   ) return Exit.succeed(Option.getOrThrow(TextToImage_Server_Current_accordingToEnvironment));
@@ -54,7 +53,7 @@ const TextToImage_Server_Current_retrieve = (): Promise<
   );
 
   return Exit.fail(newSpecificationError);
-});
+}));
 
 export {
   TextToImage_Server_Current_retrieve,

--- a/src/library/HTTP/Client.ts
+++ b/src/library/HTTP/Client.ts
@@ -3,7 +3,6 @@ import {
   Exit,
 } from 'effect';
 
-import Attempt from '@/library/Attempt';
 import ContentDescriptor from '@/library/ContentDescriptor';
 import URLComponent from '@/library/URLComponent';
 
@@ -48,7 +47,7 @@ class HTTP_Client {
       to: URLComponent.Path;
       using: HTTP_Request.Method;
     },
-  ): Promise<HTTP_Endpoint.Exit> => Attempt.Fresh.thatEventually(async () => {
+  ): Promise<HTTP_Endpoint.Exit> => Effect.runPromise(Effect.promise(async () => {
     const endpointURL = this.originAt(givenPath);
 
     const promisedResponse = fetch(endpointURL, {
@@ -89,7 +88,7 @@ class HTTP_Client {
       exitFromDigestingResponseBody,
       $0 => new HTTP_Endpoint.Error.IndigestibleResponseBody(endpointURL, $0),
     );
-  });
+  }));
 
   public async fetchResource(
     {

--- a/src/library/HTTP/Response/bodyOf.ts
+++ b/src/library/HTTP/Response/bodyOf.ts
@@ -3,7 +3,6 @@ import {
   Exit,
 } from 'effect';
 
-import Attempt from '@/library/Attempt';
 import ContentDescriptor from '@/library/ContentDescriptor';
 
 import {
@@ -29,7 +28,7 @@ const bodyOf = (
     return actualRawDescriptor.includes(givenDescriptor.serialized.toString());
   },
   async digestAsUnknown() {
-    return Attempt.Fresh.thatEventually(async () => {
+    return Effect.runPromise(Effect.promise(async () => {
       if (!this.isSuggestedToBeDigestibleAs(ContentDescriptor.json)) {
         const newDescriptorMismatchError = new HTTP_Response_Body.Digestion.Error.DescriptorMismatch(givenResponse, ContentDescriptor.json);
         return Exit.fail(newDescriptorMismatchError);
@@ -50,7 +49,7 @@ const bodyOf = (
       ));
 
       return exitFromDigestingResponseBody;
-    });
+    }));
   },
 });
 

--- a/src/library/Shortfin/TextToImage/SDXL/Client/definition.declared.ts
+++ b/src/library/Shortfin/TextToImage/SDXL/Client/definition.declared.ts
@@ -1,9 +1,9 @@
 import {
+  Effect,
   Exit,
   Schema,
 } from 'effect';
 
-import Attempt from '@/library/Attempt';
 import ContentDescriptor from '@/library/ContentDescriptor';
 import HTTP from '@/library/HTTP';
 import URLComponent from '@/library/URLComponent';
@@ -38,7 +38,7 @@ class Shortfin_TextToImage_SDXL_Client
   > {
     const generationEndpoint = URLComponent.Path('/generate');
 
-    return Attempt.Fresh.thatEventually(async () => {
+    return Effect.runPromise(Effect.promise(async () => {
       const exitFromSubmittingResource = await this.submitResource({
         bySending: givenBatchedRequestBody,
         to       : generationEndpoint,
@@ -52,7 +52,7 @@ class Shortfin_TextToImage_SDXL_Client
       const decodedResource = Schema.decodeUnknownSync(Shortfin_TextToImage_SDXL_Client_Response.Body)(rawResource);
       const [soleGeneratedImage] = decodedResource.images;
       return Exit.succeed(soleGeneratedImage);
-    });
+    }));
   }
 }
 

--- a/src/library/vue/composables/useStatefulAttemptThatEventually.ts
+++ b/src/library/vue/composables/useStatefulAttemptThatEventually.ts
@@ -6,11 +6,12 @@ import {
 } from '@/library/vue';
 
 import {
+  Effect,
   type Exit,
   Option,
 } from 'effect';
 
-import Attempt from '@/library/Attempt';
+import type Attempt from '@/library/Attempt';
 
 /** Useful when state of UI is dependent on some async operation and the result upon completion */
 const useStatefulAttemptThatEventually = <
@@ -43,7 +44,7 @@ const useStatefulAttemptThatEventually = <
       set(flagIsRaised, false);
     });
 
-    const retrievedExit = await Attempt.Fresh.thatEventually(retrieveExit);
+    const retrievedExit = await Effect.runPromise(Effect.promise(retrieveExit));
     set(capturedExit, Option.some(retrievedExit));
   };
 


### PR DESCRIPTION
- implements the `effect` version of creating and immediately invoking an "attempt"