### PR TITLE
fix: ensures getters don't immediately invoke `Option.gen`

### DIFF
--- a/src/library/ContentDescriptor/definition.declared.ts
+++ b/src/library/ContentDescriptor/definition.declared.ts
@@ -36,28 +36,34 @@ class ContentDescriptor {
 
   public static readonly treeBranchSuffix = '.';
 
-  private readonly serializableTree = Option.gen(this, function* () {
-    const suffixedTreeBranches = (yield* this.tree).map(($0) => $0.concat(ContentDescriptor.treeBranchSuffix));
-    const serializedTreeBranches = concatenated(...suffixedTreeBranches);
-    return serializedTreeBranches;
-  });
+  private get serializableTree(): Option.Option<string> {
+    return Option.gen(this, function* () {
+      const suffixedTreeBranches = (yield* this.tree).map(($0) => $0.concat(ContentDescriptor.treeBranchSuffix));
+      const serializedTreeBranches = concatenated(...suffixedTreeBranches);
+      return serializedTreeBranches;
+    });
+  }
 
   public static readonly structureDescriptorPrefix = '+';
 
-  private readonly serializableStructureDescriptor = Option.gen(this, function* () {
-    return ContentDescriptor.structureDescriptorPrefix.concat(yield* this.structureDescriptor);
-  });
+  private get serializableStructureDescriptor(): Option.Option<string> {
+    return Option.gen(this, function* () {
+      return ContentDescriptor.structureDescriptorPrefix.concat(yield* this.structureDescriptor);
+    });
+  }
 
   public static readonly parameterPrefix = ';';
   public static readonly parameterKeyValueDelimiter = '=';
 
-  private readonly serializableParameters = Option.gen(this, function* () {
-    const serializableParameterEntries = Object.entries(yield* this.parameters)
-      .map(($0) => $0.join(ContentDescriptor.parameterKeyValueDelimiter))
-      .map(($0) => ContentDescriptor.parameterPrefix.concat($0));
+  private get serializableParameters(): Option.Option<string> {
+    return Option.gen(this, function* () {
+      const serializableParameterEntries = Object.entries(yield* this.parameters)
+        .map(($0) => $0.join(ContentDescriptor.parameterKeyValueDelimiter))
+        .map(($0) => ContentDescriptor.parameterPrefix.concat($0));
 
-    return concatenated(...serializableParameterEntries);
-  });
+      return concatenated(...serializableParameterEntries);
+    });
+  }
 
   public get serialized(): NonTrivialString {
     const orderedComponents = [

--- a/src/library/URI/Data/definition.declared.ts
+++ b/src/library/URI/Data/definition.declared.ts
@@ -42,14 +42,14 @@ class URI_Data
 
   public static readonly encodingPrefix = ';';
 
-  public readonly serializableEncoding = Option.gen(this, function* () {
+  public get serializableEncoding(): Option.Option<string> {
     if (
       this.encoding !== 'base64'
-    ) return yield* Option.none();
+    ) return Option.none();
 
     const prefixedEncoding = URI_Data.encodingPrefix.concat(this.encoding);
-    return prefixedEncoding;
-  });
+    return Option.some(prefixedEncoding);
+  }
 
   public static readonly dataPrefix = ',';
 

--- a/src/library/URI/definition.declared.ts
+++ b/src/library/URI/definition.declared.ts
@@ -35,9 +35,11 @@ class URI {
 
   public static readonly authorityPrefix = '//';
 
-  private readonly serializableAuthority = Option.gen(this, function* () {
-    return URI.authorityPrefix.concat(yield* this.authority);
-  });
+  private get serializableAuthority(): Option.Option<string> {
+    return Option.gen(this, function* () {
+      return URI.authorityPrefix.concat(yield* this.authority);
+    });
+  }
 
   public get path(): Option.Option.Value<URI['overridablePath']> {
     return Option.getOrThrowWith(
@@ -48,15 +50,19 @@ class URI {
 
   public static readonly queryPrefix = '?';
 
-  private readonly serializableQuery = Option.gen(this, function* () {
-    return URI.queryPrefix.concat(yield* this.query);
-  });
+  private get serializableQuery(): Option.Option<string> {
+    return Option.gen(this, function* () {
+      return URI.queryPrefix.concat(yield* this.query);
+    });
+  }
 
   public static readonly fragmentPrefix = '#';
 
-  private readonly serializableFragment = Option.gen(this, function* () {
-    return URI.fragmentPrefix.concat(yield* this.fragment);
-  });
+  private get serializableFragment(): Option.Option<string> {
+    return Option.gen(this, function* () {
+      return URI.fragmentPrefix.concat(yield* this.fragment);
+    });
+  }
 
   public get serialized(): string {
     const orderedComponents = [


### PR DESCRIPTION
- `Option.gen` immediately consumes its generator body
- this means that it can't be used as a pure getter, [unlike `Effect.gen`](https://effect.website/docs/getting-started/using-generators/#passing-this)

Introduced in #1240