### PR TITLE
refactor: swaps all extraneous `Effect.runSync` with `yield`

### DIFF
--- a/src/features/TextToImage/Client/SDXL/generateOutputFrom.ts
+++ b/src/features/TextToImage/Client/SDXL/generateOutputFrom.ts
@@ -65,10 +65,10 @@ const TextToImage_Client_SDXL_generateOutputFrom = (
     }),
   );
 
-  const soleTextToImageOutput = toSharkUIOutput.first({
+  const soleTextToImageOutput = yield* toSharkUIOutput.first({
     in          : textToImageResponse,
     inferredFrom: given.textToImageRequestBody.textPrompts,
-  }).pipe(Effect.runSync);
+  });
 
   return soleTextToImageOutput;
 });

--- a/src/features/TextToImage/Client/SDXL/toSharkUIOutput/Image/definition.declared.ts
+++ b/src/features/TextToImage/Client/SDXL/toSharkUIOutput/Image/definition.declared.ts
@@ -19,13 +19,13 @@ function toSharkUIOutput_Image(
   },
 ): Effect.Effect<TextToImage_Pipeline.Output['image']> {
   return Effect.gen(function* () {
-    const rawBase64Data = Option.fromNullable(givenImage.base64).pipe(
+    const rawBase64Data = yield* Option.fromNullable(givenImage.base64).pipe(
       Effect.orDieWith(() => new Error('Data for Stability AI image was not present.')),
-    ).pipe(Effect.runSync);
+    );
 
-    const base64DataOfRawImage = Sequence.Byte.Encoded.Base64.option(rawBase64Data).pipe(
+    const base64DataOfRawImage = yield* Sequence.Byte.Encoded.Base64.option(rawBase64Data).pipe(
       Effect.orDieWith(() => new Error('Data for Stability AI image was not base64-encoded.')),
-    ).pipe(Effect.runSync);
+    );
 
     const derivedImage = {
       uri        : new URI.Image('png', 'base64', base64DataOfRawImage),

--- a/src/features/TextToImage/Client/SDXL/toSharkUIOutput/first.ts
+++ b/src/features/TextToImage/Client/SDXL/toSharkUIOutput/first.ts
@@ -27,14 +27,14 @@ const toSharkUIOutput_first = (
     inferredFrom: TextToImage_Pipeline.Input['text'];
   },
 ): Effect.Effect<TextToImage_Pipeline.Output> => Effect.gen(function* () {
-  const inferredOutputs = toSharkUIOutput_plural({
+  const inferredOutputs = yield* toSharkUIOutput_plural({
     in          : givenResponse,
     inferredFrom: givenInputText,
-  }).pipe(Effect.runSync);
+  });
 
   if (
     !isNonEmptyArray(inferredOutputs)
-  ) return Effect.dieMessage('Expected at least one text-to-image output in response').pipe(Effect.runSync);
+  ) return yield* Effect.dieMessage('Expected at least one text-to-image output in response');
 
   const [firstPipelineOutput] = inferredOutputs;
   return firstPipelineOutput;

--- a/src/features/TextToImage/Client/SDXL/toSharkUIOutput/plural.ts
+++ b/src/features/TextToImage/Client/SDXL/toSharkUIOutput/plural.ts
@@ -26,19 +26,19 @@ const toSharkUIOutput_plural = (
 ): Effect.Effect<TextToImage_Pipeline.Output[]> => Effect.gen(function* () {
   if (
     !('artifacts' in givenResponse.result)
-  ) return Effect.dieMessage('Expected response body rather than readable stream').pipe(Effect.runSync);
+  ) return yield* Effect.dieMessage('Expected response body rather than readable stream');
 
-  const inferredRawImages = Option.fromNullable(givenResponse.result.artifacts).pipe(
+  const inferredRawImages = yield* Option.fromNullable(givenResponse.result.artifacts).pipe(
     Effect.orDieWith(() => new Error('Expected text-to-image output in response result')),
-  ).pipe(Effect.runSync);
+  );
 
   const potentialOutputImages = inferredRawImages.map(($0) => toSharkUIOutput_Image($0, {
     description: toSharkUIOutput_Image.Description.all(givenInputText),
   }));
 
-  const inferredOutputImages = Effect.all(potentialOutputImages).pipe(
+  const inferredOutputImages = yield* Effect.all(potentialOutputImages).pipe(
     Effect.orDieWith(() => new Error('Failed to convert one or more raw images to Shark UI output image.')),
-  ).pipe(Effect.runSync);
+  );
 
   const inferredOutputs = inferredOutputImages.map(($0) => new TextToImage_Pipeline.Output({
     image: $0,

--- a/src/library/Range/Discrete.ts
+++ b/src/library/Range/Discrete.ts
@@ -40,17 +40,17 @@ class Range_Discrete
     });
 
     return Effect.gen(this, function* () {
-      const validRange = potentialRange.pipe(Effect.runSync);
+      const validRange = yield* potentialRange;
 
       if (
-        isNegative(givenStepSize).pipe(Effect.runSync)
-      ) return Effect.dieMessage('Step size must be non-negative').pipe(Effect.runSync);
+        yield* isNegative(givenStepSize)
+      ) return yield* Effect.dieMessage('Step size must be non-negative');
 
       const overstep = validRange.width % givenStepSize;
 
       if (
         overstep !== 0
-      ) return Effect.dieMessage('Step size must fit evenly into the range').pipe(Effect.runSync);
+      ) return yield* Effect.dieMessage('Step size must fit evenly into the range');
 
       const validDiscreteRange = new this(
         validRange.lowerBound,

--- a/src/library/Range/definition.declared.ts
+++ b/src/library/Range/definition.declared.ts
@@ -28,7 +28,7 @@ class Range {
     return Effect.gen(this, function* () {
       if (
         givenUpperBound < givenLowerBound
-      ) return Effect.dieMessage('Upper bound must not be lower than lower bound').pipe(Effect.runSync);
+      ) return yield* Effect.dieMessage('Upper bound must not be lower than lower bound');
 
       const validRange = new this(
         givenLowerBound,

--- a/src/library/math/operators/predicate/isNegative.ts
+++ b/src/library/math/operators/predicate/isNegative.ts
@@ -11,7 +11,7 @@ const isNegative = (
 ): Effect.Effect<boolean> => Effect.gen(function* () {
   if (
     !isOperable(givenOperand)
-  ) return Effect.dieMessage('Operand must be operable').pipe(Effect.runSync);
+  ) return yield* Effect.dieMessage('Operand must be operable');
 
   return (givenOperand < 0);
 });

--- a/src/pages/TextToImagePage.vue
+++ b/src/pages/TextToImagePage.vue
@@ -51,9 +51,9 @@ const {
 const currentNumberOfDiffusionSteps = ref<number>(range.midpoint);
 
 const imageGeneration = progressiveRef(Effect.gen(function* () {
-  const proposedPrompt = get(currentPrompt).pipe(
+  const proposedPrompt = yield* get(currentPrompt).pipe(
     Effect.orDieWith(() => new Error('Prompt was not set before submission')),
-  ).pipe(Effect.runSync);
+  );
 
   const generatedOutput = yield* TextToImage.Client.SDXL.generateOutputFrom({
     textToImageRequestBody: {


### PR DESCRIPTION
- `Effect.runSync` is reserved for the "edges" of the program