### PR TITLE
refactor: avoids redundant `.toString()` on branded string instances

### DIFF
--- a/src/features/TextToImage/components/TextToImageServerSpecificationAlert.vue
+++ b/src/features/TextToImage/components/TextToImageServerSpecificationAlert.vue
@@ -17,8 +17,8 @@ defineProps<{
   >
     Either:<br>
     a) supply it's corresponding environment variable named `{{ error.environmentKey }}` and rebuild<br>
-    b) specify it within "{{ error.file.toString() }}"<br>
+    b) specify it within "{{ error.file }}"<br>
     OR<br>
-    c) specify it within the response from "{{ error.endpoint.toString() }}"<br>
+    c) specify it within the response from "{{ error.endpoint }}"<br>
   </VAlert>
 </template>

--- a/src/library/GitHub/Repository/definition.declared.ts
+++ b/src/library/GitHub/Repository/definition.declared.ts
@@ -22,7 +22,7 @@ class GitHub_Repository<
   }
 
   public get site(): URL {
-    return new URL(GitHub_site.toString().concat(this.path.toString()));
+    return new URL(GitHub_site.toString().concat(this.path));
   }
 
   public get Issue(): ReturnType<typeof GitHub_Repository_Issue.Draftable> {

--- a/src/library/HTTP/Response/Body/Digestion/Error/DescriptorMismatch.ts
+++ b/src/library/HTTP/Response/Body/Digestion/Error/DescriptorMismatch.ts
@@ -16,7 +16,7 @@ class HTTP_Response_Body_Digestion_Error_DescriptorMismatch
     expectedDescriptor: ContentDescriptor;
   }> {
   public override get message(): string {
-    const /**/expectedRawDescriptor = this.expectedDescriptor.serialized.toString();
+    const /**/expectedRawDescriptor = this.expectedDescriptor.serialized;
     const /*  */actualRawDescriptor = this.response.headers.get(HTTP_Header.Content.Descriptor) ?? '';
 
     return `Expected content descriptor to be "${expectedRawDescriptor}", but it was actually "${actualRawDescriptor}"`;

--- a/src/library/HTTP/Response/bodyOf.ts
+++ b/src/library/HTTP/Response/bodyOf.ts
@@ -25,7 +25,7 @@ const bodyOf = (
       actualRawDescriptor === null
     ) return false;
 
-    return actualRawDescriptor.includes(givenDescriptor.serialized.toString());
+    return actualRawDescriptor.includes(givenDescriptor.serialized);
   },
   async digestAsUnknown() {
     return Effect.runPromise(Effect.promise(async () => {

--- a/src/library/ShimmedStabilityAIClient/Version1/Image.ts
+++ b/src/library/ShimmedStabilityAIClient/Version1/Image.ts
@@ -41,7 +41,7 @@ class ShimmedStabilityAIClient_Version1_Image
     );
 
     const soleGeneratedArtifact: StabilityAI_TextToImage_Pipeline_Output = {
-      base64      : generatedImage.toString(),
+      base64      : generatedImage,
       finishReason: 'SUCCESS',
       seed        : givenRequest.textToImageRequestBody.seed,
     };

--- a/src/library/Shortfin/TextToImage/SDXL/Client/definition.declared.ts
+++ b/src/library/Shortfin/TextToImage/SDXL/Client/definition.declared.ts
@@ -22,7 +22,7 @@ class Shortfin_TextToImage_SDXL_Client
     givenOrigin: URLComponent.Origin,
   ) {
     const defaultHeaders = {
-      [HTTP.Header.Content.Descriptor]: ContentDescriptor.json.serialized.toString(),
+      [HTTP.Header.Content.Descriptor]: ContentDescriptor.json.serialized,
     };
 
     super(


### PR DESCRIPTION
Follows up on #1098, #1100, #1108, #1110