### PR TITLE
refactor: absorbs sparse operand handling into `concatenated`

### DIFF
--- a/src/library/ContentDescriptor/definition.declared.ts
+++ b/src/library/ContentDescriptor/definition.declared.ts
@@ -74,11 +74,11 @@ class ContentDescriptor {
 
   public get serialized(): NonTrivialString {
     const orderedComponents = [
-      /*       */ this.serializableTopLevelDescriptor,
-      /*       */ this.serializableTree,
-      /*       */ this.bottomLevelDescriptor,
-      /*       */ this.serializableStructureDescriptor,
-      /*       */ this.serializableParameters,
+      this.serializableTopLevelDescriptor,
+      this.serializableTree,
+      this.bottomLevelDescriptor,
+      this.serializableStructureDescriptor,
+      this.serializableParameters,
     ];
 
     const serializedComponents = concatenated(...orderedComponents);

--- a/src/library/ContentDescriptor/definition.declared.ts
+++ b/src/library/ContentDescriptor/definition.declared.ts
@@ -73,7 +73,7 @@ class ContentDescriptor {
   }
 
   public get serialized(): NonTrivialString {
-    const orderedComponents: Option.Option<string>[] = [
+    const orderedComponents = [
       Option.some(this.serializableTopLevelDescriptor),
       /*       */ this.serializableTree,
       Option.some(this.bottomLevelDescriptor),

--- a/src/library/ContentDescriptor/definition.declared.ts
+++ b/src/library/ContentDescriptor/definition.declared.ts
@@ -74,9 +74,9 @@ class ContentDescriptor {
 
   public get serialized(): NonTrivialString {
     const orderedComponents = [
-      Option.some(this.serializableTopLevelDescriptor),
+      /*       */ this.serializableTopLevelDescriptor,
       /*       */ this.serializableTree,
-      Option.some(this.bottomLevelDescriptor),
+      /*       */ this.bottomLevelDescriptor,
       /*       */ this.serializableStructureDescriptor,
       /*       */ this.serializableParameters,
     ];

--- a/src/library/ContentDescriptor/definition.declared.ts
+++ b/src/library/ContentDescriptor/definition.declared.ts
@@ -1,5 +1,4 @@
 import {
-  Array,
   Option,
 } from 'effect';
 
@@ -82,8 +81,7 @@ class ContentDescriptor {
       /*       */ this.serializableParameters,
     ];
 
-    const orderedComponents = Array.getSomes(sparseOrderedComponents);
-    const serializedComponents = concatenated(...orderedComponents);
+    const serializedComponents = concatenated(...sparseOrderedComponents);
     return NonTrivialString(serializedComponents);
   }
 }

--- a/src/library/ContentDescriptor/definition.declared.ts
+++ b/src/library/ContentDescriptor/definition.declared.ts
@@ -73,7 +73,7 @@ class ContentDescriptor {
   }
 
   public get serialized(): NonTrivialString {
-    const sparseOrderedComponents: Option.Option<string>[] = [
+    const orderedComponents: Option.Option<string>[] = [
       Option.some(this.serializableTopLevelDescriptor),
       /*       */ this.serializableTree,
       Option.some(this.bottomLevelDescriptor),
@@ -81,7 +81,7 @@ class ContentDescriptor {
       /*       */ this.serializableParameters,
     ];
 
-    const serializedComponents = concatenated(...sparseOrderedComponents);
+    const serializedComponents = concatenated(...orderedComponents);
     return NonTrivialString(serializedComponents);
   }
 }

--- a/src/library/URI/Data/definition.declared.ts
+++ b/src/library/URI/Data/definition.declared.ts
@@ -60,9 +60,9 @@ class URI_Data
 
   public override get path(): NonTrivialString {
     const orderedPathComponents = [
-      /*       */ this.descriptor.serialized,
-      /*       */ this.serializableEncoding,
-      /*       */ this.serializableData,
+      this.descriptor.serialized,
+      this.serializableEncoding,
+      this.serializableData,
     ];
 
     const serializedPathComponents = concatenated(...orderedPathComponents);

--- a/src/library/URI/Data/definition.declared.ts
+++ b/src/library/URI/Data/definition.declared.ts
@@ -59,13 +59,13 @@ class URI_Data
   }
 
   public override get path(): NonTrivialString {
-    const sparseOrderedPathComponents: Option.Option<string>[] = [
+    const orderedPathComponents: Option.Option<string>[] = [
       Option.some(this.descriptor.serialized),
       /*       */ this.serializableEncoding,
       Option.some(this.serializableData),
     ];
 
-    const serializedPathComponents = concatenated(...sparseOrderedPathComponents);
+    const serializedPathComponents = concatenated(...orderedPathComponents);
     return NonTrivialString(serializedPathComponents);
   }
 }

--- a/src/library/URI/Data/definition.declared.ts
+++ b/src/library/URI/Data/definition.declared.ts
@@ -59,7 +59,7 @@ class URI_Data
   }
 
   public override get path(): NonTrivialString {
-    const orderedPathComponents: Option.Option<string>[] = [
+    const orderedPathComponents = [
       Option.some(this.descriptor.serialized),
       /*       */ this.serializableEncoding,
       Option.some(this.serializableData),

--- a/src/library/URI/Data/definition.declared.ts
+++ b/src/library/URI/Data/definition.declared.ts
@@ -60,9 +60,9 @@ class URI_Data
 
   public override get path(): NonTrivialString {
     const orderedPathComponents = [
-      Option.some(this.descriptor.serialized),
+      /*       */ this.descriptor.serialized,
       /*       */ this.serializableEncoding,
-      Option.some(this.serializableData),
+      /*       */ this.serializableData,
     ];
 
     const serializedPathComponents = concatenated(...orderedPathComponents);

--- a/src/library/URI/Data/definition.declared.ts
+++ b/src/library/URI/Data/definition.declared.ts
@@ -1,5 +1,4 @@
 import {
-  Array,
   Option,
 } from 'effect';
 
@@ -66,8 +65,7 @@ class URI_Data
       Option.some(this.serializableData),
     ];
 
-    const orderedPathComponents = Array.getSomes(sparseOrderedPathComponents);
-    const serializedPathComponents = concatenated(...orderedPathComponents);
+    const serializedPathComponents = concatenated(...sparseOrderedPathComponents);
     return NonTrivialString(serializedPathComponents);
   }
 }

--- a/src/library/URI/definition.declared.ts
+++ b/src/library/URI/definition.declared.ts
@@ -1,5 +1,4 @@
 import {
-  Array,
   Option,
 } from 'effect';
 
@@ -77,8 +76,7 @@ class URI {
       /*       */ this.serializableFragment,
     ];
 
-    const orderedComponents = Array.getSomes(sparseOrderedComponents);
-    const serializedComponents = concatenated(...orderedComponents);
+    const serializedComponents = concatenated(...sparseOrderedComponents);
     return serializedComponents;
   }
 }

--- a/src/library/URI/definition.declared.ts
+++ b/src/library/URI/definition.declared.ts
@@ -69,11 +69,11 @@ class URI {
 
   public get serialized(): string {
     const orderedComponents = [
-      /*       */ this.serializableScheme,
-      /*       */ this.serializableAuthority,
-      /*       */ this.path,
-      /*       */ this.serializableQuery,
-      /*       */ this.serializableFragment,
+      this.serializableScheme,
+      this.serializableAuthority,
+      this.path,
+      this.serializableQuery,
+      this.serializableFragment,
     ];
 
     const serializedComponents = concatenated(...orderedComponents);

--- a/src/library/URI/definition.declared.ts
+++ b/src/library/URI/definition.declared.ts
@@ -68,7 +68,7 @@ class URI {
   }
 
   public get serialized(): string {
-    const orderedComponents: Option.Option<string>[] = [
+    const orderedComponents = [
       Option.some(this.serializableScheme),
       /*       */ this.serializableAuthority,
       Option.some(this.path),

--- a/src/library/URI/definition.declared.ts
+++ b/src/library/URI/definition.declared.ts
@@ -68,7 +68,7 @@ class URI {
   }
 
   public get serialized(): string {
-    const sparseOrderedComponents: Option.Option<string>[] = [
+    const orderedComponents: Option.Option<string>[] = [
       Option.some(this.serializableScheme),
       /*       */ this.serializableAuthority,
       Option.some(this.path),
@@ -76,7 +76,7 @@ class URI {
       /*       */ this.serializableFragment,
     ];
 
-    const serializedComponents = concatenated(...sparseOrderedComponents);
+    const serializedComponents = concatenated(...orderedComponents);
     return serializedComponents;
   }
 }

--- a/src/library/URI/definition.declared.ts
+++ b/src/library/URI/definition.declared.ts
@@ -69,9 +69,9 @@ class URI {
 
   public get serialized(): string {
     const orderedComponents = [
-      Option.some(this.serializableScheme),
+      /*       */ this.serializableScheme,
       /*       */ this.serializableAuthority,
-      Option.some(this.path),
+      /*       */ this.path,
       /*       */ this.serializableQuery,
       /*       */ this.serializableFragment,
     ];

--- a/src/library/utilitiesByType/string/concatenated.ts
+++ b/src/library/utilitiesByType/string/concatenated.ts
@@ -9,6 +9,7 @@ const concatenated = (
   )[]
 ): string => pipe(
   givenOperands,
+  Array.map($0 => $0),
   Array.join(''),
 );
 

--- a/src/library/utilitiesByType/string/concatenated.ts
+++ b/src/library/utilitiesByType/string/concatenated.ts
@@ -4,7 +4,9 @@ import {
 } from 'effect';
 
 const concatenated = (
-  ...givenOperands: string[]
+  ...givenOperands: (
+    | string
+  )[]
 ): string => pipe(
   givenOperands,
   Array.join(''),

--- a/src/library/utilitiesByType/string/concatenated.ts
+++ b/src/library/utilitiesByType/string/concatenated.ts
@@ -1,9 +1,14 @@
+import {
+  Array,
+  pipe,
+} from 'effect';
+
 const concatenated = (
   ...givenOperands: string[]
-): string => {
-  return givenOperands
-    .join('');
-};
+): string => pipe(
+  givenOperands,
+  Array.join(''),
+);
 
 export {
   concatenated,

--- a/src/library/utilitiesByType/string/concatenated.ts
+++ b/src/library/utilitiesByType/string/concatenated.ts
@@ -1,7 +1,8 @@
 const concatenated = (
   ...givenOperands: string[]
 ): string => {
-  return givenOperands.join('');
+  return givenOperands
+    .join('');
 };
 
 export {

--- a/src/library/utilitiesByType/string/concatenated.ts
+++ b/src/library/utilitiesByType/string/concatenated.ts
@@ -1,15 +1,22 @@
 import {
   Array,
+  Option,
   pipe,
 } from 'effect';
 
+import {
+  isString,
+} from 'effect/Predicate';
+
 const concatenated = (
   ...givenOperands: (
-    | string
+    | /*         */ string
+    | Option.Option<string>
   )[]
 ): string => pipe(
   givenOperands,
-  Array.map($0 => $0),
+  Array.map($0 => isString($0) ? Option.some($0) : $0),
+  Array.getSomes,
   Array.join(''),
 );
 


### PR DESCRIPTION
- before, `concatenated` was a nearly extraneous wrapper for `.join('')`
- the choices were either a) dissolve it or b) have it do something more useful
- choice b) ended up simplifying a few implementations