### PR TITLE
refactor: leverages `Option.fromNullable`

### DIFF
--- a/src/features/TextToImage/Client/SDXL/toSharkUIOutput/Image/definition.declared.ts
+++ b/src/features/TextToImage/Client/SDXL/toSharkUIOutput/Image/definition.declared.ts
@@ -18,12 +18,7 @@ function toSharkUIOutput_Image(
   },
 ): Option.Option<TextToImage_Pipeline.Output['image']> {
   return Option.gen(function* () {
-    const rawBase64Data = givenImage.base64;
-
-    if (
-      rawBase64Data === undefined
-    ) return yield* Option.none();
-
+    const rawBase64Data = yield* Option.fromNullable(givenImage.base64);
     const base64DataOfRawImage = Sequence.Byte.Encoded.Base64(rawBase64Data);
 
     const derivedImage = {

--- a/src/features/TextToImage/Client/SDXL/toSharkUIOutput/Image/definition.declared.ts
+++ b/src/features/TextToImage/Client/SDXL/toSharkUIOutput/Image/definition.declared.ts
@@ -18,11 +18,13 @@ function toSharkUIOutput_Image(
   },
 ): Option.Option<TextToImage_Pipeline.Output['image']> {
   return Option.gen(function* () {
+    const rawBase64Data = givenImage.base64;
+
     if (
-      givenImage.base64 === undefined
+      rawBase64Data === undefined
     ) return yield* Option.none();
 
-    const base64DataOfRawImage = Sequence.Byte.Encoded.Base64(givenImage.base64);
+    const base64DataOfRawImage = Sequence.Byte.Encoded.Base64(rawBase64Data);
 
     const derivedImage = {
       uri        : new URI.Image('png', 'base64', base64DataOfRawImage),

--- a/src/library/ShimmedStabilityAIClient/toShortfinRequestBody/definition.declared.ts
+++ b/src/library/ShimmedStabilityAIClient/toShortfinRequestBody/definition.declared.ts
@@ -24,13 +24,17 @@ function toShortfinRequestBody(
       || (givenRequestBody.seed === undefined)
     ) return yield* Option.none();
 
-    const derivedShortfinRequestBody = {
+    const promptsForShortfinRequestBody = {
       prompt: toShortfinRequestBody_Prompt(givenRequestBody.textPrompts, {
         weight: 1,
       }),
       neg_prompt: toShortfinRequestBody_Prompt(givenRequestBody.textPrompts, {
         weight: -1,
       }),
+    };
+
+    const derivedShortfinRequestBody = {
+      ...promptsForShortfinRequestBody,
       height        : givenRequestBody.height,
       width         : givenRequestBody.width,
       steps         : givenRequestBody.steps,

--- a/src/library/ShimmedStabilityAIClient/toShortfinRequestBody/definition.declared.ts
+++ b/src/library/ShimmedStabilityAIClient/toShortfinRequestBody/definition.declared.ts
@@ -16,13 +16,13 @@ function toShortfinRequestBody(
   givenRequestBody: GenerateFromTextRequest['textToImageRequestBody'],
 ): Option.Option<Shortfin.TextToImage.SDXL.Client.Request.Body> {
   return Option.gen(function* () {
-    if (
-      (givenRequestBody.height === undefined)
-      || (givenRequestBody.width === undefined)
-      || (givenRequestBody.steps === undefined)
-      || (givenRequestBody.cfgScale === undefined)
-      || (givenRequestBody.seed === undefined)
-    ) return yield* Option.none();
+    const remainderOfShortfinRequestBody = yield* Option.all({
+      height        : Option.fromNullable(givenRequestBody.height /*  */),
+      width         : Option.fromNullable(givenRequestBody.width /*   */),
+      steps         : Option.fromNullable(givenRequestBody.steps /*   */),
+      guidance_scale: Option.fromNullable(givenRequestBody.cfgScale /**/),
+      seed          : Option.fromNullable(givenRequestBody.seed /*    */),
+    });
 
     const promptsForShortfinRequestBody = {
       prompt: toShortfinRequestBody_Prompt(givenRequestBody.textPrompts, {
@@ -35,11 +35,7 @@ function toShortfinRequestBody(
 
     const derivedShortfinRequestBody = {
       ...promptsForShortfinRequestBody,
-      height        : givenRequestBody.height,
-      width         : givenRequestBody.width,
-      steps         : givenRequestBody.steps,
-      guidance_scale: givenRequestBody.cfgScale,
-      seed          : givenRequestBody.seed,
+      ...remainderOfShortfinRequestBody,
     };
 
     return derivedShortfinRequestBody;


### PR DESCRIPTION
- short-circuits via `yield*`ing the relevant `Option` rather than using a guard
- reduces boilerplate, enriches semantics 