### PR TITLE
refactor: prefers piping `Effect.run*` calls

### DIFF
--- a/src/features/TextToImage/Client/SDXL/toSharkUIOutput/first.ts
+++ b/src/features/TextToImage/Client/SDXL/toSharkUIOutput/first.ts
@@ -40,7 +40,7 @@ const toSharkUIOutput_first = (
 
   if (
     !hasAtLeastOne(inferredOutputs)
-  ) return Effect.runSync(Effect.dieMessage('Expected at least one text-to-image output in response'));
+  ) return Effect.dieMessage('Expected at least one text-to-image output in response').pipe(Effect.runSync);
 
   const [firstPotentialOutput] = inferredOutputs;
 

--- a/src/features/TextToImage/Client/SDXL/toSharkUIOutput/plural.ts
+++ b/src/features/TextToImage/Client/SDXL/toSharkUIOutput/plural.ts
@@ -26,7 +26,7 @@ const toSharkUIOutput_plural = (
 ): Option.Option<Option.Option<TextToImage_Pipeline.Output>[]> => {
   if (
     !('artifacts' in givenResponse.result)
-  ) return Effect.runSync(Effect.dieMessage('Expected response body rather than readable stream'));
+  ) return Effect.dieMessage('Expected response body rather than readable stream').pipe(Effect.runSync);
 
   const inferredRawImages = Option.fromNullable(givenResponse.result.artifacts);
 

--- a/src/features/TextToImage/Pipeline/Output/definition.declared.ts
+++ b/src/features/TextToImage/Pipeline/Output/definition.declared.ts
@@ -12,9 +12,9 @@ interface TextToImage_Pipeline_Output {
 }
 
 function TextToImage_Pipeline_Output(
-  namespaceOnly: never = Effect.runSync(Effect.dieMessage(
+  namespaceOnly: never = Effect.dieMessage(
     `Unexpected call of module augmentation provision for ${TextToImage_Pipeline_Output.name}.`,
-  )),
+  ).pipe(Effect.runSync),
 ): never {
   return namespaceOnly;
 }

--- a/src/features/TextToImage/components/TextToImageOutputView.vue
+++ b/src/features/TextToImage/components/TextToImageOutputView.vue
@@ -30,6 +30,6 @@ defineProps<{
   <template
     v-else
   >
-    {{ Effect.runSync(Effect.dieMessage(Cause.pretty(output.cause))) }}
+    {{ Effect.dieMessage(Cause.pretty(output.cause)).pipe(Effect.runSync) }}
   </template>
 </template>

--- a/src/library/Range/Discrete.ts
+++ b/src/library/Range/Discrete.ts
@@ -41,13 +41,13 @@ class Range_Discrete
 
     if (
       isNegative(givenStepSize)
-    ) return Effect.runSync(Effect.dieMessage('Step size must be non-negative'));
+    ) return Effect.dieMessage('Step size must be non-negative').pipe(Effect.runSync);
 
     const overstep = validRange.width % givenStepSize;
 
     if (
       overstep !== 0
-    ) return Effect.runSync(Effect.dieMessage('Step size must fit evenly into the range'));
+    ) return Effect.dieMessage('Step size must fit evenly into the range').pipe(Effect.runSync);
 
     const validDiscreteRange = new this(
       validRange.lowerBound,

--- a/src/library/Range/definition.declared.ts
+++ b/src/library/Range/definition.declared.ts
@@ -27,7 +27,7 @@ class Range {
   ): Range {
     if (
       givenUpperBound < givenLowerBound
-    ) return Effect.runSync(Effect.dieMessage('Upper bound must not be lower than lower bound'));
+    ) return Effect.dieMessage('Upper bound must not be lower than lower bound').pipe(Effect.runSync);
 
     const validRange = new this(
       givenLowerBound,

--- a/src/library/ShimmedStabilityAIClient/Version1/Image.ts
+++ b/src/library/ShimmedStabilityAIClient/Version1/Image.ts
@@ -29,9 +29,12 @@ class ShimmedStabilityAIClient_Version1_Image
     ]);
 
     const textToImageSDXLShortfinClient = new Shortfin.TextToImage.SDXL.Client(this.origin);
-
     const effectOfGeneratingImage = textToImageSDXLShortfinClient.generateImageFrom(derivedBatchedRequestBody);
-    const resultOfGeneratingImage = await Effect.runPromise(Effect.either(effectOfGeneratingImage));
+
+    const resultOfGeneratingImage = await effectOfGeneratingImage.pipe(
+      Effect.either,
+      Effect.runPromise,
+    );
 
     const generatedImage = Either.getOrThrowWith(
       resultOfGeneratingImage,

--- a/src/library/math/operators/predicate/isNegative.ts
+++ b/src/library/math/operators/predicate/isNegative.ts
@@ -11,7 +11,7 @@ const isNegative = (
 ): boolean => {
   if (
     !isOperable(givenOperand)
-  ) return Effect.runSync(Effect.dieMessage('Operand must be operable'));
+  ) return Effect.dieMessage('Operand must be operable').pipe(Effect.runSync);
 
   return (givenOperand < 0);
 };

--- a/src/library/modifiersByType/error/Contextualized/assume.ts
+++ b/src/library/modifiersByType/error/Contextualized/assume.ts
@@ -25,7 +25,7 @@ const Contextualized_assume = <
     Contextualized_describes<SomeError, SomeCause>(givenError, GivenCause)
   ) return givenError;
 
-  return Effect.runSync(Effect.dieMessage('Expected error to have a cause'));
+  return Effect.dieMessage('Expected error to have a cause').pipe(Effect.runSync);
 };
 
 export {

--- a/src/library/vue/ProgressiveRef/instance.ts
+++ b/src/library/vue/ProgressiveRef/instance.ts
@@ -44,7 +44,11 @@ const progressiveRef = <
       set(flagIsRaised, false);
     });
 
-    const exitFromOperation = await Effect.runPromise(Effect.exit(givenOperation));
+    const exitFromOperation = await givenOperation.pipe(
+      Effect.exit,
+      Effect.runPromise,
+    );
+
     set(capturedExit, Option.some(exitFromOperation));
   };
 


### PR DESCRIPTION
- makes it easier to see the "subject" of the `.run*`