### PR TITLE
refactor: leverages `someOption.pipe(...)`

### DIFF
--- a/src/features/TextToImage/Client/SDXL/toSharkUIOutput/first.ts
+++ b/src/features/TextToImage/Client/SDXL/toSharkUIOutput/first.ts
@@ -33,9 +33,8 @@ const toSharkUIOutput_first = (
     inferredFrom: givenInputText,
   });
 
-  const inferredOutputs = Option.getOrThrowWith(
-    potentialInferredOutputs,
-    () => new Error('Expected text-to-image output in response result'),
+  const inferredOutputs = potentialInferredOutputs.pipe(
+    Option.getOrThrowWith(() => new Error('Expected text-to-image output in response result')),
   );
 
   if (
@@ -44,9 +43,8 @@ const toSharkUIOutput_first = (
 
   const [firstPotentialOutput] = inferredOutputs;
 
-  const firstPipelineOutput = Option.getOrThrowWith(
-    firstPotentialOutput,
-    () => new Error('Expected at least one well-formed text-to-image output in response'),
+  const firstPipelineOutput = firstPotentialOutput.pipe(
+    Option.getOrThrowWith(() => new Error('Expected at least one well-formed text-to-image output in response')),
   );
 
   return firstPipelineOutput;

--- a/src/library/URI/Data/definition.declared.ts
+++ b/src/library/URI/Data/definition.declared.ts
@@ -34,9 +34,8 @@ class URI_Data
   }
 
   public get descriptor(): Option.Option.Value<URI_Data['overridableDescriptor']> {
-    return Option.getOrThrowWith(
-      this.overridableDescriptor,
-      () => new Error('Descriptor either needs to be initialized or overridden'),
+    return this.overridableDescriptor.pipe(
+      Option.getOrThrowWith(() => new Error('Descriptor either needs to be initialized or overridden')),
     );
   }
 

--- a/src/library/URI/definition.declared.ts
+++ b/src/library/URI/definition.declared.ts
@@ -42,9 +42,8 @@ class URI {
   }
 
   public get path(): Option.Option.Value<URI['overridablePath']> {
-    return Option.getOrThrowWith(
-      this.overridablePath,
-      () => new Error('`path` must either be a) provided via constructor or b) overridden via public getter'),
+    return this.overridablePath.pipe(
+      Option.getOrThrowWith(() => new Error('`path` must either be a) provided via constructor or b) overridden via public getter')),
     );
   }
 

--- a/src/pages/TextToImagePage.vue
+++ b/src/pages/TextToImagePage.vue
@@ -51,9 +51,8 @@ const {
 const currentNumberOfDiffusionSteps = ref<number>(range.midpoint);
 
 const imageGeneration = progressiveRef(Effect.gen(function* () {
-  const proposedPrompt = Option.getOrThrowWith(
-    get(currentPrompt),
-    () => new Error('Prompt was not set before submission'),
+  const proposedPrompt = get(currentPrompt).pipe(
+    Option.getOrThrowWith(() => new Error('Prompt was not set before submission')),
   );
 
   const generatedOutput = yield* TextToImage.Client.SDXL.generateOutputFrom({


### PR DESCRIPTION
- puts the `Option` in question at the beginning of the line
- makes it easier to switch between `Option.getOrThrowWith`, `Effect.orDieWith`, `Effect.orElseFail`

Facilitates #1246