### PR TITLE
refactor(text-to-image): moves "response result" error next to source of failure

### DIFF
--- a/src/features/TextToImage/Client/SDXL/toSharkUIOutput/plural.ts
+++ b/src/features/TextToImage/Client/SDXL/toSharkUIOutput/plural.ts
@@ -28,7 +28,9 @@ const toSharkUIOutput_plural = (
     !('artifacts' in givenResponse.result)
   ) return Effect.dieMessage('Expected response body rather than readable stream').pipe(Effect.runSync);
 
-  const inferredRawImages = yield* Option.fromNullable(givenResponse.result.artifacts);
+  const inferredRawImages = Option.fromNullable(givenResponse.result.artifacts).pipe(
+    Option.getOrThrowWith(() => new Error('Expected text-to-image output in response result')),
+  );
 
   const inferredOutputs = inferredRawImages
     .map(($0) => toSharkUIOutput_Image($0, {
@@ -40,7 +42,7 @@ const toSharkUIOutput_plural = (
     Option.getOrThrowWith(() => new Error('Expected at least one well-formed text-to-image output in response')),
   );
 }).pipe(
-  Option.getOrThrowWith(() => new Error('Expected text-to-image output in response result')),
+  Option.getOrThrow,
 );
 
 export {

--- a/src/features/TextToImage/Client/SDXL/toSharkUIOutput/plural.ts
+++ b/src/features/TextToImage/Client/SDXL/toSharkUIOutput/plural.ts
@@ -23,7 +23,7 @@ const toSharkUIOutput_plural = (
     in: GenerateFromTextResponse;
     inferredFrom: TextToImage_Pipeline.Input['text'];
   },
-): TextToImage_Pipeline.Output[] => Option.gen(function* () {
+): TextToImage_Pipeline.Output[] => {
   if (
     !('artifacts' in givenResponse.result)
   ) return Effect.dieMessage('Expected response body rather than readable stream').pipe(Effect.runSync);
@@ -41,9 +41,7 @@ const toSharkUIOutput_plural = (
   return Option.all(inferredOutputs).pipe(
     Option.getOrThrowWith(() => new Error('Expected at least one well-formed text-to-image output in response')),
   );
-}).pipe(
-  Option.getOrThrow,
-);
+};
 
 export {
   toSharkUIOutput_plural,


### PR DESCRIPTION
- moves the error and its message to the "first opportunity to interpret", which makes it easier to locally reason about failure modes