### PR TITLE
refactor(text-to-image): avoids antipattern interface between artifact conversion methods

### DIFF
--- a/src/features/TextToImage/Client/SDXL/toSharkUIOutput/first.ts
+++ b/src/features/TextToImage/Client/SDXL/toSharkUIOutput/first.ts
@@ -33,7 +33,7 @@ const toSharkUIOutput_first = (
     inferredFrom: givenInputText,
   });
 
-  const inferredOutputs = Option.all(potentialInferredOutputs).pipe(
+  const inferredOutputs = potentialInferredOutputs.pipe(
     Option.getOrThrowWith(() => new Error('Expected at least one well-formed text-to-image output in response')),
   );
 

--- a/src/features/TextToImage/Client/SDXL/toSharkUIOutput/first.ts
+++ b/src/features/TextToImage/Client/SDXL/toSharkUIOutput/first.ts
@@ -33,9 +33,7 @@ const toSharkUIOutput_first = (
     inferredFrom: givenInputText,
   });
 
-  const inferredOutputs = potentialInferredOutputs.pipe(
-    Option.getOrThrowWith(() => new Error('Expected text-to-image output in response result')),
-  );
+  const inferredOutputs = potentialInferredOutputs;
 
   if (
     !isNonEmptyArray(inferredOutputs)

--- a/src/features/TextToImage/Client/SDXL/toSharkUIOutput/first.ts
+++ b/src/features/TextToImage/Client/SDXL/toSharkUIOutput/first.ts
@@ -33,18 +33,16 @@ const toSharkUIOutput_first = (
     inferredFrom: givenInputText,
   });
 
-  const inferredOutputs = potentialInferredOutputs;
+  const inferredOutputs = Option.all(potentialInferredOutputs).pipe(
+    Option.getOrThrowWith(() => new Error('Expected at least one well-formed text-to-image output in response')),
+  );
 
   if (
     !isNonEmptyArray(inferredOutputs)
   ) return Effect.dieMessage('Expected at least one text-to-image output in response').pipe(Effect.runSync);
 
   const [firstPotentialOutput] = inferredOutputs;
-
-  const firstPipelineOutput = firstPotentialOutput.pipe(
-    Option.getOrThrowWith(() => new Error('Expected at least one well-formed text-to-image output in response')),
-  );
-
+  const firstPipelineOutput = firstPotentialOutput;
   return firstPipelineOutput;
 };
 

--- a/src/features/TextToImage/Client/SDXL/toSharkUIOutput/first.ts
+++ b/src/features/TextToImage/Client/SDXL/toSharkUIOutput/first.ts
@@ -1,6 +1,5 @@
 import {
   Effect,
-  Option,
 } from 'effect';
 
 import {
@@ -33,9 +32,7 @@ const toSharkUIOutput_first = (
     inferredFrom: givenInputText,
   });
 
-  const inferredOutputs = potentialInferredOutputs.pipe(
-    Option.getOrThrowWith(() => new Error('Expected at least one well-formed text-to-image output in response')),
-  );
+  const inferredOutputs = potentialInferredOutputs;
 
   if (
     !isNonEmptyArray(inferredOutputs)

--- a/src/features/TextToImage/Client/SDXL/toSharkUIOutput/first.ts
+++ b/src/features/TextToImage/Client/SDXL/toSharkUIOutput/first.ts
@@ -41,8 +41,7 @@ const toSharkUIOutput_first = (
     !isNonEmptyArray(inferredOutputs)
   ) return Effect.dieMessage('Expected at least one text-to-image output in response').pipe(Effect.runSync);
 
-  const [firstPotentialOutput] = inferredOutputs;
-  const firstPipelineOutput = firstPotentialOutput;
+  const [firstPipelineOutput] = inferredOutputs;
   return firstPipelineOutput;
 };
 

