### PR TITLE
refactor: leverages `Effect` piping to improve clarity

### DIFF
--- a/src/features/TextToImage/Config/Dynamic/fetch.ts
+++ b/src/features/TextToImage/Config/Dynamic/fetch.ts
@@ -22,7 +22,7 @@ const TextToImage_Config_Dynamic_fetch: TextToImage_Config_Dynamic_Fetching.Effe
     from: TextToImage_Config_Dynamic_endpoint,
   });
 
-  const decodedConfigFromEndpoint = Schema.decodeUnknownSync(TextToImage_Config)(rawConfigFromEndpoint);
+  const decodedConfigFromEndpoint = yield* Schema.decodeUnknown(TextToImage_Config)(rawConfigFromEndpoint).pipe(Effect.orDie);
   return decodedConfigFromEndpoint;
 }).pipe(
   Effect.mapError($0 => new TextToImage_Config_Dynamic_Fetching.Error({

--- a/src/features/TextToImage/Config/Dynamic/fetch.ts
+++ b/src/features/TextToImage/Config/Dynamic/fetch.ts
@@ -20,16 +20,16 @@ import {
 const TextToImage_Config_Dynamic_fetch: TextToImage_Config_Dynamic_Fetching.Effect = Effect.gen(function* () {
   const rawConfigFromEndpoint = yield* HTTP.Client.local.fetchResource({
     from: TextToImage_Config_Dynamic_endpoint,
-  }).pipe(
-    Effect.mapError($0 => new TextToImage_Config_Dynamic_Fetching.Error({
-      endpoint: TextToImage_Config_Dynamic_endpoint,
-      cause   : $0,
-    })),
-  );
+  });
 
   const decodedConfigFromEndpoint = Schema.decodeUnknownSync(TextToImage_Config)(rawConfigFromEndpoint);
   return decodedConfigFromEndpoint;
-});
+}).pipe(
+  Effect.mapError($0 => new TextToImage_Config_Dynamic_Fetching.Error({
+    endpoint: TextToImage_Config_Dynamic_endpoint,
+    cause   : $0,
+  })),
+);
 
 export {
   TextToImage_Config_Dynamic_fetch,

--- a/src/features/TextToImage/Config/Static/read.ts
+++ b/src/features/TextToImage/Config/Static/read.ts
@@ -20,16 +20,16 @@ import {
 const TextToImage_Config_Static_read: TextToImage_Config_Static_Reading.Effect = Effect.gen(function* () {
   const rawConfigFromFile = yield* HTTP.Client.local.fetchResource({
     from: TextToImage_Config_Static_file,
-  }).pipe(
-    Effect.mapError($0 => new TextToImage_Config_Static_Reading.Error({
-      filePath: TextToImage_Config_Static_file,
-      cause   : $0,
-    })),
-  );
+  });
 
   const decodedConfigFromFile = Schema.decodeUnknownSync(TextToImage_Config)(rawConfigFromFile);
   return decodedConfigFromFile;
-});
+}).pipe(
+  Effect.mapError($0 => new TextToImage_Config_Static_Reading.Error({
+    filePath: TextToImage_Config_Static_file,
+    cause   : $0,
+  })),
+);
 
 export {
   TextToImage_Config_Static_read,

--- a/src/features/TextToImage/Config/Static/read.ts
+++ b/src/features/TextToImage/Config/Static/read.ts
@@ -22,7 +22,7 @@ const TextToImage_Config_Static_read: TextToImage_Config_Static_Reading.Effect =
     from: TextToImage_Config_Static_file,
   });
 
-  const decodedConfigFromFile = Schema.decodeUnknownSync(TextToImage_Config)(rawConfigFromFile);
+  const decodedConfigFromFile = yield* Schema.decodeUnknown(TextToImage_Config)(rawConfigFromFile).pipe(Effect.orDie);
   return decodedConfigFromFile;
 }).pipe(
   Effect.mapError($0 => new TextToImage_Config_Static_Reading.Error({

--- a/src/library/HTTP/Client.ts
+++ b/src/library/HTTP/Client.ts
@@ -81,12 +81,11 @@ class HTTP_Client {
       return yield* newResponseError;
     }
 
-    const digestedResponseBody = yield* Effect.mapError(
-      bodyOf(fetchedResponse).digestAsUnknown,
-      $0 => new HTTP_Endpoint.Error.IndigestibleResponseBody({
+    const digestedResponseBody = yield* bodyOf(fetchedResponse).digestAsUnknown.pipe(
+      Effect.mapError($0 => new HTTP_Endpoint.Error.IndigestibleResponseBody({
         endpoint: endpointURL,
         cause   : $0,
-      }),
+      })),
     );
 
     return digestedResponseBody;

--- a/src/library/Shortfin/TextToImage/SDXL/Client/definition.declared.ts
+++ b/src/library/Shortfin/TextToImage/SDXL/Client/definition.declared.ts
@@ -38,7 +38,7 @@ class Shortfin_TextToImage_SDXL_Client
       to       : URLComponent.Path('/generate'),
     });
 
-    const decodedResource = Schema.decodeUnknownSync(Shortfin_TextToImage_SDXL_Client_Response.Body)(rawResource);
+    const decodedResource = yield* Schema.decodeUnknown(Shortfin_TextToImage_SDXL_Client_Response.Body)(rawResource).pipe(Effect.orDie);
     const [soleGeneratedImage] = decodedResource.images;
     return soleGeneratedImage;
   });


### PR DESCRIPTION
- maps final errors _after_ constructing full `Effect`
- uses pipes for single step transforms to put "subject" closer to `=`
- pipes `Effect.orDie` whenever something is being coerced

Facilitates #1220 