### PR TITLE
linter(IDE): extracts "dictionary.stability-ai.txt"

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,5 @@
 {
     "cSpell.words": [
-        "SDXL",
-        "stabilityai",
         "vite",
         "vitest",
         "vuetify"
@@ -17,6 +15,12 @@
             "name": "library/Shortfin",
             "path": "./src/library/Shortfin/dictionary.txt",
             "description": "Words introduced by the @/library/Shortfin module",
+            "addWords": false
+        },
+        "stability-ai": {
+            "name": "stability-ai",
+            "path": "./dictionary.stability-ai.txt",
+            "description": "Words introduced by the stability-ai organization",
             "addWords": false
         },
     },

--- a/dictionary.stability-ai.txt
+++ b/dictionary.stability-ai.txt
@@ -1,0 +1,2 @@
+SDXL
+stabilityai


### PR DESCRIPTION
- sandboxes the group of words under the "Stability AI" umbrella

Establishes precedent for #1229