### PR TITLE
refactor: highlights which callers are force-applying `Effect`s

### DIFF
--- a/src/features/TextToImage/Client/SDXL/generateOutputFrom.ts
+++ b/src/features/TextToImage/Client/SDXL/generateOutputFrom.ts
@@ -68,7 +68,7 @@ const TextToImage_Client_SDXL_generateOutputFrom = (
   const soleTextToImageOutput = yield* toSharkUIOutput.first({
     in          : textToImageResponse,
     inferredFrom: given.textToImageRequestBody.textPrompts,
-  });
+  }).pipe(Effect.orDie);
 
   return soleTextToImageOutput;
 });

--- a/src/features/TextToImage/Client/SDXL/toSharkUIOutput/Image/definition.declared.ts
+++ b/src/features/TextToImage/Client/SDXL/toSharkUIOutput/Image/definition.declared.ts
@@ -17,7 +17,7 @@ function toSharkUIOutput_Image(
   given: {
     description: TextToImage_Pipeline.Output['image']['description'];
   },
-): Effect.Effect<TextToImage_Pipeline.Output['image']> {
+): Effect.Effect<TextToImage_Pipeline.Output['image'], Error> {
   return Effect.gen(function* () {
     const rawBase64Data = yield* Option.fromNullable(givenImage.base64).pipe(
       Effect.orElseFail(() => new Error('Data for Stability AI image was not present.')),
@@ -33,7 +33,7 @@ function toSharkUIOutput_Image(
     };
 
     return derivedImage;
-  }).pipe(Effect.orDie);
+  });
 }
 
 export {

--- a/src/features/TextToImage/Client/SDXL/toSharkUIOutput/Image/definition.declared.ts
+++ b/src/features/TextToImage/Client/SDXL/toSharkUIOutput/Image/definition.declared.ts
@@ -21,11 +21,11 @@ function toSharkUIOutput_Image(
   return Effect.gen(function* () {
     const rawBase64Data = yield* Option.fromNullable(givenImage.base64).pipe(
       Effect.orElseFail(() => new Error('Data for Stability AI image was not present.')),
-    ).pipe(Effect.orDie);
+    );
 
     const base64DataOfRawImage = yield* Sequence.Byte.Encoded.Base64.option(rawBase64Data).pipe(
       Effect.orElseFail(() => new Error('Data for Stability AI image was not base64-encoded.')),
-    ).pipe(Effect.orDie);
+    );
 
     const derivedImage = {
       uri        : new URI.Image('png', 'base64', base64DataOfRawImage),
@@ -33,7 +33,7 @@ function toSharkUIOutput_Image(
     };
 
     return derivedImage;
-  });
+  }).pipe(Effect.orDie);
 }
 
 export {

--- a/src/features/TextToImage/Client/SDXL/toSharkUIOutput/first.ts
+++ b/src/features/TextToImage/Client/SDXL/toSharkUIOutput/first.ts
@@ -26,7 +26,7 @@ const toSharkUIOutput_first = (
     in: GenerateFromTextResponse;
     inferredFrom: TextToImage_Pipeline.Input['text'];
   },
-): Effect.Effect<TextToImage_Pipeline.Output> => Effect.gen(function* () {
+): Effect.Effect<TextToImage_Pipeline.Output, Error> => Effect.gen(function* () {
   const inferredOutputs = yield* toSharkUIOutput_plural({
     in          : givenResponse,
     inferredFrom: givenInputText,
@@ -38,7 +38,7 @@ const toSharkUIOutput_first = (
 
   const [firstPipelineOutput] = inferredOutputs;
   return firstPipelineOutput;
-}).pipe(Effect.orDie);
+});
 
 export {
   toSharkUIOutput_first,

--- a/src/features/TextToImage/Client/SDXL/toSharkUIOutput/first.ts
+++ b/src/features/TextToImage/Client/SDXL/toSharkUIOutput/first.ts
@@ -34,11 +34,11 @@ const toSharkUIOutput_first = (
 
   if (
     !isNonEmptyArray(inferredOutputs)
-  ) return yield* Effect.fail(new Error('Response had no text-to-image outputs.')).pipe(Effect.orDie);
+  ) return yield* Effect.fail(new Error('Response had no text-to-image outputs.'));
 
   const [firstPipelineOutput] = inferredOutputs;
   return firstPipelineOutput;
-});
+}).pipe(Effect.orDie);
 
 export {
   toSharkUIOutput_first,

--- a/src/features/TextToImage/Client/SDXL/toSharkUIOutput/plural.ts
+++ b/src/features/TextToImage/Client/SDXL/toSharkUIOutput/plural.ts
@@ -23,7 +23,7 @@ const toSharkUIOutput_plural = (
     in: GenerateFromTextResponse;
     inferredFrom: TextToImage_Pipeline.Input['text'];
   },
-): Effect.Effect<TextToImage_Pipeline.Output[]> => Effect.gen(function* () {
+): Effect.Effect<TextToImage_Pipeline.Output[], Error> => Effect.gen(function* () {
   if (
     !('artifacts' in givenResponse.result)
   ) return yield* Effect.fail(new Error('Response had readable stream rather than body.'));
@@ -45,7 +45,7 @@ const toSharkUIOutput_plural = (
   }));
 
   return inferredOutputs;
-}).pipe(Effect.orDie);
+});
 
 export {
   toSharkUIOutput_plural,

--- a/src/features/TextToImage/Client/SDXL/toSharkUIOutput/plural.ts
+++ b/src/features/TextToImage/Client/SDXL/toSharkUIOutput/plural.ts
@@ -26,11 +26,11 @@ const toSharkUIOutput_plural = (
 ): Effect.Effect<TextToImage_Pipeline.Output[]> => Effect.gen(function* () {
   if (
     !('artifacts' in givenResponse.result)
-  ) return yield* Effect.fail(new Error('Response had readable stream rather than body.')).pipe(Effect.orDie);
+  ) return yield* Effect.fail(new Error('Response had readable stream rather than body.'));
 
   const inferredRawImages = yield* Option.fromNullable(givenResponse.result.artifacts).pipe(
     Effect.orElseFail(() => new Error('Response body had no text-to-image results.')),
-  ).pipe(Effect.orDie);
+  );
 
   const potentialOutputImages = inferredRawImages.map(($0) => toSharkUIOutput_Image($0, {
     description: toSharkUIOutput_Image.Description.all(givenInputText),
@@ -38,14 +38,14 @@ const toSharkUIOutput_plural = (
 
   const inferredOutputImages = yield* Effect.all(potentialOutputImages).pipe(
     Effect.orElseFail(() => new Error('Response had one or more malformed text-to-image outputs.')),
-  ).pipe(Effect.orDie);
+  );
 
   const inferredOutputs = inferredOutputImages.map(($0) => new TextToImage_Pipeline.Output({
     image: $0,
   }));
 
   return inferredOutputs;
-});
+}).pipe(Effect.orDie);
 
 export {
   toSharkUIOutput_plural,

--- a/src/library/Range/Discrete.ts
+++ b/src/library/Range/Discrete.ts
@@ -33,7 +33,7 @@ class Range_Discrete
       to: Range_Discrete['upperBound'];
       by: Range_Discrete['stepSize'];
     },
