### PR TITLE
tests: clarifies verbiage for "sad outcomes"

### DIFF
--- a/docs/testing/unit/seeds/functional.md
+++ b/docs/testing/unit/seeds/functional.md
@@ -108,9 +108,9 @@ describe(doSomething, () => {
       describe('due to <sadAdjectiveC> <pluralInputNoun>', () => {
         it.todo('should reject them');
 
-        it.todo('should safely propagate the error');
+        it.todo('should safely propagate the rejection');
 
-        it.todo('should communicate clearly with developers');
+        it.todo('should clearly communicate the rejection to developers');
       });
     });
   });

--- a/src/library/math/operators/predicate/isNegative.test.ts
+++ b/src/library/math/operators/predicate/isNegative.test.ts
@@ -42,7 +42,7 @@ describe(isNegative, () => {
         expect(() => isNegative(soleInoperableNumber).pipe(Effect.runSync)).toThrow(Error);
       });
 
-      it('should safely propagate the error', () => {
+      it('should safely propagate the rejection', () => {
         expect.assertions(1);
 
         expect((() => {
@@ -56,7 +56,7 @@ describe(isNegative, () => {
         })()).toBe(true);
       });
 
-      it('should communicate clearly with developers', () => {
+      it('should clearly communicate the rejection to developers', () => {
         expect.assertions(1);
 
         expect(() => isNegative(soleInoperableNumber).pipe(Effect.runSync)).toThrow('Operand must be operable');


### PR DESCRIPTION
- prefers "rejection" over "error" so the connotation leans more towards "failure" rather than "defect"