### PR TITLE
refactor: avoids `someOption.getOrThrowWith` for failures

### DIFF
--- a/src/features/TextToImage/Client/SDXL/toSharkUIOutput/Image/definition.declared.ts
+++ b/src/features/TextToImage/Client/SDXL/toSharkUIOutput/Image/definition.declared.ts
@@ -1,4 +1,5 @@
 import {
+  Effect,
   Option,
 } from 'effect';
 
@@ -18,12 +19,12 @@ function toSharkUIOutput_Image(
   },
 ): TextToImage_Pipeline.Output['image'] {
   const rawBase64Data = Option.fromNullable(givenImage.base64).pipe(
-    Option.getOrThrowWith(() => new Error('Data for Stability AI image was not present.')),
-  );
+    Effect.orDieWith(() => new Error('Data for Stability AI image was not present.')),
+  ).pipe(Effect.runSync);
 
   const base64DataOfRawImage = Sequence.Byte.Encoded.Base64.option(rawBase64Data).pipe(
-    Option.getOrThrowWith(() => new Error('Data for Stability AI image was not base64-encoded.')),
-  );
+    Effect.orDieWith(() => new Error('Data for Stability AI image was not base64-encoded.')),
+  ).pipe(Effect.runSync);
 
   const derivedImage = {
     uri        : new URI.Image('png', 'base64', base64DataOfRawImage),

--- a/src/features/TextToImage/Client/SDXL/toSharkUIOutput/plural.ts
+++ b/src/features/TextToImage/Client/SDXL/toSharkUIOutput/plural.ts
@@ -29,16 +29,16 @@ const toSharkUIOutput_plural = (
   ) return Effect.dieMessage('Expected response body rather than readable stream').pipe(Effect.runSync);
 
   const inferredRawImages = Option.fromNullable(givenResponse.result.artifacts).pipe(
-    Option.getOrThrowWith(() => new Error('Expected text-to-image output in response result')),
-  );
+    Effect.orDieWith(() => new Error('Expected text-to-image output in response result')),
+  ).pipe(Effect.runSync);
 
   const potentialOutputImages = inferredRawImages.map(($0) => toSharkUIOutput_Image($0, {
     description: toSharkUIOutput_Image.Description.all(givenInputText),
   }));
 
   const inferredOutputImages = Option.some(potentialOutputImages).pipe(
-    Option.getOrThrowWith(() => new Error('Failed to convert one or more raw images to Shark UI output image.')),
-  );
+    Effect.orDieWith(() => new Error('Failed to convert one or more raw images to Shark UI output image.')),
+  ).pipe(Effect.runSync);
 
   const inferredOutputs = inferredOutputImages.map(($0) => new TextToImage_Pipeline.Output({
     image: $0,

--- a/src/pages/TextToImagePage.vue
+++ b/src/pages/TextToImagePage.vue
@@ -52,8 +52,8 @@ const currentNumberOfDiffusionSteps = ref<number>(range.midpoint);
 
 const imageGeneration = progressiveRef(Effect.gen(function* () {
   const proposedPrompt = get(currentPrompt).pipe(
-    Option.getOrThrowWith(() => new Error('Prompt was not set before submission')),
-  );
+    Effect.orDieWith(() => new Error('Prompt was not set before submission')),
+  ).pipe(Effect.runSync);
 
   const generatedOutput = yield* TextToImage.Client.SDXL.generateOutputFrom({
     textToImageRequestBody: {


### PR DESCRIPTION
Facilitates #1262 