### PR TITLE
linter: enforces use of arrow parentheses

### DIFF
--- a/eslint.stylistic.ts
+++ b/eslint.stylistic.ts
@@ -10,6 +10,10 @@ const extraConfig: ConfigWithExtends = {
     '@stylistic': stylistic,
   },
   rules: {
+    '@stylistic/arrow-parens': [
+      'error',
+      'always', // Helps minimize diffs and mitigate merge conflicts.
+    ],
     '@stylistic/function-call-argument-newline': [
       'error',
       'consistent', // Helps minimize diffs and mitigate merge conflicts.

--- a/src/components/DiscreteSlider.vue
+++ b/src/components/DiscreteSlider.vue
@@ -103,7 +103,7 @@ const tickLabelsAlong = (
     by  : givenStepSize,
   });
 
-  const labelSets = tickRange.inclusiveSteps.map(eachPosition => tickLabels({
+  const labelSets = tickRange.inclusiveSteps.map((eachPosition) => tickLabels({
     by: eachPosition,
     in: tickRange,
   }));

--- a/src/features/TextToImage/Client/SDXL/toSharkUIOutput/plural.ts
+++ b/src/features/TextToImage/Client/SDXL/toSharkUIOutput/plural.ts
@@ -32,11 +32,11 @@ const toSharkUIOutput_plural = (
 
   const inferredOutputs = Option.map(
     inferredRawImages,
-    $0 => $0
-      .map($0 => toSharkUIOutput_Image($0, {
+    ($0) => $0
+      .map(($0) => toSharkUIOutput_Image($0, {
         description: toSharkUIOutput_Image.Description.all(givenInputText),
       }))
-      .map($0 => TextToImage_Pipeline.Output.Option.from($0)),
+      .map(($0) => TextToImage_Pipeline.Output.Option.from($0)),
   );
 
   return inferredOutputs;

--- a/src/features/TextToImage/Config/Dynamic/fetch.ts
+++ b/src/features/TextToImage/Config/Dynamic/fetch.ts
@@ -26,7 +26,7 @@ const TextToImage_Config_Dynamic_fetch: TextToImage_Config_Dynamic_Fetching.Effe
   const decodedConfigFromEndpoint = yield* decodedBodyFrom(endpointResponse).pipe(Effect.orDie);
   return decodedConfigFromEndpoint;
 }).pipe(
-  Effect.mapError($0 => new TextToImage_Config_Dynamic_Fetching.Error({
+  Effect.mapError(($0) => new TextToImage_Config_Dynamic_Fetching.Error({
     endpoint: TextToImage_Config_Dynamic_endpoint,
     cause   : $0,
   })),

--- a/src/features/TextToImage/Config/Static/read.ts
+++ b/src/features/TextToImage/Config/Static/read.ts
@@ -26,7 +26,7 @@ const TextToImage_Config_Static_read: TextToImage_Config_Static_Reading.Effect =
   const decodedConfigFromFile = yield* decodedBodyFrom(fileResponse).pipe(Effect.orDie);
   return decodedConfigFromFile;
 }).pipe(
-  Effect.mapError($0 => new TextToImage_Config_Static_Reading.Error({
+  Effect.mapError(($0) => new TextToImage_Config_Static_Reading.Error({
     filePath: TextToImage_Config_Static_file,
     cause   : $0,
   })),

--- a/src/features/TextToImage/Pipeline/Output/Option/from.ts
+++ b/src/features/TextToImage/Pipeline/Output/Option/from.ts
@@ -10,7 +10,7 @@ const TextToImage_Pipeline_Output_Option_from = (
   givenImage: Option.Option<TextToImage_Pipeline_Output['image']>,
 ): Option.Option<TextToImage_Pipeline_Output> => Option.map(
   givenImage,
-  $0 => ({
+  ($0) => ({
     image: $0,
   }),
 );

--- a/src/features/TextToImage/Server/Current/accordingToEnvironment.ts
+++ b/src/features/TextToImage/Server/Current/accordingToEnvironment.ts
@@ -13,7 +13,7 @@ const TextToImage_Server_Current_accordingToEnvironment = ((): Option.Option<Web
 
   const serverAccordingToEnvironment = Option.map(
     originAccordingToEnvironment,
-    $0 => new WebAPI.Server({
+    ($0) => new WebAPI.Server({
       origin: $0,
     }),
   );

--- a/src/features/TextToImage/components/TextToImageInputSection.vue
+++ b/src/features/TextToImage/components/TextToImageInputSection.vue
@@ -55,8 +55,8 @@ const byQualitativeWeight = (givenInputText: StandardizedInputText): InputTextBy
   const entriesForInputTextByQualitativeWeight = Object.entries(qualitativeToQuantitativeTextWeightMap)
     .map(([eachUnsafeQualitativeWeight, eachQuantitativeWeight]) => {
       const eachSerializationByWeight = givenInputText
-        .filter($0 => $0.weight === eachQuantitativeWeight)
-        .map($0 => $0.text.trim())
+        .filter(($0) => $0.weight === eachQuantitativeWeight)
+        .map(($0) => $0.text.trim())
         .join(', ');
 
       const eachDerivedEntry = [
@@ -101,7 +101,7 @@ const initialInputText: InputTextByQualitativeWeight = (() => {
 
   return Option.match(initialExposedInputText, {
     onNone: () => defaultInitialInputText,
-    onSome: $0 => byQualitativeWeight($0),
+    onSome: ($0) => byQualitativeWeight($0),
   });
 })();
 

--- a/src/library/ContentDescriptor/definition.declared.ts
+++ b/src/library/ContentDescriptor/definition.declared.ts
@@ -40,7 +40,7 @@ class ContentDescriptor {
     return Option.map(
       this.tree,
       ($0) => {
-        const suffixedTreeBranches = $0.map($0 => $0.concat(ContentDescriptor.treeBranchSuffix));
+        const suffixedTreeBranches = $0.map(($0) => $0.concat(ContentDescriptor.treeBranchSuffix));
         const serializedTreeBranches = concatenated(...suffixedTreeBranches);
         return serializedTreeBranches;
       },
@@ -52,7 +52,7 @@ class ContentDescriptor {
   private get serializableStructureDescriptor(): Option.Option<string> {
     return Option.map(
       this.structureDescriptor,
-      $0 => ContentDescriptor.structureDescriptorPrefix.concat($0),
+      ($0) => ContentDescriptor.structureDescriptorPrefix.concat($0),
     );
   }
 
@@ -64,8 +64,8 @@ class ContentDescriptor {
       this.parameters,
       ($0) => {
         const serializableParameterEntries = Object.entries($0)
-          .map($0 => $0.join(ContentDescriptor.parameterKeyValueDelimiter))
-          .map($0 => ContentDescriptor.parameterPrefix.concat($0));
+          .map(($0) => $0.join(ContentDescriptor.parameterKeyValueDelimiter))
+          .map(($0) => ContentDescriptor.parameterPrefix.concat($0));
 
         return concatenated(...serializableParameterEntries);
       },

--- a/src/library/NonTrivialString.ts
+++ b/src/library/NonTrivialString.ts
@@ -18,7 +18,7 @@ const NonTrivialString = Brand.refined<
 
     const potentialRefinementError = Option.map(
       potentialParsingError,
-      $0 => Brand.error(`Expected string to contain something beyond just whitespace, got "${someString}"`, {
+      ($0) => Brand.error(`Expected string to contain something beyond just whitespace, got "${someString}"`, {
         cause: $0,
       }),
     );

--- a/src/library/Sequence/Byte/Encoded/Base64.ts
+++ b/src/library/Sequence/Byte/Encoded/Base64.ts
@@ -19,7 +19,7 @@ const Sequence_Byte_Encoded_Base64 = Brand.refined<
 
     const potentialRefinementError = Option.map(
       potentialParsingError,
-      $0 => Brand.error('String is not valid Base64-encoded byte sequence', {
+      ($0) => Brand.error('String is not valid Base64-encoded byte sequence', {
         cause: $0,
       }),
     );

--- a/src/library/ShimmedStabilityAIClient/toShortfinRequestBody/Prompt.ts
+++ b/src/library/ShimmedStabilityAIClient/toShortfinRequestBody/Prompt.ts
@@ -11,8 +11,8 @@ const toShortfinRequestBody_Prompt = (
   },
 ): Shortfin.TextToImage.SDXL.Client.Request.Body['prompt'] => {
   return givenTextPrompts
-    .filter($0 => $0.weight === given.weight)
-    .map($0 => $0.text.trim())
+    .filter(($0) => $0.weight === given.weight)
+    .map(($0) => $0.text.trim())
     .join(',');
 };
 

--- a/src/library/URI/definition.declared.ts
+++ b/src/library/URI/definition.declared.ts
@@ -38,7 +38,7 @@ class URI {
   private get serializableAuthority(): Option.Option<string> {
     return Option.map(
       this.authority,
-      $0 => URI.authorityPrefix.concat($0),
+      ($0) => URI.authorityPrefix.concat($0),
     );
   }
 
@@ -54,7 +54,7 @@ class URI {
   private get serializableQuery(): Option.Option<string> {
     return Option.map(
       this.query,
-      $0 => URI.queryPrefix.concat($0),
+      ($0) => URI.queryPrefix.concat($0),
     );
   }
 
@@ -63,7 +63,7 @@ class URI {
   private get serializableFragment(): Option.Option<string> {
     return Option.map(
       this.fragment,
-      $0 => URI.fragmentPrefix.concat($0),
+      ($0) => URI.fragmentPrefix.concat($0),
     );
   }
 

--- a/src/library/math/operators/predicate/isNegative.test.ts
+++ b/src/library/math/operators/predicate/isNegative.test.ts
@@ -69,7 +69,7 @@ describe(isNegative, () => {
       [infinite.positive, false],
     ] as const;
 
-    const infiniteNumbers = infiniteAssertions.map($0 => $0[0]);
+    const infiniteNumbers = infiniteAssertions.map(($0) => $0[0]);
 
     const neutralFiniteNumbers = [
       neutralNumber,
@@ -86,7 +86,7 @@ describe(isNegative, () => {
       runtime.max,
     ];
 
-    const negativeFiniteNumbers = positiveFiniteNumbers.map($0 => $0 * signed.negative);
+    const negativeFiniteNumbers = positiveFiniteNumbers.map(($0) => $0 * signed.negative);
 
     const operableNumbers = [
       ...infiniteNumbers,

--- a/src/library/utilitiesByType/string/concatenated.ts
+++ b/src/library/utilitiesByType/string/concatenated.ts
@@ -15,7 +15,7 @@ const concatenated = (
   )[]
 ): string => pipe(
   givenOperands,
-  Array.map($0 => isString($0) ? Option.some($0) : $0),
+  Array.map(($0) => isString($0) ? Option.some($0) : $0),
   Array.getSomes,
   Array.join(''),
 );


### PR DESCRIPTION
- ensures that parentheses don't toggle under any circumstance so they don't add noise to diffs 

Encountered while drafting #1240