### PR TITLE
refactor: clarifies identifiers affected by `Effect.run*`

### DIFF
--- a/src/features/TextToImage/Config/Dynamic/fetch.ts
+++ b/src/features/TextToImage/Config/Dynamic/fetch.ts
@@ -21,11 +21,11 @@ import {
 const TextToImage_Config_Dynamic_fetch = (): Promise<
   TextToImage_Config_Dynamic_Fetching.Exit
 > => Effect.runPromise(Effect.promise(async () => {
-  const exitFromFetchingResource = await HTTP.Client.local.fetchResource({
+  const exitFromFetchingRawConfigFromEndpoint = await HTTP.Client.local.fetchResource({
     from: TextToImage_Config_Dynamic_endpoint,
   });
 
-  return Exit.mapBoth(exitFromFetchingResource, {
+  return Exit.mapBoth(exitFromFetchingRawConfigFromEndpoint, {
     onSuccess: $0 => Schema.decodeUnknownSync(TextToImage_Config)($0),
     onFailure: $0 => new TextToImage_Config_Dynamic_Fetching.Error({
       endpoint: TextToImage_Config_Dynamic_endpoint,

--- a/src/features/TextToImage/Config/Dynamic/fetch.ts
+++ b/src/features/TextToImage/Config/Dynamic/fetch.ts
@@ -25,13 +25,15 @@ const TextToImage_Config_Dynamic_fetch = (): Promise<
     from: TextToImage_Config_Dynamic_endpoint,
   });
 
-  return Exit.mapBoth(exitFromFetchingRawConfigFromEndpoint, {
+  const exitFromDecodingConfigFromEndpoint = Exit.mapBoth(exitFromFetchingRawConfigFromEndpoint, {
     onSuccess: $0 => Schema.decodeUnknownSync(TextToImage_Config)($0),
     onFailure: $0 => new TextToImage_Config_Dynamic_Fetching.Error({
       endpoint: TextToImage_Config_Dynamic_endpoint,
       cause   : $0,
     }),
   });
+
+  return exitFromDecodingConfigFromEndpoint;
 }));
 
 export {

--- a/src/features/TextToImage/Config/Static/read.ts
+++ b/src/features/TextToImage/Config/Static/read.ts
@@ -21,11 +21,11 @@ import {
 const TextToImage_Config_Static_read = (): Promise<
   TextToImage_Config_Static_Reading.Exit
 > => Effect.runPromise(Effect.promise(async () => {
-  const exitFromFetchingFile = await HTTP.Client.local.fetchResource({
+  const exitFromFetchingRawConfigFromFile = await HTTP.Client.local.fetchResource({
     from: TextToImage_Config_Static_file,
   });
 
-  return Exit.mapBoth(exitFromFetchingFile, {
+  return Exit.mapBoth(exitFromFetchingRawConfigFromFile, {
     onSuccess: $0 => Schema.decodeUnknownSync(TextToImage_Config)($0),
     onFailure: $0 => new TextToImage_Config_Static_Reading.Error({
       cause   : $0,

--- a/src/features/TextToImage/Config/Static/read.ts
+++ b/src/features/TextToImage/Config/Static/read.ts
@@ -25,13 +25,15 @@ const TextToImage_Config_Static_read = (): Promise<
     from: TextToImage_Config_Static_file,
   });
 
-  return Exit.mapBoth(exitFromFetchingRawConfigFromFile, {
+  const exitFromDecodingConfigFromFile = Exit.mapBoth(exitFromFetchingRawConfigFromFile, {
     onSuccess: $0 => Schema.decodeUnknownSync(TextToImage_Config)($0),
     onFailure: $0 => new TextToImage_Config_Static_Reading.Error({
       cause   : $0,
       filePath: TextToImage_Config_Static_file,
     }),
   });
+
+  return exitFromDecodingConfigFromFile;
 }));
 
 export {

--- a/src/library/HTTP/Client.ts
+++ b/src/library/HTTP/Client.ts
@@ -88,15 +88,15 @@ class HTTP_Client {
       return Exit.fail(newResponseError);
     }
 
-    const exitFromDigestingResponseBody = await bodyOf(fetchedResponse).digestAsUnknown();
-
-    return Exit.mapError(
-      exitFromDigestingResponseBody,
+    const exitFromDigestingResponseBody = Exit.mapError(
+      await bodyOf(fetchedResponse).digestAsUnknown(),
       $0 => new HTTP_Endpoint.Error.IndigestibleResponseBody({
         endpoint: endpointURL,
         cause   : $0,
       }),
     );
+
+    return exitFromDigestingResponseBody;
   }));
 
   public async fetchResource(

--- a/src/library/HTTP/Client.ts
+++ b/src/library/HTTP/Client.ts
@@ -77,18 +77,18 @@ class HTTP_Client {
       Exit.isFailure(exitFromSettlingResponse)
     ) return Exit.failCause(exitFromSettlingResponse.cause);
 
-    const response = exitFromSettlingResponse.value;
+    const fetchedResponse = exitFromSettlingResponse.value;
 
-    if (!response.ok) {
+    if (!fetchedResponse.ok) {
       const newResponseError = new HTTP_Endpoint.Error.RespondedWithFailure({
-        message: response.statusText,
-        status : response.status,
+        message: fetchedResponse.statusText,
+        status : fetchedResponse.status,
       });
 
       return Exit.fail(newResponseError);
     }
 
-    const exitFromDigestingResponseBody = await bodyOf(response).digestAsUnknown();
+    const exitFromDigestingResponseBody = await bodyOf(fetchedResponse).digestAsUnknown();
 
     return Exit.mapError(
       exitFromDigestingResponseBody,


### PR DESCRIPTION
Pins learnings from drafting #1203