### PR TITLE
refactor: switches from `HTTP` library to `@effect/platform` analog

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "shark-ui",
       "version": "0.5.0",
       "dependencies": {
+        "@effect/platform": "^0.92.1",
         "effect": "^3.18.4",
         "stabilityai-client-typescript": "github:nod-ai/StabilityAI-client-typescript#npm/v0.1.0",
         "vue": "^3.5.22",
@@ -824,6 +825,20 @@
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.1"
+      }
+    },
+    "node_modules/@effect/platform": {
+      "version": "0.92.1",
+      "resolved": "https://registry.npmjs.org/@effect/platform/-/platform-0.92.1.tgz",
+      "integrity": "sha512-XXWCBVwyhaKZISN7aM1fv/3fWDGyxr84ObywnUrL8aHvJLoIeskWFAP/fqw3c5MFCrJ3ZV97RWLbv6JiBQugdg==",
+      "license": "MIT",
+      "dependencies": {
+        "find-my-way-ts": "^0.1.6",
+        "msgpackr": "^1.11.4",
+        "multipasta": "^0.2.7"
+      },
+      "peerDependencies": {
+        "effect": "^3.18.1"
       }
     },
     "node_modules/@emnapi/core": {
@@ -1754,6 +1769,84 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-darwin-arm64": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-arm64/-/msgpackr-extract-darwin-arm64-3.0.3.tgz",
+      "integrity": "sha512-QZHtlVgbAdy2zAqNA9Gu1UpIuI8Xvsd1v8ic6B2pZmeFnFcMWiPLfWXh7TVw4eGEZ/C9TH281KwhVoeQUKbyjw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-darwin-x64": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-x64/-/msgpackr-extract-darwin-x64-3.0.3.tgz",
+      "integrity": "sha512-mdzd3AVzYKuUmiWOQ8GNhl64/IoFGol569zNRdkLReh6LRLHOXxU4U8eq0JwaD8iFHdVGqSy4IjFL4reoWCDFw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm/-/msgpackr-extract-linux-arm-3.0.3.tgz",
+      "integrity": "sha512-fg0uy/dG/nZEXfYilKoRe7yALaNmHoYeIoJuJ7KJ+YyU2bvY8vPv27f7UKhGRpY6euFYqEVhxCFZgAUNQBM3nw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm64": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm64/-/msgpackr-extract-linux-arm64-3.0.3.tgz",
+      "integrity": "sha512-YxQL+ax0XqBJDZiKimS2XQaf+2wDGVa1enVRGzEvLLVFeqa5kx2bWbtcSXgsxjQB7nRqqIGFIcLteF/sHeVtQg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-x64": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-x64/-/msgpackr-extract-linux-x64-3.0.3.tgz",
+      "integrity": "sha512-cvwNfbP07pKUfq1uH+S6KJ7dT9K8WOE4ZiAcsrSes+UY55E/0jLYc+vq+DO7jlmqRb5zAggExKm0H7O/CBaesg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-win32-x64": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-win32-x64/-/msgpackr-extract-win32-x64-3.0.3.tgz",
+      "integrity": "sha512-x0fWaQtYp4E6sktbsdAqnehxDgEc/VwM7uLsRCYWaiGu0ykYdZPiS8zCWdnjHwyiumousxfBm4SO31eXqwEZhQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "0.2.10",
@@ -4746,6 +4839,16 @@
         "node": ">=6"
       }
     },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/devlop": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
@@ -5906,6 +6009,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/find-my-way-ts": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/find-my-way-ts/-/find-my-way-ts-0.1.6.tgz",
+      "integrity": "sha512-a85L9ZoXtNAey3Y6Z+eBWW658kO/MwR7zIafkIUPUMf3isZG0NCs2pjW2wtjxAKuJPxMAsHUIP4ZPGv0o5gyTA==",
+      "license": "MIT"
     },
     "node_modules/find-up": {
       "version": "5.0.0",
@@ -9506,11 +9615,48 @@
       "devOptional": true,
       "license": "MIT"
     },
