### PR TITLE
refactor(text-to-image): avoids running `Effect` instances in template

### DIFF
--- a/src/features/TextToImage/components/TextToImageOutputView.vue
+++ b/src/features/TextToImage/components/TextToImageOutputView.vue
@@ -1,8 +1,6 @@
 <script setup lang="ts">
 import {
-  Cause,
-  Effect,
-  Exit,
+  Either,
 } from 'effect';
 
 import type TextToImage from '@/features/TextToImage';
@@ -11,7 +9,7 @@ import TextToImageOutputAlert from './TextToImageOutputAlert.vue';
 import TextToImageOutputImg from './TextToImageOutputImg.vue';
 
 defineProps<{
-  output: Exit.Exit<
+  output: Either.Either<
     TextToImage.Pipeline.Output.Image,
     TextToImage.Server.Error.Any
   >;
@@ -20,16 +18,11 @@ defineProps<{
 
 <template>
   <TextToImageOutputImg
-    v-if="Exit.isSuccess(output)"
-    :model-value="output.value"
+    v-if="Either.isRight(output)"
+    :model-value="output.right"
   />
   <TextToImageOutputAlert
-    v-else-if="Cause.isFailType(output.cause)"
-    :error="output.cause.error"
-  />
-  <template
     v-else
-  >
-    {{ Effect.dieMessage(Cause.pretty(output.cause)).pipe(Effect.runSync) }}
-  </template>
+    :error="output.left"
+  />
 </template>

--- a/src/library/vue/ProgressiveRef/instance.ts
+++ b/src/library/vue/ProgressiveRef/instance.ts
@@ -7,7 +7,7 @@ import {
 
 import {
   Effect,
-  type Exit,
+  type Either,
   Option,
 } from 'effect';
 
@@ -27,7 +27,7 @@ const progressiveRef = <
 > => {
   const flagIsRaised = ref(false);
 
-  type CapturedOutput = Exit.Exit<
+  type CapturedOutput = Either.Either<
     SomeProduct,
     SomeFailure
   >;
@@ -45,7 +45,7 @@ const progressiveRef = <
     });
 
     const outputOfOperation = await givenOperation.pipe(
-      Effect.exit,
+      Effect.either,
       Effect.runPromise,
     );
 

--- a/src/library/vue/ProgressiveRef/instance.ts
+++ b/src/library/vue/ProgressiveRef/instance.ts
@@ -27,42 +27,42 @@ const progressiveRef = <
 > => {
   const flagIsRaised = ref(false);
 
-  type CapturedExit = Exit.Exit<
+  type CapturedOutput = Exit.Exit<
     SomeProduct,
     SomeFailure
   >;
 
-  const capturedExit = ref(Option.none()) as Ref<Option.Option<CapturedExit>>;
+  const capturedOutput = ref(Option.none()) as Ref<Option.Option<CapturedOutput>>;
 
-  const captureExit = async (): Promise<void> => {
+  const captureOutput = async (): Promise<void> => {
     using cleanup = new DisposableStack();
 
-    set(capturedExit, Option.none());
+    set(capturedOutput, Option.none());
     set(flagIsRaised, true);
 
     cleanup.defer(() => {
       set(flagIsRaised, false);
     });
 
-    const exitFromOperation = await givenOperation.pipe(
+    const outputOfOperation = await givenOperation.pipe(
       Effect.exit,
       Effect.runPromise,
     );
 
-    set(capturedExit, Option.some(exitFromOperation));
+    set(capturedOutput, Option.some(outputOfOperation));
   };
 
   return {
-    initiate: captureExit,
+    initiate: captureOutput,
     get isInProgress() {
       return get(flagIsRaised);
     },
-    get result() {
+    get output() {
       if (
         this.isInProgress
       ) return Option.none();
 
-      return get(capturedExit);
+      return get(capturedOutput);
     },
   };
 };

--- a/src/library/vue/ProgressiveRef/type.ts
+++ b/src/library/vue/ProgressiveRef/type.ts
@@ -1,5 +1,5 @@
 import type {
-  Exit,
+  Either,
   Option,
 } from 'effect';
 
@@ -10,7 +10,7 @@ interface ProgressiveRef<
   initiate: () => Promise<void>;
   isInProgress: boolean;
   output: Option.Option<
-    Exit.Exit<
+    Either.Either<
       SomeProduct,
       SomeFailure
     >

--- a/src/library/vue/ProgressiveRef/type.ts
+++ b/src/library/vue/ProgressiveRef/type.ts
@@ -9,7 +9,7 @@ interface ProgressiveRef<
 > {
   initiate: () => Promise<void>;
   isInProgress: boolean;
-  result: Option.Option<
+  output: Option.Option<
     Exit.Exit<
       SomeProduct,
       SomeFailure

--- a/src/pages/TextToImagePage.vue
+++ b/src/pages/TextToImagePage.vue
@@ -122,7 +122,7 @@ const imageGeneration = progressiveRef(Effect.gen(function* () {
       class="fill-height"
     >
       <VSkeletonLoader
-        v-if="Option.isNone(imageGeneration.result)"
+        v-if="Option.isNone(imageGeneration.output)"
         :boilerplate="!imageGeneration.isInProgress"
         width="100vh"
         :style="{
@@ -131,7 +131,7 @@ const imageGeneration = progressiveRef(Effect.gen(function* () {
       />
       <TextToImageOutputView
         v-else
-        :output="imageGeneration.result.value"
+        :output="imageGeneration.output.value"
       />
     </VContainer>
   </VMain>


### PR DESCRIPTION
- running an `Effect` is very much a job for the script in a Vue SFC
- if a `.run*` is in the template, it's most definitely a code smell