### PR TITLE
refactor: ensures effectful functions have effectful signatures

### DIFF
--- a/src/components/DiscreteSlider.vue
+++ b/src/components/DiscreteSlider.vue
@@ -5,6 +5,10 @@ import {
 } from '@/library/vue';
 
 import {
+  Effect,
+} from 'effect';
+
+import {
   VBtn,
 } from 'vuetify/components/VBtn';
 
@@ -101,7 +105,7 @@ const tickLabelsAlong = (
     from: givenRange.lowerBound,
     to  : givenRange.upperBound,
     by  : givenStepSize,
-  });
+  }).pipe(Effect.runSync);
 
   const labelSets = tickRange.inclusiveSteps.map((eachPosition) => tickLabels({
     by: eachPosition,

--- a/src/features/TextToImage/Client/SDXL/generateOutputFrom.ts
+++ b/src/features/TextToImage/Client/SDXL/generateOutputFrom.ts
@@ -68,7 +68,7 @@ const TextToImage_Client_SDXL_generateOutputFrom = (
   const soleTextToImageOutput = toSharkUIOutput.first({
     in          : textToImageResponse,
     inferredFrom: given.textToImageRequestBody.textPrompts,
-  });
+  }).pipe(Effect.runSync);
 
   return soleTextToImageOutput;
 });