+    "node_modules/msgpackr": {
+      "version": "1.11.5",
+      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.11.5.tgz",
+      "integrity": "sha512-UjkUHN0yqp9RWKy0Lplhh+wlpdt9oQBYgULZOiFhV3VclSF1JnSQWZ5r9gORQlNYaUKQoR8itv7g7z1xDDuACA==",
+      "license": "MIT",
+      "optionalDependencies": {
+        "msgpackr-extract": "^3.0.2"
+      }
+    },
+    "node_modules/msgpackr-extract": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/msgpackr-extract/-/msgpackr-extract-3.0.3.tgz",
+      "integrity": "sha512-P0efT1C9jIdVRefqjzOQ9Xml57zpOXnIuS+csaB4MdZbTdmGDLo8XhzBG1N7aO11gKDDkJvBLULeFTo46wwreA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "node-gyp-build-optional-packages": "5.2.2"
+      },
+      "bin": {
+        "download-msgpackr-prebuilds": "bin/download-prebuilds.js"
+      },
+      "optionalDependencies": {
+        "@msgpackr-extract/msgpackr-extract-darwin-arm64": "3.0.3",
+        "@msgpackr-extract/msgpackr-extract-darwin-x64": "3.0.3",
+        "@msgpackr-extract/msgpackr-extract-linux-arm": "3.0.3",
+        "@msgpackr-extract/msgpackr-extract-linux-arm64": "3.0.3",
+        "@msgpackr-extract/msgpackr-extract-linux-x64": "3.0.3",
+        "@msgpackr-extract/msgpackr-extract-win32-x64": "3.0.3"
+      }
+    },
     "node_modules/muggle-string": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/muggle-string/-/muggle-string-0.4.1.tgz",
       "integrity": "sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/multipasta": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/multipasta/-/multipasta-0.2.7.tgz",