--- a/src/features/TextToImage/Client/SDXL/toSharkUIOutput/first.ts
+++ b/src/features/TextToImage/Client/SDXL/toSharkUIOutput/first.ts
@@ -27,12 +27,10 @@ const toSharkUIOutput_first = (
     inferredFrom: TextToImage_Pipeline.Input['text'];
   },
 ): TextToImage_Pipeline.Output => {
-  const potentialInferredOutputs = toSharkUIOutput_plural({
+  const inferredOutputs = toSharkUIOutput_plural({
     in          : givenResponse,
     inferredFrom: givenInputText,
   });
-
-  const inferredOutputs = potentialInferredOutputs;
 
   if (
     !isNonEmptyArray(inferredOutputs)

--- a/src/features/TextToImage/Client/SDXL/toSharkUIOutput/plural.ts
+++ b/src/features/TextToImage/Client/SDXL/toSharkUIOutput/plural.ts
@@ -23,7 +23,7 @@ const toSharkUIOutput_plural = (
     in: GenerateFromTextResponse;
     inferredFrom: TextToImage_Pipeline.Input['text'];
   },
-): Option.Option<Option.Option<TextToImage_Pipeline.Output>[]> => Option.gen(function* () {
+): Option.Option<TextToImage_Pipeline.Output>[] => Option.gen(function* () {
   if (
     !('artifacts' in givenResponse.result)
   ) return Effect.dieMessage('Expected response body rather than readable stream').pipe(Effect.runSync);
@@ -37,7 +37,9 @@ const toSharkUIOutput_plural = (
     .map(($0) => TextToImage_Pipeline.Output.Option.from($0));
 
   return inferredOutputs;
-});
+}).pipe(
+  Option.getOrThrowWith(() => new Error('Expected text-to-image output in response result')),
+);
 
 export {
   toSharkUIOutput_plural,

--- a/src/features/TextToImage/Client/SDXL/toSharkUIOutput/plural.ts
+++ b/src/features/TextToImage/Client/SDXL/toSharkUIOutput/plural.ts
@@ -23,7 +23,7 @@ const toSharkUIOutput_plural = (
     in: GenerateFromTextResponse;
     inferredFrom: TextToImage_Pipeline.Input['text'];
   },
-): Option.Option<TextToImage_Pipeline.Output[]> => Option.gen(function* () {
+): TextToImage_Pipeline.Output[] => Option.gen(function* () {
   if (
     !('artifacts' in givenResponse.result)
   ) return Effect.dieMessage('Expected response body rather than readable stream').pipe(Effect.runSync);
@@ -36,7 +36,9 @@ const toSharkUIOutput_plural = (
     }))
     .map(($0) => TextToImage_Pipeline.Output.Option.from($0));
 
-  return Option.all(inferredOutputs);
+  return Option.all(inferredOutputs).pipe(
+    Option.getOrThrowWith(() => new Error('Expected at least one well-formed text-to-image output in response')),
+  );
 }).pipe(
   Option.getOrThrowWith(() => new Error('Expected text-to-image output in response result')),
 );

--- a/src/features/TextToImage/Client/SDXL/toSharkUIOutput/plural.ts
+++ b/src/features/TextToImage/Client/SDXL/toSharkUIOutput/plural.ts
@@ -23,7 +23,7 @@ const toSharkUIOutput_plural = (
     in: GenerateFromTextResponse;
     inferredFrom: TextToImage_Pipeline.Input['text'];
   },
-): Option.Option<TextToImage_Pipeline.Output>[] => Option.gen(function* () {
+): Option.Option<TextToImage_Pipeline.Output[]> => Option.gen(function* () {
   if (
     !('artifacts' in givenResponse.result)
   ) return Effect.dieMessage('Expected response body rather than readable stream').pipe(Effect.runSync);
@@ -36,7 +36,7 @@ const toSharkUIOutput_plural = (
     }))
     .map(($0) => TextToImage_Pipeline.Output.Option.from($0));
 
-  return inferredOutputs;
+  return Option.all(inferredOutputs);
 }).pipe(
   Option.getOrThrowWith(() => new Error('Expected text-to-image output in response result')),
 );


### PR DESCRIPTION
- A return type like `Option<Option<T>>` is likely indicative of an error accumulation chain where the errors are obfuscated.
- In this particular case, the obfuscation chain forced the sole caller to rethrow failed unwraps with a custom error that exhibits inappropriate intimacy with the function it just called
- In the future, implementing an `Effect<T, E>` would allow explicit error chaining while still keeping the error implementation close to the cause of the error.