### PR TITLE
refactor: extracts `decoded` anywhere `Schema.decode*` is used

### DIFF
--- a/src/features/TextToImage/Config/Dynamic/fetch.ts
+++ b/src/features/TextToImage/Config/Dynamic/fetch.ts
@@ -22,7 +22,8 @@ const TextToImage_Config_Dynamic_fetch: TextToImage_Config_Dynamic_Fetching.Effe
     from: TextToImage_Config_Dynamic_endpoint,
   });
 
-  const decodedConfigFromEndpoint = yield* Schema.decodeUnknown(TextToImage_Config)(rawConfigFromEndpoint).pipe(Effect.orDie);
+  const decoded = Schema.decodeUnknown(TextToImage_Config);
+  const decodedConfigFromEndpoint = yield* decoded(rawConfigFromEndpoint).pipe(Effect.orDie);
   return decodedConfigFromEndpoint;
 }).pipe(
   Effect.mapError($0 => new TextToImage_Config_Dynamic_Fetching.Error({

--- a/src/features/TextToImage/Config/Static/read.ts
+++ b/src/features/TextToImage/Config/Static/read.ts
@@ -22,7 +22,8 @@ const TextToImage_Config_Static_read: TextToImage_Config_Static_Reading.Effect =
     from: TextToImage_Config_Static_file,
   });
 
-  const decodedConfigFromFile = yield* Schema.decodeUnknown(TextToImage_Config)(rawConfigFromFile).pipe(Effect.orDie);
+  const decoded = Schema.decodeUnknown(TextToImage_Config);
+  const decodedConfigFromFile = yield* decoded(rawConfigFromFile).pipe(Effect.orDie);
   return decodedConfigFromFile;
 }).pipe(
   Effect.mapError($0 => new TextToImage_Config_Static_Reading.Error({

--- a/src/library/Shortfin/TextToImage/SDXL/Client/definition.declared.ts
+++ b/src/library/Shortfin/TextToImage/SDXL/Client/definition.declared.ts
@@ -38,7 +38,8 @@ class Shortfin_TextToImage_SDXL_Client
       to       : URLComponent.Path('/generate'),
     });
 
-    const decodedResource = yield* Schema.decodeUnknown(Shortfin_TextToImage_SDXL_Client_Response.Body)(rawResource).pipe(Effect.orDie);
+    const decoded = Schema.decodeUnknown(Shortfin_TextToImage_SDXL_Client_Response.Body);
+    const decodedResource = yield* decoded(rawResource).pipe(Effect.orDie);
     const [soleGeneratedImage] = decodedResource.images;
     return soleGeneratedImage;
   });


### PR DESCRIPTION
- helps avoid long lines and reduce rebase conflicts

Facilitates #1220