--- a/src/features/TextToImage/Client/SDXL/toSharkUIOutput/Image/definition.declared.ts
+++ b/src/features/TextToImage/Client/SDXL/toSharkUIOutput/Image/definition.declared.ts
@@ -18,20 +18,22 @@ function toSharkUIOutput_Image(
     description: TextToImage_Pipeline.Output['image']['description'];
   },
 ): TextToImage_Pipeline.Output['image'] {
-  const rawBase64Data = Option.fromNullable(givenImage.base64).pipe(
-    Effect.orDieWith(() => new Error('Data for Stability AI image was not present.')),
-  ).pipe(Effect.runSync);
+  return Effect.gen(function* () {
+    const rawBase64Data = Option.fromNullable(givenImage.base64).pipe(
+      Effect.orDieWith(() => new Error('Data for Stability AI image was not present.')),
+    ).pipe(Effect.runSync);
 
-  const base64DataOfRawImage = Sequence.Byte.Encoded.Base64.option(rawBase64Data).pipe(
-    Effect.orDieWith(() => new Error('Data for Stability AI image was not base64-encoded.')),
-  ).pipe(Effect.runSync);
+    const base64DataOfRawImage = Sequence.Byte.Encoded.Base64.option(rawBase64Data).pipe(
+      Effect.orDieWith(() => new Error('Data for Stability AI image was not base64-encoded.')),
+    ).pipe(Effect.runSync);
 
-  const derivedImage = {
-    uri        : new URI.Image('png', 'base64', base64DataOfRawImage),
-    description: given.description,
-  };
+    const derivedImage = {
+      uri        : new URI.Image('png', 'base64', base64DataOfRawImage),
+      description: given.description,
+    };
 
-  return derivedImage;
+    return derivedImage;
+  }).pipe(Effect.runSync);
 }
 
 export {

--- a/src/features/TextToImage/Client/SDXL/toSharkUIOutput/Image/definition.declared.ts
+++ b/src/features/TextToImage/Client/SDXL/toSharkUIOutput/Image/definition.declared.ts
@@ -17,7 +17,7 @@ function toSharkUIOutput_Image(
   given: {
     description: TextToImage_Pipeline.Output['image']['description'];
   },
-): TextToImage_Pipeline.Output['image'] {
+): Effect.Effect<TextToImage_Pipeline.Output['image']> {
   return Effect.gen(function* () {
     const rawBase64Data = Option.fromNullable(givenImage.base64).pipe(
       Effect.orDieWith(() => new Error('Data for Stability AI image was not present.')),
@@ -33,7 +33,7 @@ function toSharkUIOutput_Image(
     };
 
     return derivedImage;
-  }).pipe(Effect.runSync);
+  });
 }
 
 export {

--- a/src/features/TextToImage/Client/SDXL/toSharkUIOutput/first.ts
+++ b/src/features/TextToImage/Client/SDXL/toSharkUIOutput/first.ts
@@ -26,11 +26,11 @@ const toSharkUIOutput_first = (
     in: GenerateFromTextResponse;
     inferredFrom: TextToImage_Pipeline.Input['text'];
   },
-): TextToImage_Pipeline.Output => Effect.gen(function* () {
+): Effect.Effect<TextToImage_Pipeline.Output> => Effect.gen(function* () {
   const inferredOutputs = toSharkUIOutput_plural({
     in          : givenResponse,
     inferredFrom: givenInputText,
-  });
+  }).pipe(Effect.runSync);
 
   if (
     !isNonEmptyArray(inferredOutputs)
@@ -38,7 +38,7 @@ const toSharkUIOutput_first = (
 
   const [firstPipelineOutput] = inferredOutputs;
   return firstPipelineOutput;
-}).pipe(Effect.runSync);
+});
 
 export {
   toSharkUIOutput_first,

--- a/src/features/TextToImage/Client/SDXL/toSharkUIOutput/first.ts
+++ b/src/features/TextToImage/Client/SDXL/toSharkUIOutput/first.ts
@@ -26,7 +26,7 @@ const toSharkUIOutput_first = (
     in: GenerateFromTextResponse;
     inferredFrom: TextToImage_Pipeline.Input['text'];
   },
-): TextToImage_Pipeline.Output => {
+): TextToImage_Pipeline.Output => Effect.gen(function* () {
   const inferredOutputs = toSharkUIOutput_plural({
     in          : givenResponse,
     inferredFrom: givenInputText,
@@ -38,7 +38,7 @@ const toSharkUIOutput_first = (
 
   const [firstPipelineOutput] = inferredOutputs;
   return firstPipelineOutput;
-};
+}).pipe(Effect.runSync);
 
 export {
   toSharkUIOutput_first,

--- a/src/features/TextToImage/Client/SDXL/toSharkUIOutput/plural.ts
+++ b/src/features/TextToImage/Client/SDXL/toSharkUIOutput/plural.ts
@@ -23,7 +23,7 @@ const toSharkUIOutput_plural = (
     in: GenerateFromTextResponse;
     inferredFrom: TextToImage_Pipeline.Input['text'];
   },
-): TextToImage_Pipeline.Output[] => {
+): TextToImage_Pipeline.Output[] => Effect.gen(function* () {
   if (
     !('artifacts' in givenResponse.result)
   ) return Effect.dieMessage('Expected response body rather than readable stream').pipe(Effect.runSync);
@@ -45,7 +45,7 @@ const toSharkUIOutput_plural = (
   }));
 
   return inferredOutputs;
-};
+}).pipe(Effect.runSync);
 
 export {
   toSharkUIOutput_plural,

--- a/src/features/TextToImage/Client/SDXL/toSharkUIOutput/plural.ts
+++ b/src/features/TextToImage/Client/SDXL/toSharkUIOutput/plural.ts
@@ -23,7 +23,7 @@ const toSharkUIOutput_plural = (
     in: GenerateFromTextResponse;
     inferredFrom: TextToImage_Pipeline.Input['text'];
   },
-): TextToImage_Pipeline.Output[] => Effect.gen(function* () {
+): Effect.Effect<TextToImage_Pipeline.Output[]> => Effect.gen(function* () {
   if (
     !('artifacts' in givenResponse.result)
   ) return Effect.dieMessage('Expected response body rather than readable stream').pipe(Effect.runSync);
@@ -34,7 +34,7 @@ const toSharkUIOutput_plural = (
 
   const potentialOutputImages = inferredRawImages.map(($0) => toSharkUIOutput_Image($0, {
     description: toSharkUIOutput_Image.Description.all(givenInputText),
-  }));
+  })).map(Effect.runSync);
 
   const inferredOutputImages = Option.some(potentialOutputImages).pipe(
     Effect.orDieWith(() => new Error('Failed to convert one or more raw images to Shark UI output image.')),
@@ -45,7 +45,7 @@ const toSharkUIOutput_plural = (
   }));
 
   return inferredOutputs;
-}).pipe(Effect.runSync);
+});
 
 export {
   toSharkUIOutput_plural,

--- a/src/library/Range/Discrete.ts
+++ b/src/library/Range/Discrete.ts
@@ -33,15 +33,15 @@ class Range_Discrete
       to: Range_Discrete['upperBound'];
       by: Range_Discrete['stepSize'];
     },
