### PR TITLE
refactor: decouples mapping of successes and failures

### DIFF
--- a/src/features/TextToImage/Config/Dynamic/fetch.ts
+++ b/src/features/TextToImage/Config/Dynamic/fetch.ts
@@ -25,13 +25,13 @@ const TextToImage_Config_Dynamic_fetch = (): Promise<
     from: TextToImage_Config_Dynamic_endpoint,
   });
 
-  const exitFromDecodingConfigFromEndpoint = Exit.mapBoth(exitFromFetchingRawConfigFromEndpoint, {
+  const exitFromDecodingConfigFromEndpoint = exitFromFetchingRawConfigFromEndpoint.pipe(Exit.mapBoth({
     onSuccess: $0 => Schema.decodeUnknownSync(TextToImage_Config)($0),
     onFailure: $0 => new TextToImage_Config_Dynamic_Fetching.Error({
       endpoint: TextToImage_Config_Dynamic_endpoint,
       cause   : $0,
     }),
-  });
+  }));
 
   return exitFromDecodingConfigFromEndpoint;
 }));

--- a/src/features/TextToImage/Config/Dynamic/fetch.ts
+++ b/src/features/TextToImage/Config/Dynamic/fetch.ts
@@ -30,10 +30,9 @@ const TextToImage_Config_Dynamic_fetch = (): Promise<
     })),
   );
 
-  const exitFromDecodingConfigFromEndpoint = exitFromFetchingRawConfigFromEndpoint.pipe(Exit.mapBoth({
-    onSuccess: $0 => Schema.decodeUnknownSync(TextToImage_Config)($0),
-    onFailure: $0 => $0,
-  }));
+  const exitFromDecodingConfigFromEndpoint = exitFromFetchingRawConfigFromEndpoint.pipe(
+    Exit.map($0 => Schema.decodeUnknownSync(TextToImage_Config)($0)),
+  );
 
   return exitFromDecodingConfigFromEndpoint;
 }));

--- a/src/features/TextToImage/Config/Dynamic/fetch.ts
+++ b/src/features/TextToImage/Config/Dynamic/fetch.ts
@@ -21,16 +21,18 @@ import {
 const TextToImage_Config_Dynamic_fetch = (): Promise<
   TextToImage_Config_Dynamic_Fetching.Exit
 > => Effect.runPromise(Effect.promise(async () => {
-  const exitFromFetchingRawConfigFromEndpoint = await HTTP.Client.local.fetchResource({
+  const exitFromFetchingRawConfigFromEndpoint = (await HTTP.Client.local.fetchResource({
     from: TextToImage_Config_Dynamic_endpoint,
-  });
+  })).pipe(
+    Exit.mapError($0 => new TextToImage_Config_Dynamic_Fetching.Error({
+      endpoint: TextToImage_Config_Dynamic_endpoint,
+      cause   : $0,
+    })),
+  );
 
   const exitFromDecodingConfigFromEndpoint = exitFromFetchingRawConfigFromEndpoint.pipe(Exit.mapBoth({
     onSuccess: $0 => Schema.decodeUnknownSync(TextToImage_Config)($0),
-    onFailure: $0 => new TextToImage_Config_Dynamic_Fetching.Error({
-      endpoint: TextToImage_Config_Dynamic_endpoint,
-      cause   : $0,
-    }),
+    onFailure: $0 => $0,
   }));
 
   return exitFromDecodingConfigFromEndpoint;

--- a/src/features/TextToImage/Config/Static/read.ts
+++ b/src/features/TextToImage/Config/Static/read.ts
@@ -21,16 +21,18 @@ import {
 const TextToImage_Config_Static_read = (): Promise<
   TextToImage_Config_Static_Reading.Exit
 > => Effect.runPromise(Effect.promise(async () => {
-  const exitFromFetchingRawConfigFromFile = await HTTP.Client.local.fetchResource({
+  const exitFromFetchingRawConfigFromFile = (await HTTP.Client.local.fetchResource({
     from: TextToImage_Config_Static_file,
-  });
+  })).pipe(
+    Exit.mapError($0 => new TextToImage_Config_Static_Reading.Error({
+      filePath: TextToImage_Config_Static_file,
+      cause   : $0,
+    })),
+  );
 
   const exitFromDecodingConfigFromFile = exitFromFetchingRawConfigFromFile.pipe(Exit.mapBoth({
     onSuccess: $0 => Schema.decodeUnknownSync(TextToImage_Config)($0),
-    onFailure: $0 => new TextToImage_Config_Static_Reading.Error({
-      cause   : $0,
-      filePath: TextToImage_Config_Static_file,
-    }),
+    onFailure: $0 => $0,
   }));
 
   return exitFromDecodingConfigFromFile;

--- a/src/features/TextToImage/Config/Static/read.ts
+++ b/src/features/TextToImage/Config/Static/read.ts
@@ -25,13 +25,13 @@ const TextToImage_Config_Static_read = (): Promise<
     from: TextToImage_Config_Static_file,
   });
 
-  const exitFromDecodingConfigFromFile = Exit.mapBoth(exitFromFetchingRawConfigFromFile, {
+  const exitFromDecodingConfigFromFile = exitFromFetchingRawConfigFromFile.pipe(Exit.mapBoth({
     onSuccess: $0 => Schema.decodeUnknownSync(TextToImage_Config)($0),
     onFailure: $0 => new TextToImage_Config_Static_Reading.Error({
       cause   : $0,
       filePath: TextToImage_Config_Static_file,
     }),
-  });
+  }));
 
   return exitFromDecodingConfigFromFile;
 }));

--- a/src/features/TextToImage/Config/Static/read.ts
+++ b/src/features/TextToImage/Config/Static/read.ts
@@ -30,10 +30,9 @@ const TextToImage_Config_Static_read = (): Promise<
     })),
   );
 
-  const exitFromDecodingConfigFromFile = exitFromFetchingRawConfigFromFile.pipe(Exit.mapBoth({
-    onSuccess: $0 => Schema.decodeUnknownSync(TextToImage_Config)($0),
-    onFailure: $0 => $0,
-  }));
+  const exitFromDecodingConfigFromFile = exitFromFetchingRawConfigFromFile.pipe(
+    Exit.map($0 => Schema.decodeUnknownSync(TextToImage_Config)($0)),
+  );
 
   return exitFromDecodingConfigFromFile;
 }));


### PR DESCRIPTION
- using the `yield` syntax, transforming the success payload need not be done within a `.map*` function
- these changes decouple these from failure transformations ahead of time to prep for this syntax

Facilitates #1203