### PR TITLE
refactor(text-to-image): simplifies `TextToImage.Server.Current.retrieve`

### DIFF
--- a/src/features/TextToImage/Server/Current/retrieve.ts
+++ b/src/features/TextToImage/Server/Current/retrieve.ts
@@ -27,7 +27,7 @@ const TextToImage_Server_Current_retrieve: Effect.Effect<
 > = Effect.gen(function* () {
   if (
     Option.isSome(TextToImage_Server_Current_accordingToEnvironment)
-  ) return Option.getOrThrow(TextToImage_Server_Current_accordingToEnvironment);
+  ) return TextToImage_Server_Current_accordingToEnvironment.value;
 
   const remoteConfig = yield* Effect.firstSuccessOf([
     TextToImage_Config.Static.read,

--- a/src/features/TextToImage/Server/Current/retrieve.ts
+++ b/src/features/TextToImage/Server/Current/retrieve.ts
@@ -29,13 +29,18 @@ const TextToImage_Server_Current_retrieve: Effect.Effect<
     Option.isSome(TextToImage_Server_Current_accordingToEnvironment)
   ) return Option.getOrThrow(TextToImage_Server_Current_accordingToEnvironment);
 
-  const staticConfig = yield* Effect.orElseSucceed(TextToImage_Config.Static.read, () => TextToImage_Config.empty);
+  const staticConfig = yield* Effect.orElseSucceed(
+    TextToImage_Config.Static.read,
+    () => TextToImage_Config.empty,
+  );
 
   if (
     Option.isSome(staticConfig.server)
   ) return Option.getOrThrow(staticConfig.server);
 
-  const dynamicConfig = yield* TextToImage_Config.Dynamic.fetch.pipe(Effect.orElseSucceed(() => TextToImage_Config.empty));
+  const dynamicConfig = yield* TextToImage_Config.Dynamic.fetch.pipe(
+    Effect.orElseSucceed(() => TextToImage_Config.empty),
+  );
 
   if (
     Option.isSome(dynamicConfig.server)

--- a/src/features/TextToImage/Server/Current/retrieve.ts
+++ b/src/features/TextToImage/Server/Current/retrieve.ts
@@ -36,9 +36,11 @@ const TextToImage_Server_Current_retrieve: Effect.Effect<
     Effect.orElseSucceed(() => TextToImage_Config.empty),
   );
 
+  const currentTextToImageServer = remoteConfig.server;
+
   if (
-    Option.isSome(remoteConfig.server)
-  ) return Option.getOrThrow(remoteConfig.server);
+    Option.isSome(currentTextToImageServer)
+  ) return Option.getOrThrow(currentTextToImageServer);
 
   const newSpecificationError = yield* new TextToImage_Server_Error.MissingSpecification({
     environmentKey: TextToImage_Server_Origin.environmentKey,

--- a/src/features/TextToImage/Server/Current/retrieve.ts
+++ b/src/features/TextToImage/Server/Current/retrieve.ts
@@ -35,7 +35,7 @@ const TextToImage_Server_Current_retrieve: Effect.Effect<
     Option.isSome(staticConfig.server)
   ) return Option.getOrThrow(staticConfig.server);
 
-  const dynamicConfig = yield* Effect.orElseSucceed(TextToImage_Config.Dynamic.fetch, () => TextToImage_Config.empty);
+  const dynamicConfig = yield* TextToImage_Config.Dynamic.fetch.pipe(Effect.orElseSucceed(() => TextToImage_Config.empty));
 
   if (
     Option.isSome(dynamicConfig.server)

--- a/src/features/TextToImage/Server/Current/retrieve.ts
+++ b/src/features/TextToImage/Server/Current/retrieve.ts
@@ -36,19 +36,15 @@ const TextToImage_Server_Current_retrieve: Effect.Effect<
     Effect.orElseSucceed(() => TextToImage_Config.empty),
   );
 
-  const currentTextToImageServer = remoteConfig.server;
+  const currentTextToImageServer = yield* remoteConfig.server.pipe(
+    Effect.orElse(() => new TextToImage_Server_Error.MissingSpecification({
+      environmentKey: TextToImage_Server_Origin.environmentKey,
+      file          : TextToImage_Config.Static.file,
+      endpoint      : TextToImage_Config.Dynamic.endpoint,
+    })),
+  );
 
-  if (
-    Option.isSome(currentTextToImageServer)
-  ) return Option.getOrThrow(currentTextToImageServer);
-
-  const newSpecificationError = yield* new TextToImage_Server_Error.MissingSpecification({
-    environmentKey: TextToImage_Server_Origin.environmentKey,
-    file          : TextToImage_Config.Static.file,
-    endpoint      : TextToImage_Config.Dynamic.endpoint,
-  });
-
-  return newSpecificationError;
+  return currentTextToImageServer;
 });
 
 export {

--- a/src/features/TextToImage/Server/Current/retrieve.ts
+++ b/src/features/TextToImage/Server/Current/retrieve.ts
@@ -29,22 +29,16 @@ const TextToImage_Server_Current_retrieve: Effect.Effect<
     Option.isSome(TextToImage_Server_Current_accordingToEnvironment)
   ) return Option.getOrThrow(TextToImage_Server_Current_accordingToEnvironment);
 
-  const staticConfig = yield* Effect.orElseSucceed(
+  const remoteConfig = yield* Effect.firstSuccessOf([
     TextToImage_Config.Static.read,
-    () => TextToImage_Config.empty,
-  );
-
-  if (
-    Option.isSome(staticConfig.server)
-  ) return Option.getOrThrow(staticConfig.server);
-
-  const dynamicConfig = yield* TextToImage_Config.Dynamic.fetch.pipe(
+    TextToImage_Config.Dynamic.fetch,
+  ]).pipe(
     Effect.orElseSucceed(() => TextToImage_Config.empty),
   );
 
   if (
-    Option.isSome(dynamicConfig.server)
-  ) return Option.getOrThrow(dynamicConfig.server);
+    Option.isSome(remoteConfig.server)
+  ) return Option.getOrThrow(remoteConfig.server);
 
   const newSpecificationError = yield* new TextToImage_Server_Error.MissingSpecification({
     environmentKey: TextToImage_Server_Origin.environmentKey,


### PR DESCRIPTION
- see [PR commits](https://github.com/nod-ai/shark-ui/pull/1214/commits) for steps

Enabled by #1203