### PR TITLE
refactor(text-to-image): simplifies effect propagation in response converter

### DIFF
--- a/src/features/TextToImage/Client/SDXL/toSharkUIOutput/plural.ts
+++ b/src/features/TextToImage/Client/SDXL/toSharkUIOutput/plural.ts
@@ -36,7 +36,7 @@ const toSharkUIOutput_plural = (
     description: toSharkUIOutput_Image.Description.all(givenInputText),
   }));
 
-  const inferredOutputImages = Option.some(potentialOutputImages.map(Effect.runSync)).pipe(
+  const inferredOutputImages = Effect.succeed(potentialOutputImages.map(Effect.runSync)).pipe(
     Effect.orDieWith(() => new Error('Failed to convert one or more raw images to Shark UI output image.')),
   ).pipe(Effect.runSync);
 

--- a/src/features/TextToImage/Client/SDXL/toSharkUIOutput/plural.ts
+++ b/src/features/TextToImage/Client/SDXL/toSharkUIOutput/plural.ts
@@ -36,7 +36,7 @@ const toSharkUIOutput_plural = (
     description: toSharkUIOutput_Image.Description.all(givenInputText),
   }));
 
-  const inferredOutputImages = Effect.succeed(potentialOutputImages.map(Effect.runSync)).pipe(
+  const inferredOutputImages = Effect.all(potentialOutputImages).pipe(
     Effect.orDieWith(() => new Error('Failed to convert one or more raw images to Shark UI output image.')),
   ).pipe(Effect.runSync);
 

--- a/src/features/TextToImage/Client/SDXL/toSharkUIOutput/plural.ts
+++ b/src/features/TextToImage/Client/SDXL/toSharkUIOutput/plural.ts
@@ -34,9 +34,9 @@ const toSharkUIOutput_plural = (
 
   const potentialOutputImages = inferredRawImages.map(($0) => toSharkUIOutput_Image($0, {
     description: toSharkUIOutput_Image.Description.all(givenInputText),
-  })).map(Effect.runSync);
+  }));
 
-  const inferredOutputImages = Option.some(potentialOutputImages).pipe(
+  const inferredOutputImages = Option.some(potentialOutputImages.map(Effect.runSync)).pipe(
     Effect.orDieWith(() => new Error('Failed to convert one or more raw images to Shark UI output image.')),
   ).pipe(Effect.runSync);
 


### PR DESCRIPTION
Enabled by #1246 and #1262