### PR TITLE
refactor: prefers arrow syntax when returning immediately invoked `Effect`

### DIFF
--- a/src/library/Shortfin/TextToImage/SDXL/Client/definition.declared.ts
+++ b/src/library/Shortfin/TextToImage/SDXL/Client/definition.declared.ts
@@ -36,12 +36,10 @@ class Shortfin_TextToImage_SDXL_Client
   ): Promise<
     Shortfin_TextToImage_SDXL_Client_Request.Exit
   > {
-    const generationEndpoint = URLComponent.Path('/generate');
-
     return Effect.runPromise(Effect.promise(async () => {
       const exitFromSubmittingResource = await this.submitResource({
         bySending: givenBatchedRequestBody,
-        to       : generationEndpoint,
+        to       : URLComponent.Path('/generate'),
       });
 
       if (

--- a/src/library/Shortfin/TextToImage/SDXL/Client/definition.declared.ts
+++ b/src/library/Shortfin/TextToImage/SDXL/Client/definition.declared.ts
@@ -31,11 +31,11 @@ class Shortfin_TextToImage_SDXL_Client
     );
   }
 
-  public generateImageFrom(
+  public generateImageFrom = (
     givenBatchedRequestBody: Shortfin_TextToImage_SDXL_Client_Request.Body.Batched,
   ): Promise<
     Shortfin_TextToImage_SDXL_Client_Request.Exit
-  > {
+  > => {
     return Effect.runPromise(Effect.promise(async () => {
       const exitFromSubmittingResource = await this.submitResource({
         bySending: givenBatchedRequestBody,
@@ -51,7 +51,7 @@ class Shortfin_TextToImage_SDXL_Client
       const [soleGeneratedImage] = decodedResource.images;
       return Exit.succeed(soleGeneratedImage);
     }));
-  }
+  };
 }
 
 export {

--- a/src/library/Shortfin/TextToImage/SDXL/Client/definition.declared.ts
+++ b/src/library/Shortfin/TextToImage/SDXL/Client/definition.declared.ts
@@ -35,23 +35,21 @@ class Shortfin_TextToImage_SDXL_Client
     givenBatchedRequestBody: Shortfin_TextToImage_SDXL_Client_Request.Body.Batched,
   ): Promise<
     Shortfin_TextToImage_SDXL_Client_Request.Exit
-  > => {
-    return Effect.runPromise(Effect.promise(async () => {
-      const exitFromSubmittingResource = await this.submitResource({
-        bySending: givenBatchedRequestBody,
-        to       : URLComponent.Path('/generate'),
-      });
+  > => Effect.runPromise(Effect.promise(async () => {
+    const exitFromSubmittingResource = await this.submitResource({
+      bySending: givenBatchedRequestBody,
+      to       : URLComponent.Path('/generate'),
+    });
 
-      if (
-        Exit.isFailure(exitFromSubmittingResource)
-      ) return Exit.failCause(exitFromSubmittingResource.cause);
+    if (
+      Exit.isFailure(exitFromSubmittingResource)
+    ) return Exit.failCause(exitFromSubmittingResource.cause);
 
-      const rawResource = exitFromSubmittingResource.value;
-      const decodedResource = Schema.decodeUnknownSync(Shortfin_TextToImage_SDXL_Client_Response.Body)(rawResource);
-      const [soleGeneratedImage] = decodedResource.images;
-      return Exit.succeed(soleGeneratedImage);
-    }));
-  };
+    const rawResource = exitFromSubmittingResource.value;
+    const decodedResource = Schema.decodeUnknownSync(Shortfin_TextToImage_SDXL_Client_Response.Body)(rawResource);
+    const [soleGeneratedImage] = decodedResource.images;
+    return Exit.succeed(soleGeneratedImage);
+  }));
 }
 
 export {


### PR DESCRIPTION
- Since `Effect` instances are executable, aligning their blocks with what's usually the body of a callable function makes it easier to convert between effectful and traditional function bodies
- i.e. it becomes a simple matter of "wrapping"/"unwrapping" the block with `Effect.gen`

Facilitates #1203