-  ): Range_Discrete {
+  ): Effect.Effect<Range_Discrete> {
     const validRange = super.spanning({
       from: givenLowerBound,
       to  : givenUpperBound,
-    });
+    }).pipe(Effect.runSync);
 
     return Effect.gen(this, function* () {
       if (
-        isNegative(givenStepSize)
+        isNegative(givenStepSize).pipe(Effect.runSync)
       ) return Effect.dieMessage('Step size must be non-negative').pipe(Effect.runSync);
 
       const overstep = validRange.width % givenStepSize;
@@ -57,7 +57,7 @@ class Range_Discrete
       );
 
       return validDiscreteRange;
-    }).pipe(Effect.runSync);
+    });
   }
 
   public override exclusivelyContains(givenValue: number): boolean {

--- a/src/library/Range/Discrete.ts
+++ b/src/library/Range/Discrete.ts
@@ -39,23 +39,25 @@ class Range_Discrete
       to  : givenUpperBound,
     });
 
-    if (
-      isNegative(givenStepSize)
-    ) return Effect.dieMessage('Step size must be non-negative').pipe(Effect.runSync);
+    return Effect.gen(this, function* () {
+      if (
+        isNegative(givenStepSize)
+      ) return Effect.dieMessage('Step size must be non-negative').pipe(Effect.runSync);
 
-    const overstep = validRange.width % givenStepSize;
+      const overstep = validRange.width % givenStepSize;
 
-    if (
-      overstep !== 0
-    ) return Effect.dieMessage('Step size must fit evenly into the range').pipe(Effect.runSync);
+      if (
+        overstep !== 0
+      ) return Effect.dieMessage('Step size must fit evenly into the range').pipe(Effect.runSync);
 
-    const validDiscreteRange = new this(
-      validRange.lowerBound,
-      validRange.upperBound,
-      givenStepSize,
-    );
+      const validDiscreteRange = new this(
+        validRange.lowerBound,
+        validRange.upperBound,
+        givenStepSize,
+      );
 
-    return validDiscreteRange;
+      return validDiscreteRange;
+    }).pipe(Effect.runSync);
   }
 
   public override exclusivelyContains(givenValue: number): boolean {

--- a/src/library/Range/definition.declared.ts
+++ b/src/library/Range/definition.declared.ts
@@ -24,7 +24,7 @@ class Range {
       from: Range['lowerBound'];
       to: Range['upperBound'];
     },
-  ): Range {
+  ): Effect.Effect<Range> {
     return Effect.gen(this, function* () {
       if (
         givenUpperBound < givenLowerBound
@@ -36,7 +36,7 @@ class Range {
       );
 
       return validRange;
-    }).pipe(Effect.runSync);
+    });
   }
 
   public get width(): number {

--- a/src/library/Range/definition.declared.ts
+++ b/src/library/Range/definition.declared.ts
@@ -25,16 +25,18 @@ class Range {
       to: Range['upperBound'];
     },
   ): Range {
-    if (
-      givenUpperBound < givenLowerBound
-    ) return Effect.dieMessage('Upper bound must not be lower than lower bound').pipe(Effect.runSync);
+    return Effect.gen(this, function* () {
+      if (
+        givenUpperBound < givenLowerBound
+      ) return Effect.dieMessage('Upper bound must not be lower than lower bound').pipe(Effect.runSync);
 
-    const validRange = new this(
-      givenLowerBound,
-      givenUpperBound,
-    );
+      const validRange = new this(
+        givenLowerBound,
+        givenUpperBound,
+      );
 
-    return validRange;
+      return validRange;
+    }).pipe(Effect.runSync);
   }
 
   public get width(): number {

--- a/src/library/ShimmedStabilityAIClient/SDXL/DiffusionStepCount.ts
+++ b/src/library/ShimmedStabilityAIClient/SDXL/DiffusionStepCount.ts
@@ -1,3 +1,7 @@
+import {
+  Effect,
+} from 'effect';
+
 import Range from '@/library/Range';
 
 /**
@@ -10,7 +14,7 @@ abstract class SDXL_DiffusionStepCount { // eslint-disable-line @typescript-esli
     from: 10,
     to  : 50,
     by  : 1,
-  });
+  }).pipe(Effect.runSync);
 }
 
 export {

--- a/src/library/math/operators/predicate/isNegative.test.ts
+++ b/src/library/math/operators/predicate/isNegative.test.ts
@@ -1,4 +1,5 @@
 import {
+  Effect,
   Runtime,
 } from 'effect';
 
@@ -38,7 +39,7 @@ describe(isNegative, () => {
       it('should reject the operand', () => {
         expect.assertions(1);
 
-        expect(() => isNegative(soleInoperableNumber)).toThrow(Error);
+        expect(() => isNegative(soleInoperableNumber).pipe(Effect.runSync)).toThrow(Error);
       });
 
       it('should safely propagate the error', () => {
@@ -47,7 +48,7 @@ describe(isNegative, () => {
         expect((() => {
           // eslint-disable-next-line no-restricted-syntax
           try {
-            isNegative(soleInoperableNumber);
+            isNegative(soleInoperableNumber).pipe(Effect.runSync);
           }
           catch (error) {
             return Runtime.isFiberFailure(error);
@@ -58,7 +59,7 @@ describe(isNegative, () => {
       it('should communicate clearly with developers', () => {
         expect.assertions(1);
 
-        expect(() => isNegative(soleInoperableNumber)).toThrow('Operand must be operable');
+        expect(() => isNegative(soleInoperableNumber).pipe(Effect.runSync)).toThrow('Operand must be operable');
       });
     });
   });
@@ -98,31 +99,31 @@ describe(isNegative, () => {
     it.each(operableNumbers)('should accept valid operands', (eachOperableNumber) => {
       expect.assertions(1);
 
-      expect(() => isNegative(eachOperableNumber)).not.toThrow();
+      expect(() => isNegative(eachOperableNumber).pipe(Effect.runSync)).not.toThrow();
     });
 
     it.each(infiniteAssertions)('should support infinite operands', (eachInfiniteNumber, eachExpectOutput) => {
       expect.assertions(1);
 
-      expect(isNegative(eachInfiniteNumber)).toBe(eachExpectOutput);
+      expect(isNegative(eachInfiniteNumber).pipe(Effect.runSync)).toBe(eachExpectOutput);
     });
 
     it.each(neutralFiniteNumbers)('should detect neutral operands', (eachNeutralNumber) => {
       expect.assertions(1);
 
-      expect(isNegative(eachNeutralNumber)).toBe(false);
+      expect(isNegative(eachNeutralNumber).pipe(Effect.runSync)).toBe(false);
     });
 
     it.each(positiveFiniteNumbers)('should detect positive operands', (eachPositiveNumber) => {
       expect.assertions(1);
 
-      expect(isNegative(eachPositiveNumber)).toBe(false);
+      expect(isNegative(eachPositiveNumber).pipe(Effect.runSync)).toBe(false);
     });
 
     it.each(negativeFiniteNumbers)('should detect negative operands', (eachNegativeNumber) => {
       expect.assertions(1);
 
-      expect(isNegative(eachNegativeNumber)).toBe(true);
+      expect(isNegative(eachNegativeNumber).pipe(Effect.runSync)).toBe(true);
     });
   });
 });

--- a/src/library/math/operators/predicate/isNegative.ts
+++ b/src/library/math/operators/predicate/isNegative.ts
@@ -8,13 +8,13 @@ import {
 
 const isNegative = (
   givenOperand: number,
-): boolean => {
+): boolean => Effect.gen(function* () {
   if (
     !isOperable(givenOperand)
   ) return Effect.dieMessage('Operand must be operable').pipe(Effect.runSync);
 
   return (givenOperand < 0);
-};
+}).pipe(Effect.runSync);
 
 export {
   isNegative,

--- a/src/library/math/operators/predicate/isNegative.ts
+++ b/src/library/math/operators/predicate/isNegative.ts
@@ -8,13 +8,13 @@ import {
 
 const isNegative = (
   givenOperand: number,
-): boolean => Effect.gen(function* () {
+): Effect.Effect<boolean> => Effect.gen(function* () {
   if (
     !isOperable(givenOperand)
   ) return Effect.dieMessage('Operand must be operable').pipe(Effect.runSync);
 
   return (givenOperand < 0);
-}).pipe(Effect.runSync);
+});
 
 export {
   isNegative,


### PR DESCRIPTION
- any function body that contains "success", "fail", or "crash"/"die" semantics is considered "effectful"
- leveraging `Effect<A>` return types highlights the functions that might throw when called, i.e. `Effect.runSync`
- this is desired because function calls
  - with literal inputs (like for a factory function) can be validated via inspection
  - occurring within another effectful scope can offer up their failures or defects to their caller, if appropriate