### PR TITLE
refactor: cleans up use of `Option` in "TextToImageInputSection.vue"

### DIFF
--- a/src/features/TextToImage/components/TextToImageInputSection.vue
+++ b/src/features/TextToImage/components/TextToImageInputSection.vue
@@ -97,9 +97,7 @@ const defaultInitialInputText: InputTextByQualitativeWeight = {
 };
 
 const initialInputText: InputTextByQualitativeWeight = (() => {
-  const initialExposedInputText = get(exposedInputText);
-
-  return Option.match(initialExposedInputText, {
+  return Option.match(get(exposedInputText), {
     onNone: () => defaultInitialInputText,
     onSome: ($0) => byQualitativeWeight($0),
   });

--- a/src/features/TextToImage/components/TextToImageInputSection.vue
+++ b/src/features/TextToImage/components/TextToImageInputSection.vue
@@ -96,12 +96,10 @@ const defaultInitialInputText: InputTextByQualitativeWeight = {
   negative: 'Watermark, blurry, over-saturated, low resolution, pollution',
 };
 
-const initialInputText: InputTextByQualitativeWeight = (() => {
-  return Option.match(get(exposedInputText), {
-    onNone: () => defaultInitialInputText,
-    onSome: ($0) => byQualitativeWeight($0),
-  });
-})();
+const initialInputText: InputTextByQualitativeWeight = Option.match(get(exposedInputText), {
+  onNone: () => defaultInitialInputText,
+  onSome: ($0) => byQualitativeWeight($0),
+});
 
 const currentInputText: Ref<InputTextByQualitativeWeight> = ref(initialInputText);
 

--- a/src/features/TextToImage/components/TextToImageInputSection.vue
+++ b/src/features/TextToImage/components/TextToImageInputSection.vue
@@ -97,8 +97,8 @@ const defaultInitialInputText: InputTextByQualitativeWeight = {
 };
 
 const initialInputText: InputTextByQualitativeWeight = Option.match(get(exposedInputText), {
-  onNone: () => defaultInitialInputText,
   onSome: ($0) => byQualitativeWeight($0),
+  onNone: () => defaultInitialInputText,
 });
 
 const currentInputText: Ref<InputTextByQualitativeWeight> = ref(initialInputText);

--- a/src/features/TextToImage/components/TextToImageInputSection.vue
+++ b/src/features/TextToImage/components/TextToImageInputSection.vue
@@ -106,7 +106,8 @@ const currentInputText: Ref<InputTextByQualitativeWeight> = ref(initialInputText
 watch(
   currentInputText,
   (updatedInputText) => {
-    set(exposedInputText, Option.some(standardized(updatedInputText)));
+    const wrappedInputText = Option.some(standardized(updatedInputText));
+    set(exposedInputText, wrappedInputText);
   },
   {
     deep     : true,


### PR DESCRIPTION
- avoids redundant IIFEs since `Option.gen` is also immediately invoked