### PR TITLE
refactor(text-to-image): moves "failed to convert" error closer to source of failure

### DIFF
--- a/src/features/TextToImage/Client/SDXL/toSharkUIOutput/plural.ts
+++ b/src/features/TextToImage/Client/SDXL/toSharkUIOutput/plural.ts
@@ -39,7 +39,11 @@ const toSharkUIOutput_plural = (
     .map(($0) => TextToImage_Pipeline.Output.Option.from($0));
 
   return Option.all(
-    inferredOutputs,
+    inferredOutputs
+      .map(
+        Option.getOrThrowWith(() => new Error('Failed to convert one or more raw images to Shark UI output')),
+      )
+      .map(Option.some),
   ).pipe(
     Option.getOrThrowWith(() => new Error('Expected at least one well-formed text-to-image output in response')),
   );

--- a/src/features/TextToImage/Client/SDXL/toSharkUIOutput/plural.ts
+++ b/src/features/TextToImage/Client/SDXL/toSharkUIOutput/plural.ts
@@ -36,13 +36,13 @@ const toSharkUIOutput_plural = (
     .map(($0) => toSharkUIOutput_Image($0, {
       description: toSharkUIOutput_Image.Description.all(givenInputText),
     }))
-    .map(($0) => TextToImage_Pipeline.Output.Option.from($0));
+    .map(($0) => TextToImage_Pipeline.Output.Option.from($0))
+    .map(
+      Option.getOrThrowWith(() => new Error('Failed to convert one or more raw images to Shark UI output')),
+    );
 
   return Option.all(
     inferredOutputs
-      .map(
-        Option.getOrThrowWith(() => new Error('Failed to convert one or more raw images to Shark UI output')),
-      )
       .map(Option.some),
   ).pipe(
     Option.getOrThrowWith(() => new Error('Expected at least one well-formed text-to-image output in response')),

--- a/src/features/TextToImage/Client/SDXL/toSharkUIOutput/plural.ts
+++ b/src/features/TextToImage/Client/SDXL/toSharkUIOutput/plural.ts
@@ -41,9 +41,8 @@ const toSharkUIOutput_plural = (
       Option.getOrThrowWith(() => new Error('Failed to convert one or more raw images to Shark UI output')),
     );
 
-  return Option.all(
-    inferredOutputs
-      .map(Option.some),
+  return Option.some(
+    inferredOutputs,
   ).pipe(
     Option.getOrThrowWith(() => new Error('Expected at least one well-formed text-to-image output in response')),
   );

--- a/src/features/TextToImage/Client/SDXL/toSharkUIOutput/plural.ts
+++ b/src/features/TextToImage/Client/SDXL/toSharkUIOutput/plural.ts
@@ -38,7 +38,9 @@ const toSharkUIOutput_plural = (
     }))
     .map(($0) => TextToImage_Pipeline.Output.Option.from($0));
 
-  return Option.all(inferredOutputs).pipe(
+  return Option.all(
+    inferredOutputs,
+  ).pipe(
     Option.getOrThrowWith(() => new Error('Expected at least one well-formed text-to-image output in response')),
   );
 };

--- a/src/features/TextToImage/Client/SDXL/toSharkUIOutput/plural.ts
+++ b/src/features/TextToImage/Client/SDXL/toSharkUIOutput/plural.ts
@@ -41,11 +41,7 @@ const toSharkUIOutput_plural = (
       Option.getOrThrowWith(() => new Error('Failed to convert one or more raw images to Shark UI output')),
     );
 
-  return Option.some(
-    inferredOutputs,
-  ).pipe(
-    Option.getOrThrowWith(() => new Error('Expected at least one well-formed text-to-image output in response')),
-  );
+  return inferredOutputs;
 };
 
 export {


### PR DESCRIPTION
Facilitates #1258