### PR TITLE
refactor(library/ShimmedStabilityAIClient): removes use of `HTTP`

### DIFF
--- a/src/library/ShimmedStabilityAIClient/Version1/Image.ts
+++ b/src/library/ShimmedStabilityAIClient/Version1/Image.ts
@@ -3,6 +3,10 @@ import {
   Either,
 } from 'effect';
 
+import {
+  ClientSDK,
+} from 'stabilityai-client-typescript/lib/sdks';
+
 import type {
   Image as StabilityAI_TextToImage_Pipeline_Output,
 } from 'stabilityai-client-typescript/models/components';
@@ -12,15 +16,20 @@ import type {
   GenerateFromTextResponse,
 } from 'stabilityai-client-typescript/models/operations';
 
-import HTTP from '@/library/HTTP';
+import type HTTP from '@/library/HTTP';
 import Shortfin from '@/library/Shortfin';
+import URLComponent from '@/library/URLComponent';
 
 import {
   toShortfinRequestBody,
 } from '../toShortfinRequestBody';
 
 class ShimmedStabilityAIClient_Version1_Image
-  extends HTTP.Client {
+  extends ClientSDK {
+  private get origin(): URLComponent.Origin {
+    return URLComponent.Origin(this._options.serverURL ?? '');
+  }
+
   private safelyGenerateFromText = (
     givenRequest: GenerateFromTextRequest,
   ): Effect.Effect<

--- a/src/library/ShimmedStabilityAIClient/Version1/definition.declared.ts
+++ b/src/library/ShimmedStabilityAIClient/Version1/definition.declared.ts
@@ -1,15 +1,17 @@
-import HTTP from '@/library/HTTP';
+import {
+  ClientSDK,
+} from 'stabilityai-client-typescript/lib/sdks';
 
 import {
   ShimmedStabilityAIClient_Version1_Image,
 } from './Image';
 
 class ShimmedStabilityAIClient_Version1
-  extends HTTP.Client {
+  extends ClientSDK {
   private cachedClient?: ShimmedStabilityAIClient_Version1_Image;
 
   public get image(): ShimmedStabilityAIClient_Version1_Image {
-    this.cachedClient ??= new ShimmedStabilityAIClient_Version1_Image(this.origin);
+    this.cachedClient ??= new ShimmedStabilityAIClient_Version1_Image(this._options);
     return this.cachedClient;
   }
 }

--- a/src/library/ShimmedStabilityAIClient/definition.declared.ts
+++ b/src/library/ShimmedStabilityAIClient/definition.declared.ts
@@ -1,26 +1,17 @@
-import HTTP from '@/library/HTTP';
-import URLComponent from '@/library/URLComponent';
+import {
+  ClientSDK,
+} from 'stabilityai-client-typescript/lib/sdks';
 
 import {
   ShimmedStabilityAIClient_Version1,
 } from './Version1';
 
 class ShimmedStabilityAIClient
-  extends HTTP.Client {
-  public constructor(given: {
-    serverURL: string;
-  }) {
-    const serverOrigin = URLComponent.Origin(given.serverURL);
-
-    super(
-      serverOrigin,
-    );
-  }
-
+  extends ClientSDK {
   private cachedClient?: ShimmedStabilityAIClient_Version1;
 
   public get version1(): ShimmedStabilityAIClient_Version1 {
-    this.cachedClient ??= new ShimmedStabilityAIClient_Version1(this.origin);
+    this.cachedClient ??= new ShimmedStabilityAIClient_Version1(this._options);
     return this.cachedClient;
   }
 }


### PR DESCRIPTION
- With a dedicated `Shortfin` SDK, there was no longer a need to subclass `HTTP`
- The original `ClientSDK` is sufficient to coordinate the layers just like in the actual `StabilityAIClient`