### PR TITLE
refactor: replaces use of `Attempt.Error.Tagged` with `Data.TaggedError`

### DIFF
--- a/src/features/TextToImage/Config/Dynamic/Fetching/Error.ts
+++ b/src/features/TextToImage/Config/Dynamic/Fetching/Error.ts
@@ -1,10 +1,16 @@
-import Attempt from '@/library/Attempt';
+import {
+  Data,
+} from 'effect';
+
 import type URLComponent from '@/library/URLComponent';
 
 class TextToImage_Config_Dynamic_Fetching_Error
-  extends Attempt.Error.Tagged(
+  extends Data.TaggedError(
     'TextToImage_Config_Dynamic_Fetching_Error',
-  ) {
+  )<{
+    message: string;
+    cause: Error;
+  }> {
   public constructor(
     public readonly endpoint: URLComponent.Path,
     givenCause: Error,

--- a/src/features/TextToImage/Config/Static/Reading/Error.ts
+++ b/src/features/TextToImage/Config/Static/Reading/Error.ts
@@ -1,10 +1,16 @@
-import Attempt from '@/library/Attempt';
+import {
+  Data,
+} from 'effect';
+
 import type URLComponent from '@/library/URLComponent';
 
 class TextToImage_Config_Static_Reading_Error
-  extends Attempt.Error.Tagged(
+  extends Data.TaggedError(
     'TextToImage_Config_Static_Reading_Error',
-  ) {
+  )<{
+    message: string;
+    cause: Error;
+  }> {
   public constructor(
     public readonly filePath: URLComponent.Path,
     givenCause: Error,

--- a/src/features/TextToImage/Server/Error/FailedToConnect.ts
+++ b/src/features/TextToImage/Server/Error/FailedToConnect.ts
@@ -1,9 +1,13 @@
-import Attempt from '@/library/Attempt';
+import {
+  Data,
+} from 'effect';
 
 class TextToImage_Server_Error_FailedToConnect
-  extends Attempt.Error.Tagged(
+  extends Data.TaggedError(
     'TextToImage_Server_Error_FailedToConnect',
-  ) {
+  )<{
+    message: string;
+  }> {
   public constructor(
     public readonly endpoint: URL,
   ) {

--- a/src/features/TextToImage/Server/Error/MissingSpecification.ts
+++ b/src/features/TextToImage/Server/Error/MissingSpecification.ts
@@ -1,10 +1,15 @@
-import Attempt from '@/library/Attempt';
+import {
+  Data,
+} from 'effect';
+
 import type URLComponent from '@/library/URLComponent';
 
 class TextToImage_Server_Error_MissingSpecification
-  extends Attempt.Error.Tagged(
+  extends Data.TaggedError(
     'TextToImage_Server_Error_MissingSpecification',
-  ) {
+  )<{
+    message: string;
+  }> {
   public constructor(
     public readonly environmentKey: string,
     public readonly file: URLComponent.Path,

--- a/src/library/Attempt/Error/Tagged.ts
+++ b/src/library/Attempt/Error/Tagged.ts
@@ -7,12 +7,10 @@ const Attempt_Error_Tagged = <
 >(
   givenBrand: SomeBrand,
 ) => { // eslint-disable-line @typescript-eslint/explicit-function-return-type
-  return class extends Data.Error<{
+  return class extends Data.TaggedError(givenBrand)<{
     message: string;
     cause?: Error;
-  }> {
-    public override readonly name = givenBrand;
-  };
+  }> {};
 };
 
 export {

--- a/src/library/Attempt/Error/Tagged.ts
+++ b/src/library/Attempt/Error/Tagged.ts
@@ -7,10 +7,10 @@ const Attempt_Error_Tagged = <
 >(
   givenBrand: SomeBrand,
 ) => { // eslint-disable-line @typescript-eslint/explicit-function-return-type
-  return class extends Data.TaggedError(givenBrand)<{
+  return Data.TaggedError(givenBrand)<{
     message: string;
     cause?: Error;
-  }> {};
+  }>;
 };
 
 export {

--- a/src/library/HTTP/Endpoint/Error/FailedToSendRequest.ts
+++ b/src/library/HTTP/Endpoint/Error/FailedToSendRequest.ts
@@ -1,9 +1,13 @@
-import Attempt from '@/library/Attempt';
+import {
+  Data,
+} from 'effect';
 
 class HTTP_Endpoint_Error_FailedToSendRequest
-  extends Attempt.Error.Tagged(
+  extends Data.TaggedError(
     'HTTP_Endpoint_Error_FailedToSendRequest',
-  ) {
+  )<{
+    message: string;
+  }> {
   public constructor(
     public readonly endpoint: URL,
   ) {

--- a/src/library/HTTP/Endpoint/Error/IndigestibleResponseBody.ts
+++ b/src/library/HTTP/Endpoint/Error/IndigestibleResponseBody.ts
@@ -1,9 +1,14 @@
-import Attempt from '@/library/Attempt';
+import {
+  Data,
+} from 'effect';
 
 class HTTP_Endpoint_Error_IndigestibleResponseBody
-  extends Attempt.Error.Tagged(
+  extends Data.TaggedError(
     'HTTP_Endpoint_Error_IndigestibleResponseBody',
-  ) {
+  )<{
+    message: string;
+    cause: Error;
+  }> {
   public constructor(
     public readonly endpoint: URL,
     givenCause: Error,

--- a/src/library/HTTP/Endpoint/Error/RespondedWithFailure.ts
+++ b/src/library/HTTP/Endpoint/Error/RespondedWithFailure.ts
@@ -1,13 +1,17 @@
-import Attempt from '@/library/Attempt';
+import {
+  Data,
+} from 'effect';
 
 import type {
   HTTP_Response,
 } from '../../Response';
 
 class HTTP_Endpoint_Error_RespondedWithFailure
-  extends Attempt.Error.Tagged(
+  extends Data.TaggedError(
     'HTTP_Endpoint_Error_RespondedWithFailure',
-  ) {
+  )<{
+    message: string;
+  }> {
   public constructor(
     givenMessage: string,
     public readonly status: HTTP_Response.StatusCode.Error.Any,

--- a/src/library/HTTP/Response/Body/Digestion/Error/DescriptorMismatch.ts
+++ b/src/library/HTTP/Response/Body/Digestion/Error/DescriptorMismatch.ts
@@ -1,4 +1,7 @@
-import Attempt from '@/library/Attempt';
+import {
+  Data,
+} from 'effect';
+
 import type ContentDescriptor from '@/library/ContentDescriptor';
 
 import {
@@ -6,9 +9,11 @@ import {
 } from '@/library/HTTP/Header'; // eslint-disable-line import/no-internal-modules -- avoids long relative path
 
 class HTTP_Response_Body_Digestion_Error_DescriptorMismatch
-  extends Attempt.Error.Tagged(
+  extends Data.TaggedError(
     'HTTP_Response_Body_Digestion_Error_DescriptorMismatch',
-  ) {
+  )<{
+    message: string;
+  }> {
   public constructor(
     public readonly response: Response,
     public readonly expectedDescriptor: ContentDescriptor,

--- a/src/library/HTTP/Response/Body/Digestion/Error/InvalidJSONSyntax.ts
+++ b/src/library/HTTP/Response/Body/Digestion/Error/InvalidJSONSyntax.ts
@@ -1,9 +1,14 @@
-import Attempt from '@/library/Attempt';
+import {
+  Data,
+} from 'effect';
 
 class HTTP_Response_Body_Digestion_Error_InvalidJSONSyntax
-  extends Attempt.Error.Tagged(
+  extends Data.TaggedError(
     'HTTP_Response_Body_Digestion_Error_InvalidJSONSyntax',
-  ) {
+  )<{
+    message: string;
+    cause: Error;
+  }> {
   public constructor(
     givenCause: Error,
   ) {


### PR DESCRIPTION
- see [PR commits](https://github.com/nod-ai/shark-ui/pull/1191/commits) for proof of parity