### PR TITLE
refactor: leverages `Option.gen`

### DIFF
--- a/src/features/TextToImage/Client/SDXL/toSharkUIOutput/Image/definition.declared.ts
+++ b/src/features/TextToImage/Client/SDXL/toSharkUIOutput/Image/definition.declared.ts
@@ -17,18 +17,20 @@ function toSharkUIOutput_Image(
     description: TextToImage_Pipeline.Output['image']['description'];
   },
 ): Option.Option<TextToImage_Pipeline.Output['image']> {
-  if (
-    givenImage.base64 === undefined
-  ) return Option.none();
+  return Option.gen(function* () {
+    if (
+      givenImage.base64 === undefined
+    ) return yield* Option.none();
 
-  const base64DataOfRawImage = Sequence.Byte.Encoded.Base64(givenImage.base64);
+    const base64DataOfRawImage = Sequence.Byte.Encoded.Base64(givenImage.base64);
 
-  const derivedImage = {
-    uri        : new URI.Image('png', 'base64', base64DataOfRawImage),
-    description: given.description,
-  };
+    const derivedImage = {
+      uri        : new URI.Image('png', 'base64', base64DataOfRawImage),
+      description: given.description,
+    };
 
-  return Option.some(derivedImage);
+    return derivedImage;
+  });
 }
 
 export {

--- a/src/features/TextToImage/Client/SDXL/toSharkUIOutput/plural.ts
+++ b/src/features/TextToImage/Client/SDXL/toSharkUIOutput/plural.ts
@@ -23,24 +23,21 @@ const toSharkUIOutput_plural = (
     in: GenerateFromTextResponse;
     inferredFrom: TextToImage_Pipeline.Input['text'];
   },
-): Option.Option<Option.Option<TextToImage_Pipeline.Output>[]> => {
+): Option.Option<Option.Option<TextToImage_Pipeline.Output>[]> => Option.gen(function* () {
   if (
     !('artifacts' in givenResponse.result)
   ) return Effect.dieMessage('Expected response body rather than readable stream').pipe(Effect.runSync);
 
-  const inferredRawImages = Option.fromNullable(givenResponse.result.artifacts);
+  const inferredRawImages = yield* Option.fromNullable(givenResponse.result.artifacts);
 
-  const inferredOutputs = Option.map(
-    inferredRawImages,
-    ($0) => $0
-      .map(($0) => toSharkUIOutput_Image($0, {
-        description: toSharkUIOutput_Image.Description.all(givenInputText),
-      }))
-      .map(($0) => TextToImage_Pipeline.Output.Option.from($0)),
-  );
+  const inferredOutputs = inferredRawImages
+    .map(($0) => toSharkUIOutput_Image($0, {
+      description: toSharkUIOutput_Image.Description.all(givenInputText),
+    }))
+    .map(($0) => TextToImage_Pipeline.Output.Option.from($0));
 
   return inferredOutputs;
-};
+});
 
 export {
   toSharkUIOutput_plural,

--- a/src/features/TextToImage/Pipeline/Output/Option/from.ts
+++ b/src/features/TextToImage/Pipeline/Output/Option/from.ts
@@ -8,12 +8,11 @@ import type {
 
 const TextToImage_Pipeline_Output_Option_from = (
   givenImage: Option.Option<TextToImage_Pipeline_Output['image']>,
-): Option.Option<TextToImage_Pipeline_Output> => Option.map(
-  givenImage,
-  ($0) => ({
-    image: $0,
-  }),
-);
+): Option.Option<TextToImage_Pipeline_Output> => Option.gen(function* () {
+  return {
+    image: yield* givenImage,
+  };
+});
 
 export {
   TextToImage_Pipeline_Output_Option_from,

--- a/src/features/TextToImage/Server/Current/accordingToEnvironment.ts
+++ b/src/features/TextToImage/Server/Current/accordingToEnvironment.ts
@@ -8,18 +8,15 @@ import {
   TextToImage_Server_Origin,
 } from '../Origin';
 
-const TextToImage_Server_Current_accordingToEnvironment = ((): Option.Option<WebAPI.Server> => {
-  const originAccordingToEnvironment = Option.fromNullable(import.meta.env[TextToImage_Server_Origin.environmentKey]);
+const TextToImage_Server_Current_accordingToEnvironment = Option.gen(function* () {
+  const originAccordingToEnvironment = yield* Option.fromNullable(import.meta.env[TextToImage_Server_Origin.environmentKey]);
 
-  const serverAccordingToEnvironment = Option.map(
-    originAccordingToEnvironment,
-    ($0) => new WebAPI.Server({
-      origin: $0,
-    }),
-  );
+  const serverAccordingToEnvironment = new WebAPI.Server({
+    origin: originAccordingToEnvironment,
+  });
 
   return serverAccordingToEnvironment;
-})();
+});
 
 export {
   TextToImage_Server_Current_accordingToEnvironment,

--- a/src/library/ContentDescriptor/definition.declared.ts
+++ b/src/library/ContentDescriptor/definition.declared.ts
@@ -36,41 +36,28 @@ class ContentDescriptor {
 
   public static readonly treeBranchSuffix = '.';
 
-  private get serializableTree(): Option.Option<string> {
-    return Option.map(
-      this.tree,
-      ($0) => {
-        const suffixedTreeBranches = $0.map(($0) => $0.concat(ContentDescriptor.treeBranchSuffix));
-        const serializedTreeBranches = concatenated(...suffixedTreeBranches);
-        return serializedTreeBranches;
-      },
-    );
-  }
+  private readonly serializableTree = Option.gen(this, function* () {
+    const suffixedTreeBranches = (yield* this.tree).map(($0) => $0.concat(ContentDescriptor.treeBranchSuffix));
+    const serializedTreeBranches = concatenated(...suffixedTreeBranches);
+    return serializedTreeBranches;
+  });
 
   public static readonly structureDescriptorPrefix = '+';
 
-  private get serializableStructureDescriptor(): Option.Option<string> {
-    return Option.map(
-      this.structureDescriptor,
-      ($0) => ContentDescriptor.structureDescriptorPrefix.concat($0),
-    );
-  }
+  private readonly serializableStructureDescriptor = Option.gen(this, function* () {
+    return ContentDescriptor.structureDescriptorPrefix.concat(yield* this.structureDescriptor);
+  });
 
   public static readonly parameterPrefix = ';';
   public static readonly parameterKeyValueDelimiter = '=';
 
-  private get serializableParameters(): Option.Option<string> {
-    return Option.map(
-      this.parameters,
-      ($0) => {
-        const serializableParameterEntries = Object.entries($0)
-          .map(($0) => $0.join(ContentDescriptor.parameterKeyValueDelimiter))
-          .map(($0) => ContentDescriptor.parameterPrefix.concat($0));
+  private readonly serializableParameters = Option.gen(this, function* () {
+    const serializableParameterEntries = Object.entries(yield* this.parameters)
+      .map(($0) => $0.join(ContentDescriptor.parameterKeyValueDelimiter))
+      .map(($0) => ContentDescriptor.parameterPrefix.concat($0));
 
-        return concatenated(...serializableParameterEntries);
-      },
-    );
-  }
+    return concatenated(...serializableParameterEntries);
+  });
 
   public get serialized(): NonTrivialString {
     const orderedComponents = [

--- a/src/library/NonTrivialString.ts
+++ b/src/library/NonTrivialString.ts
@@ -12,19 +12,16 @@ type NonTrivialString = Brand.Branded<
 const NonTrivialString = Brand.refined<
   NonTrivialString
 >(
-  (someString) => {
+  (someString) => Option.gen(function* () {
     const resultOfDecodingTrivialString = Schema.decodeEither(Schema.NonEmptyTrimmedString)(someString);
-    const potentialParsingError = Option.getLeft(resultOfDecodingTrivialString);
+    const parsingError = yield* Option.getLeft(resultOfDecodingTrivialString);
 
-    const potentialRefinementError = Option.map(
-      potentialParsingError,
-      ($0) => Brand.error(`Expected string to contain something beyond just whitespace, got "${someString}"`, {
-        cause: $0,
-      }),
-    );
+    const refinementError = Brand.error(`Expected string to contain something beyond just whitespace, got "${someString}"`, {
+      cause: parsingError,
+    });
 
-    return potentialRefinementError;
-  },
+    return refinementError;
+  }),
 );
 
 export {

--- a/src/library/Sequence/Byte/Encoded/Base64.ts
+++ b/src/library/Sequence/Byte/Encoded/Base64.ts
@@ -13,19 +13,16 @@ type Sequence_Byte_Encoded_Base64 = Brand.Branded<
 const Sequence_Byte_Encoded_Base64 = Brand.refined<
   Sequence_Byte_Encoded_Base64
 >(
-  (someString) => {
+  (someString) => Option.gen(function* () {
     const resultOfDecodingByteSequence = Encoding.decodeBase64(someString);
-    const potentialParsingError = Option.getLeft(resultOfDecodingByteSequence);
+    const parsingError = yield* Option.getLeft(resultOfDecodingByteSequence);
 
-    const potentialRefinementError = Option.map(
-      potentialParsingError,
-      ($0) => Brand.error('String is not valid Base64-encoded byte sequence', {
-        cause: $0,
-      }),
-    );
+    const refinementError = Brand.error('String is not valid Base64-encoded byte sequence', {
+      cause: parsingError,
+    });
 
-    return potentialRefinementError;
-  },
+    return refinementError;
+  }),
 );
 
 export {

--- a/src/library/ShimmedStabilityAIClient/toShortfinRequestBody/definition.declared.ts
+++ b/src/library/ShimmedStabilityAIClient/toShortfinRequestBody/definition.declared.ts
@@ -15,29 +15,31 @@ import {
 function toShortfinRequestBody(
   givenRequestBody: GenerateFromTextRequest['textToImageRequestBody'],
 ): Option.Option<Shortfin.TextToImage.SDXL.Client.Request.Body> {
-  if (
-    (givenRequestBody.height === undefined)
-    || (givenRequestBody.width === undefined)
-    || (givenRequestBody.steps === undefined)
-    || (givenRequestBody.cfgScale === undefined)
-    || (givenRequestBody.seed === undefined)
-  ) return Option.none();
+  return Option.gen(function* () {
+    if (
+      (givenRequestBody.height === undefined)
+      || (givenRequestBody.width === undefined)
+      || (givenRequestBody.steps === undefined)
+      || (givenRequestBody.cfgScale === undefined)
+      || (givenRequestBody.seed === undefined)
+    ) return yield* Option.none();
 
-  const derivedShortfinRequestBody = {
-    prompt: toShortfinRequestBody_Prompt(givenRequestBody.textPrompts, {
-      weight: 1,
-    }),
-    neg_prompt: toShortfinRequestBody_Prompt(givenRequestBody.textPrompts, {
-      weight: -1,
-    }),
-    height        : givenRequestBody.height,
-    width         : givenRequestBody.width,
-    steps         : givenRequestBody.steps,
-    guidance_scale: givenRequestBody.cfgScale,
-    seed          : givenRequestBody.seed,
-  };
+    const derivedShortfinRequestBody = {
+      prompt: toShortfinRequestBody_Prompt(givenRequestBody.textPrompts, {
+        weight: 1,
+      }),
+      neg_prompt: toShortfinRequestBody_Prompt(givenRequestBody.textPrompts, {
+        weight: -1,
+      }),
+      height        : givenRequestBody.height,
+      width         : givenRequestBody.width,
+      steps         : givenRequestBody.steps,
+      guidance_scale: givenRequestBody.cfgScale,
+      seed          : givenRequestBody.seed,
+    };
 
-  return Option.some(derivedShortfinRequestBody);
+    return derivedShortfinRequestBody;
+  });
 }
 
 export {

--- a/src/library/URI/Data/definition.declared.ts
+++ b/src/library/URI/Data/definition.declared.ts
@@ -42,14 +42,14 @@ class URI_Data
 
   public static readonly encodingPrefix = ';';
 
-  public get serializableEncoding(): Option.Option<string> {
+  public readonly serializableEncoding = Option.gen(this, function* () {
     if (
       this.encoding !== 'base64'
-    ) return Option.none();
+    ) return yield* Option.none();
 
     const prefixedEncoding = URI_Data.encodingPrefix.concat(this.encoding);
-    return Option.some(prefixedEncoding);
-  }
+    return prefixedEncoding;
+  });
 
   public static readonly dataPrefix = ',';
 

--- a/src/library/URI/definition.declared.ts
+++ b/src/library/URI/definition.declared.ts
@@ -35,12 +35,9 @@ class URI {
 
   public static readonly authorityPrefix = '//';
 
-  private get serializableAuthority(): Option.Option<string> {
-    return Option.map(
-      this.authority,
-      ($0) => URI.authorityPrefix.concat($0),
-    );
-  }
+  private readonly serializableAuthority = Option.gen(this, function* () {
+    return URI.authorityPrefix.concat(yield* this.authority);
+  });
 
   public get path(): Option.Option.Value<URI['overridablePath']> {
     return Option.getOrThrowWith(
@@ -51,21 +48,15 @@ class URI {
 
   public static readonly queryPrefix = '?';
 
-  private get serializableQuery(): Option.Option<string> {
-    return Option.map(
-      this.query,
-      ($0) => URI.queryPrefix.concat($0),
-    );
-  }
+  private readonly serializableQuery = Option.gen(this, function* () {
+    return URI.queryPrefix.concat(yield* this.query);
+  });
 
   public static readonly fragmentPrefix = '#';
 
-  private get serializableFragment(): Option.Option<string> {
-    return Option.map(
-      this.fragment,
-      ($0) => URI.fragmentPrefix.concat($0),
-    );
-  }
+  private readonly serializableFragment = Option.gen(this, function* () {
+    return URI.fragmentPrefix.concat(yield* this.fragment);
+  });
 
   public get serialized(): string {
     const orderedComponents = [

--- a/src/library/URLComponent/Origin.ts
+++ b/src/library/URLComponent/Origin.ts
@@ -11,16 +11,15 @@ type URLComponent_Origin = Brand.Branded<
 const URLComponent_Origin = Brand.refined<
   URLComponent_Origin
 >(
-  (someString) => {
+  (someString) => Option.gen(function* () {
     const derivedURL = new URL(someString);
 
     if (
       someString === derivedURL.origin
-    ) return Option.none();
+    ) return yield* Option.none();
 
-    const newRefinementError = Brand.error(`Expected pure origin: "${derivedURL.origin}", got "${someString}"`);
-    return Option.some(newRefinementError);
-  },
+    return Brand.error(`Expected pure origin: "${derivedURL.origin}", got "${someString}"`);
+  }),
 );
 
 export {

--- a/src/library/URLComponent/Path.ts
+++ b/src/library/URLComponent/Path.ts
@@ -11,16 +11,15 @@ type URLComponent_Path = Brand.Branded<
 const URLComponent_Path = Brand.refined<
   URLComponent_Path
 >(
-  (someString) => {
+  (someString) => Option.gen(function* () {
     const exampleURL = new URL(`https://example.com${someString}`);
 
     if (
       someString === exampleURL.pathname
-    ) return Option.none();
+    ) return yield* Option.none();
 
-    const newBrandError = Brand.error(`Expected pure path: "${exampleURL.pathname}", got "${someString}"`);
-    return Option.some(newBrandError);
-  },
+    return Brand.error(`Expected pure path: "${exampleURL.pathname}", got "${someString}"`);
+  }),
 );
 
 export {


### PR DESCRIPTION
- allows for more concise and conventional-looking function bodies
- also makes it easier to convert to `Effect.gen` where applicable