### PR TITLE
refactor: avoids mis-implementing failures as defects

### DIFF
--- a/src/features/TextToImage/Client/SDXL/toSharkUIOutput/Image/definition.declared.ts
+++ b/src/features/TextToImage/Client/SDXL/toSharkUIOutput/Image/definition.declared.ts
@@ -20,12 +20,12 @@ function toSharkUIOutput_Image(
 ): Effect.Effect<TextToImage_Pipeline.Output['image']> {
   return Effect.gen(function* () {
     const rawBase64Data = yield* Option.fromNullable(givenImage.base64).pipe(
-      Effect.orDieWith(() => new Error('Data for Stability AI image was not present.')),
-    );
+      Effect.orElseFail(() => new Error('Data for Stability AI image was not present.')),
+    ).pipe(Effect.orDie);
 
     const base64DataOfRawImage = yield* Sequence.Byte.Encoded.Base64.option(rawBase64Data).pipe(
-      Effect.orDieWith(() => new Error('Data for Stability AI image was not base64-encoded.')),
-    );
+      Effect.orElseFail(() => new Error('Data for Stability AI image was not base64-encoded.')),
+    ).pipe(Effect.orDie);
 
     const derivedImage = {
       uri        : new URI.Image('png', 'base64', base64DataOfRawImage),

--- a/src/features/TextToImage/Client/SDXL/toSharkUIOutput/first.ts
+++ b/src/features/TextToImage/Client/SDXL/toSharkUIOutput/first.ts
@@ -34,7 +34,7 @@ const toSharkUIOutput_first = (
 
   if (
     !isNonEmptyArray(inferredOutputs)
-  ) return yield* Effect.die(new Error('Expected at least one text-to-image output in response'));
+  ) return yield* Effect.fail(new Error('Expected at least one text-to-image output in response')).pipe(Effect.orDie);
 
   const [firstPipelineOutput] = inferredOutputs;
   return firstPipelineOutput;

--- a/src/features/TextToImage/Client/SDXL/toSharkUIOutput/first.ts
+++ b/src/features/TextToImage/Client/SDXL/toSharkUIOutput/first.ts
@@ -34,7 +34,7 @@ const toSharkUIOutput_first = (
 
   if (
     !isNonEmptyArray(inferredOutputs)
-  ) return yield* Effect.dieMessage('Expected at least one text-to-image output in response');
+  ) return yield* Effect.die(new Error('Expected at least one text-to-image output in response'));
 
   const [firstPipelineOutput] = inferredOutputs;
   return firstPipelineOutput;

--- a/src/features/TextToImage/Client/SDXL/toSharkUIOutput/plural.ts
+++ b/src/features/TextToImage/Client/SDXL/toSharkUIOutput/plural.ts
@@ -26,7 +26,7 @@ const toSharkUIOutput_plural = (
 ): Effect.Effect<TextToImage_Pipeline.Output[]> => Effect.gen(function* () {
   if (
     !('artifacts' in givenResponse.result)
-  ) return yield* Effect.die(new Error('Expected response body rather than readable stream'));
+  ) return yield* Effect.fail(new Error('Expected response body rather than readable stream')).pipe(Effect.orDie);
 
   const inferredRawImages = yield* Option.fromNullable(givenResponse.result.artifacts).pipe(
     Effect.orDieWith(() => new Error('Expected text-to-image output in response result')),

--- a/src/features/TextToImage/Client/SDXL/toSharkUIOutput/plural.ts
+++ b/src/features/TextToImage/Client/SDXL/toSharkUIOutput/plural.ts
@@ -29,16 +29,16 @@ const toSharkUIOutput_plural = (
   ) return yield* Effect.fail(new Error('Expected response body rather than readable stream')).pipe(Effect.orDie);
 
   const inferredRawImages = yield* Option.fromNullable(givenResponse.result.artifacts).pipe(
-    Effect.orDieWith(() => new Error('Expected text-to-image output in response result')),
-  );
+    Effect.orElseFail(() => new Error('Expected text-to-image output in response result')),
+  ).pipe(Effect.orDie);
 
   const potentialOutputImages = inferredRawImages.map(($0) => toSharkUIOutput_Image($0, {
     description: toSharkUIOutput_Image.Description.all(givenInputText),
   }));
 
   const inferredOutputImages = yield* Effect.all(potentialOutputImages).pipe(
-    Effect.orDieWith(() => new Error('Failed to convert one or more raw images to Shark UI output image.')),
-  );
+    Effect.orElseFail(() => new Error('Failed to convert one or more raw images to Shark UI output image.')),
+  ).pipe(Effect.orDie);
 
   const inferredOutputs = inferredOutputImages.map(($0) => new TextToImage_Pipeline.Output({
     image: $0,

--- a/src/features/TextToImage/Client/SDXL/toSharkUIOutput/plural.ts
+++ b/src/features/TextToImage/Client/SDXL/toSharkUIOutput/plural.ts
@@ -26,7 +26,7 @@ const toSharkUIOutput_plural = (
 ): Effect.Effect<TextToImage_Pipeline.Output[]> => Effect.gen(function* () {
   if (
     !('artifacts' in givenResponse.result)
-  ) return yield* Effect.dieMessage('Expected response body rather than readable stream');
+  ) return yield* Effect.die(new Error('Expected response body rather than readable stream'));
 
   const inferredRawImages = yield* Option.fromNullable(givenResponse.result.artifacts).pipe(
     Effect.orDieWith(() => new Error('Expected text-to-image output in response result')),

--- a/src/library/Range/Discrete.ts
+++ b/src/library/Range/Discrete.ts
@@ -44,13 +44,13 @@ class Range_Discrete
 
       if (
         yield* isNegative(givenStepSize)
-      ) return yield* Effect.die(new Error('Step size must be non-negative'));
+      ) return yield* Effect.fail(new Error('Step size must be non-negative')).pipe(Effect.orDie);
 
       const overstep = validRange.width % givenStepSize;
 
       if (
         overstep !== 0
-      ) return yield* Effect.die(new Error('Step size must fit evenly into the range'));
+      ) return yield* Effect.fail(new Error('Step size must fit evenly into the range')).pipe(Effect.orDie);
 
       const validDiscreteRange = new this(
         validRange.lowerBound,

--- a/src/library/Range/Discrete.ts
+++ b/src/library/Range/Discrete.ts
@@ -44,13 +44,13 @@ class Range_Discrete
 
       if (
         yield* isNegative(givenStepSize)
-      ) return yield* Effect.dieMessage('Step size must be non-negative');
+      ) return yield* Effect.die(new Error('Step size must be non-negative'));
 
       const overstep = validRange.width % givenStepSize;
 
       if (
         overstep !== 0
-      ) return yield* Effect.dieMessage('Step size must fit evenly into the range');
+      ) return yield* Effect.die(new Error('Step size must fit evenly into the range'));
 
       const validDiscreteRange = new this(
         validRange.lowerBound,

--- a/src/library/Range/definition.declared.ts
+++ b/src/library/Range/definition.declared.ts
@@ -28,7 +28,7 @@ class Range {
     return Effect.gen(this, function* () {
       if (
         givenUpperBound < givenLowerBound
-      ) return yield* Effect.dieMessage('Upper bound must not be lower than lower bound');
+      ) return yield* Effect.die(new Error('Upper bound must not be lower than lower bound'));
 
       const validRange = new this(
         givenLowerBound,

--- a/src/library/Range/definition.declared.ts
+++ b/src/library/Range/definition.declared.ts
@@ -28,7 +28,7 @@ class Range {
     return Effect.gen(this, function* () {
       if (
         givenUpperBound < givenLowerBound
-      ) return yield* Effect.die(new Error('Upper bound must not be lower than lower bound'));
+      ) return yield* Effect.fail(new Error('Upper bound must not be lower than lower bound')).pipe(Effect.orDie);
 
       const validRange = new this(
         givenLowerBound,

--- a/src/library/math/operators/predicate/isNegative.ts
+++ b/src/library/math/operators/predicate/isNegative.ts
@@ -11,7 +11,7 @@ const isNegative = (
 ): Effect.Effect<boolean> => Effect.gen(function* () {
   if (
     !isOperable(givenOperand)
-  ) return yield* Effect.dieMessage('Operand must be operable');
+  ) return yield* Effect.die(new Error('Operand must be operable'));
 
   return (givenOperand < 0);
 });

--- a/src/library/math/operators/predicate/isNegative.ts
+++ b/src/library/math/operators/predicate/isNegative.ts
@@ -11,7 +11,7 @@ const isNegative = (
 ): Effect.Effect<boolean> => Effect.gen(function* () {
   if (
     !isOperable(givenOperand)
-  ) return yield* Effect.die(new Error('Operand must be operable'));
+  ) return yield* Effect.fail(new Error('Operand must be operable')).pipe(Effect.orDie);
 
   return (givenOperand < 0);
 });


### PR DESCRIPTION
- the difference between [the two types of errors](https://effect.website/docs/error-management/two-error-types/) is subtle but important
- In general:
  - [recoverable errors](https://effect.website/docs/error-management/expected-errors/): there's a means to getting a function to return a useful output
  - [unrecoverable errors](https://effect.website/docs/error-management/unexpected-errors/): no matter what a caller inputs to a function, the function doesn't do its job; it's defective