-  ): Effect.Effect<Range_Discrete> {
+  ): Effect.Effect<Range_Discrete, Error> {
     const potentialRange = super.spanning({
       from: givenLowerBound,
       to  : givenUpperBound,
@@ -59,7 +59,7 @@ class Range_Discrete
       );
 
       return validDiscreteRange;
-    }).pipe(Effect.orDie);
+    });
   }
 
   public override exclusivelyContains(givenValue: number): boolean {

--- a/src/library/Range/Discrete.ts
+++ b/src/library/Range/Discrete.ts
@@ -44,13 +44,13 @@ class Range_Discrete
 
       if (
         yield* isNegative(givenStepSize)
-      ) return yield* Effect.fail(new Error('Step size must be non-negative')).pipe(Effect.orDie);
+      ) return yield* Effect.fail(new Error('Step size must be non-negative'));
 
       const overstep = validRange.width % givenStepSize;
 
       if (
         overstep !== 0
-      ) return yield* Effect.fail(new Error('Step size must fit evenly into the range')).pipe(Effect.orDie);
+      ) return yield* Effect.fail(new Error('Step size must fit evenly into the range'));
 
       const validDiscreteRange = new this(
         validRange.lowerBound,
@@ -59,7 +59,7 @@ class Range_Discrete
       );
 
       return validDiscreteRange;
-    });
+    }).pipe(Effect.orDie);
   }
 
   public override exclusivelyContains(givenValue: number): boolean {

--- a/src/library/Range/definition.declared.ts
+++ b/src/library/Range/definition.declared.ts
@@ -24,7 +24,7 @@ class Range {
       from: Range['lowerBound'];
       to: Range['upperBound'];
     },
-  ): Effect.Effect<Range> {
+  ): Effect.Effect<Range, Error> {
     return Effect.gen(this, function* () {
       if (
         givenUpperBound < givenLowerBound
@@ -36,7 +36,7 @@ class Range {
       );
 
       return validRange;
-    }).pipe(Effect.orDie);
+    });
   }
 
   public get width(): number {

--- a/src/library/Range/definition.declared.ts
+++ b/src/library/Range/definition.declared.ts
@@ -28,7 +28,7 @@ class Range {
     return Effect.gen(this, function* () {
       if (
         givenUpperBound < givenLowerBound
-      ) return yield* Effect.fail(new Error('Upper bound must not be lower than lower bound')).pipe(Effect.orDie);
+      ) return yield* Effect.fail(new Error('Upper bound must not be lower than lower bound'));
 
       const validRange = new this(
         givenLowerBound,
@@ -36,7 +36,7 @@ class Range {
       );
 
       return validRange;
-    });
+    }).pipe(Effect.orDie);
   }
 
   public get width(): number {

--- a/src/library/math/operators/predicate/isNegative.ts
+++ b/src/library/math/operators/predicate/isNegative.ts
@@ -11,10 +11,10 @@ const isNegative = (
 ): Effect.Effect<boolean> => Effect.gen(function* () {
   if (
     !isOperable(givenOperand)
-  ) return yield* Effect.fail(new Error('Operand must be operable')).pipe(Effect.orDie);
+  ) return yield* Effect.fail(new Error('Operand must be operable'));
 
   return (givenOperand < 0);
-});
+}).pipe(Effect.orDie);
 
 export {
   isNegative,

--- a/src/library/math/operators/predicate/isNegative.ts
+++ b/src/library/math/operators/predicate/isNegative.ts
@@ -8,13 +8,13 @@ import {
 
 const isNegative = (
   givenOperand: number,
-): Effect.Effect<boolean> => Effect.gen(function* () {
+): Effect.Effect<boolean, Error> => Effect.gen(function* () {
   if (
     !isOperable(givenOperand)
   ) return yield* Effect.fail(new Error('Operand must be operable'));
 
   return (givenOperand < 0);
-}).pipe(Effect.orDie);
+});
 
 export {
   isNegative,


### PR DESCRIPTION
- achieves this by avoiding intermediate use of `Effect.orDie`