### PR TITLE
refactor: ensures failures are worded as such

### DIFF
--- a/src/features/TextToImage/Client/SDXL/toSharkUIOutput/first.ts
+++ b/src/features/TextToImage/Client/SDXL/toSharkUIOutput/first.ts
@@ -34,7 +34,7 @@ const toSharkUIOutput_first = (
 
   if (
     !isNonEmptyArray(inferredOutputs)
-  ) return yield* Effect.fail(new Error('Expected at least one text-to-image output in response')).pipe(Effect.orDie);
+  ) return yield* Effect.fail(new Error('Response had no text-to-image outputs.')).pipe(Effect.orDie);
 
   const [firstPipelineOutput] = inferredOutputs;
   return firstPipelineOutput;

--- a/src/features/TextToImage/Client/SDXL/toSharkUIOutput/plural.ts
+++ b/src/features/TextToImage/Client/SDXL/toSharkUIOutput/plural.ts
@@ -26,10 +26,10 @@ const toSharkUIOutput_plural = (
 ): Effect.Effect<TextToImage_Pipeline.Output[]> => Effect.gen(function* () {
   if (
     !('artifacts' in givenResponse.result)
-  ) return yield* Effect.fail(new Error('Expected response body rather than readable stream')).pipe(Effect.orDie);
+  ) return yield* Effect.fail(new Error('Response had readable stream rather than body.')).pipe(Effect.orDie);
 
   const inferredRawImages = yield* Option.fromNullable(givenResponse.result.artifacts).pipe(
-    Effect.orElseFail(() => new Error('Expected text-to-image output in response result')),
+    Effect.orElseFail(() => new Error('Response body had no text-to-image results.')),
   ).pipe(Effect.orDie);
 
   const potentialOutputImages = inferredRawImages.map(($0) => toSharkUIOutput_Image($0, {
@@ -37,7 +37,7 @@ const toSharkUIOutput_plural = (
   }));
 
   const inferredOutputImages = yield* Effect.all(potentialOutputImages).pipe(
-    Effect.orElseFail(() => new Error('Failed to convert one or more raw images to Shark UI output image.')),
+    Effect.orElseFail(() => new Error('Response had one or more malformed text-to-image outputs.')),
   ).pipe(Effect.orDie);
 
   const inferredOutputs = inferredOutputImages.map(($0) => new TextToImage_Pipeline.Output({


### PR DESCRIPTION
- [defect](https://effect.website/docs/error-management/unexpected-errors/) messages read more like assertion failures or instructions to devs
- [failure](https://effect.website/docs/error-management/expected-errors/) messages read more like statements of what happened, strongly implying what can be done to make the next attempt more successful

Follows up on #1266 