+      "integrity": "sha512-KPA58d68KgGil15oDqXjkUBEBYc00XvbPj5/X+dyzeo/lWm9Nc25pQRlf1D+gv4OpK7NM0J1odrbu9JNNGvynA==",
       "license": "MIT"
     },
     "node_modules/nano-spawn": {
@@ -9566,6 +9712,21 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/node-gyp-build-optional-packages": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-5.2.2.tgz",
+      "integrity": "sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "detect-libc": "^2.0.1"
+      },
+      "bin": {
+        "node-gyp-build-optional-packages": "bin.js",
+        "node-gyp-build-optional-packages-optional": "optional.js",
+        "node-gyp-build-optional-packages-test": "build-test.js"
+      }
     },
     "node_modules/node-releases": {
       "version": "2.0.19",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "lint:docs": "markdownlint-cli2 --fix '**/*.md'"
   },
   "dependencies": {
+    "@effect/platform": "^0.92.1",
     "effect": "^3.18.4",
     "stabilityai-client-typescript": "github:nod-ai/StabilityAI-client-typescript#npm/v0.1.0",
     "vue": "^3.5.22",

--- a/src/features/TextToImage/Client/SDXL/generateOutputFrom.ts
+++ b/src/features/TextToImage/Client/SDXL/generateOutputFrom.ts
@@ -1,12 +1,14 @@
 import {
+  HttpClientError,
+} from '@effect/platform';
+
+import {
   Effect,
 } from 'effect';
 
 import type {
   GenerateFromTextRequest,
 } from 'stabilityai-client-typescript/models/operations';
-
-import HTTP from '@/library/HTTP';
 
 import {
   TextToImage_Server,
@@ -55,7 +57,8 @@ const TextToImage_Client_SDXL_generateOutputFrom = (
       const caughtError = someException.cause;
 
       if (
-        caughtError instanceof HTTP.Endpoint.Error.FailedToSendRequest
+        HttpClientError.isHttpClientError(caughtError)
+        && (caughtError.reason === 'Transport')
       ) return new TextToImage_Server.Error.FailedToConnect(caughtError);
 
       return Effect.die(caughtError);

--- a/src/features/TextToImage/Config/Dynamic/fetch.ts
+++ b/src/features/TextToImage/Config/Dynamic/fetch.ts
@@ -1,9 +1,12 @@
 import {
-  Effect,
-  Schema,
-} from 'effect';
+  FetchHttpClient,
+  HttpClient,
+  HttpClientResponse,
+} from '@effect/platform';
 
-import HTTP from '@/library/HTTP';
+import {
+  Effect,
+} from 'effect';
 
 import {
   TextToImage_Config,
@@ -18,18 +21,16 @@ import {
 } from './endpoint';
 
 const TextToImage_Config_Dynamic_fetch: TextToImage_Config_Dynamic_Fetching.Effect = Effect.gen(function* () {
-  const rawConfigFromEndpoint = yield* HTTP.Client.local.fetchResource({
-    from: TextToImage_Config_Dynamic_endpoint,
-  });
-
-  const decoded = Schema.decodeUnknown(TextToImage_Config);
-  const decodedConfigFromEndpoint = yield* decoded(rawConfigFromEndpoint).pipe(Effect.orDie);
+  const endpointResponse = yield* HttpClient.get(TextToImage_Config_Dynamic_endpoint);
+  const decodedBodyFrom = HttpClientResponse.schemaBodyJson(TextToImage_Config);
+  const decodedConfigFromEndpoint = yield* decodedBodyFrom(endpointResponse).pipe(Effect.orDie);
   return decodedConfigFromEndpoint;
 }).pipe(
   Effect.mapError($0 => new TextToImage_Config_Dynamic_Fetching.Error({
     endpoint: TextToImage_Config_Dynamic_endpoint,
     cause   : $0,
   })),
+  Effect.provide(FetchHttpClient.layer),
 );
 
 export {

--- a/src/features/TextToImage/Config/Static/read.ts
+++ b/src/features/TextToImage/Config/Static/read.ts
@@ -1,9 +1,12 @@
 import {
-  Effect,
-  Schema,
-} from 'effect';
+  FetchHttpClient,
+  HttpClient,
+  HttpClientResponse,
+} from '@effect/platform';
 
-import HTTP from '@/library/HTTP';
+import {
+  Effect,
+} from 'effect';
 
 import {
   TextToImage_Config,
@@ -18,18 +21,16 @@ import {
 } from './file';
 
 const TextToImage_Config_Static_read: TextToImage_Config_Static_Reading.Effect = Effect.gen(function* () {
-  const rawConfigFromFile = yield* HTTP.Client.local.fetchResource({
-    from: TextToImage_Config_Static_file,
-  });
-
-  const decoded = Schema.decodeUnknown(TextToImage_Config);
-  const decodedConfigFromFile = yield* decoded(rawConfigFromFile).pipe(Effect.orDie);
+  const fileResponse = yield* HttpClient.get(TextToImage_Config_Static_file);
+  const decodedBodyFrom = HttpClientResponse.schemaBodyJson(TextToImage_Config);
+  const decodedConfigFromFile = yield* decodedBodyFrom(fileResponse).pipe(Effect.orDie);
   return decodedConfigFromFile;
 }).pipe(
   Effect.mapError($0 => new TextToImage_Config_Static_Reading.Error({
     filePath: TextToImage_Config_Static_file,
     cause   : $0,
   })),
+  Effect.provide(FetchHttpClient.layer),
 );
 
 export {

--- a/src/features/TextToImage/Server/Error/FailedToConnect.ts
+++ b/src/features/TextToImage/Server/Error/FailedToConnect.ts
@@ -1,3 +1,7 @@
+import type {
+  HttpClientRequest,
+} from '@effect/platform';
+
 import {
   Data,
 } from 'effect';
@@ -6,10 +10,10 @@ class TextToImage_Server_Error_FailedToConnect
   extends Data.TaggedError(
     'TextToImage_Server_Error_FailedToConnect',
   )<{
-    endpoint: URL;
+    request: HttpClientRequest.HttpClientRequest;
   }> {
   public override get message(): string {
-    return `Failed to reach the text-to-image server at "${this.endpoint.origin}".`;
+    return `Failed to reach the text-to-image server at "${this.request.url}".`;
   }
 }
 

--- a/src/features/TextToImage/components/TextToImageServerConnectionAlert.vue
+++ b/src/features/TextToImage/components/TextToImageServerConnectionAlert.vue
@@ -15,7 +15,7 @@ defineProps<{
     type="error"
     title="Failed to Connect"
   >
-    Server not found at specified origin "{{ error.endpoint.origin }}".<br>
+    Server not found at "{{ error.request.url }}".<br>
     <br>
     Ensure that:<br>
     a. the environment/config has the correct origin<br>

--- a/src/library/ShimmedStabilityAIClient/Version1/Image.ts
+++ b/src/library/ShimmedStabilityAIClient/Version1/Image.ts
@@ -1,3 +1,7 @@
+import type {
+  HttpClientError,
+} from '@effect/platform';
+
 import {
   Effect,
   Either,
@@ -16,7 +20,6 @@ import type {
   GenerateFromTextResponse,
 } from 'stabilityai-client-typescript/models/operations';
 
-import type HTTP from '@/library/HTTP';
 import Shortfin from '@/library/Shortfin';
 import URLComponent from '@/library/URLComponent';
 
@@ -34,7 +37,7 @@ class ShimmedStabilityAIClient_Version1_Image
     givenRequest: GenerateFromTextRequest,
   ): Effect.Effect<
     GenerateFromTextResponse,
-    HTTP.Endpoint.Error.Any
+    HttpClientError.HttpClientError
   > => Effect.gen(this, function* () {
     const derivedBatchedRequestBody = toShortfinRequestBody.Batched([
       givenRequest.textToImageRequestBody,

--- a/src/library/Shortfin/TextToImage/SDXL/Client/Request/Effect.ts
+++ b/src/library/Shortfin/TextToImage/SDXL/Client/Request/Effect.ts
@@ -1,13 +1,16 @@
 import type {
+  HttpClientError,
+} from '@effect/platform';
+
+import type {
   Effect,
 } from 'effect';
 
-import type HTTP from '@/library/HTTP';
 import type Sequence from '@/library/Sequence';
 
 type Shortfin_TextToImage_SDXL_Client_Request_Effect = Effect.Effect<
   Sequence.Byte.Encoded.Base64,
-  HTTP.Endpoint.Error.Any
+  HttpClientError.HttpClientError
 >;
 
 export type {

--- a/src/library/Shortfin/TextToImage/SDXL/Client/definition.declared.ts
+++ b/src/library/Shortfin/TextToImage/SDXL/Client/definition.declared.ts
@@ -1,11 +1,15 @@
 import {
+  FetchHttpClient,
+  HttpBody,
+  HttpClient,
+  HttpClientResponse,
+} from '@effect/platform';
+
+import {
   Effect,
-  Schema,
 } from 'effect';
 
-import ContentDescriptor from '@/library/ContentDescriptor';
-import HTTP from '@/library/HTTP';
-import URLComponent from '@/library/URLComponent';
+import type URLComponent from '@/library/URLComponent';
 
 import type {
   Shortfin_TextToImage_SDXL_Client_Request,
@@ -15,34 +19,27 @@ import {
   Shortfin_TextToImage_SDXL_Client_Response,
 } from './Response';
 
-class Shortfin_TextToImage_SDXL_Client
-  extends HTTP.Client {
+class Shortfin_TextToImage_SDXL_Client {
   public constructor(
-    givenOrigin: URLComponent.Origin,
-  ) {
-    const defaultHeaders = {
-      [HTTP.Header.Content.Descriptor]: ContentDescriptor.json.serialized,
-    };
-
-    super(
-      givenOrigin,
-      defaultHeaders,
-    );
-  }
+    public readonly origin: URLComponent.Origin,
+  ) {}
 
   public generateImageFrom = (
     givenBatchedRequestBody: Shortfin_TextToImage_SDXL_Client_Request.Body.Batched,
   ): Shortfin_TextToImage_SDXL_Client_Request.Effect => Effect.gen(this, function* () {
-    const rawResource = yield* this.submitResource({
-      bySending: givenBatchedRequestBody,
-      to       : URLComponent.Path('/generate'),
+    const encodedBatchedRequestBody = yield* HttpBody.json(givenBatchedRequestBody).pipe(Effect.orDie);
+
+    const generationResponse = yield* HttpClient.post(this.origin.concat('/generate'), {
+      body: encodedBatchedRequestBody,
     });
 
-    const decoded = Schema.decodeUnknown(Shortfin_TextToImage_SDXL_Client_Response.Body);
-    const decodedResource = yield* decoded(rawResource).pipe(Effect.orDie);
+    const decodedBodyFrom = HttpClientResponse.schemaBodyJson(Shortfin_TextToImage_SDXL_Client_Response.Body);
+    const decodedResource = yield* decodedBodyFrom(generationResponse).pipe(Effect.orDie);
     const [soleGeneratedImage] = decodedResource.images;
     return soleGeneratedImage;
-  });
+  }).pipe(
+    Effect.provide(FetchHttpClient.layer),
+  );
 }
 
 export {


### PR DESCRIPTION
- installs the [`@effect/platform` sub-package](https://effect.website/docs/platform/introduction/) to gain access to the `HttpClient` library
- There are two caveats to this that have deemed manageable:
  1. The `HttpClient` is still listed as "unstable", but by [the definition provided by `effect`](https://effect.website/docs/platform/introduction/#unstable-modules), so was the custom `HTTP` library being replaced
  2. This sub package does add about 75kb to the unzipped bundled size, but it provides tools that will help polish the testing infrastructure such as [`Filesystem`](https://effect.website/docs/platform/file-system/), [`Path`](https://effect.website/docs/platform/path/), and [`Runtime`](https://effect.website/docs/platform/runtime/) that would otherwise need to be written from scratch.