### PR TITLE
tests: clarifies assertion semantics in `isNegative` suite

### DIFF
--- a/src/library/math/operators/predicate/isNegative.test.ts
+++ b/src/library/math/operators/predicate/isNegative.test.ts
@@ -47,7 +47,7 @@ describe(isNegative, () => {
       it('should safely propagate the rejection', () => {
         expect.assertions(1);
 
-        expect((() => {
+        const soleOperationDidFail = (() => {
           // eslint-disable-next-line no-restricted-syntax
           try {
             isNegative(soleInoperableNumber).pipe(Effect.runSync);
@@ -55,7 +55,9 @@ describe(isNegative, () => {
           catch (error) {
             return Runtime.isFiberFailure(error);
           }
-        })()).toBe(true);
+        })();
+
+        expect(soleOperationDidFail).toBe(true);
       });
 
       it('should clearly communicate the rejection to developers', () => {

--- a/src/library/math/operators/predicate/isNegative.test.ts
+++ b/src/library/math/operators/predicate/isNegative.test.ts
@@ -99,7 +99,9 @@ describe(isNegative, () => {
     it.each(operableNumbers)('should accept valid operands', (eachOperableNumber) => {
       expect.assertions(1);
 
-      expect(() => isNegative(eachOperableNumber).pipe(Effect.runSync)).not.toThrow();
+      const eachOperation = (): boolean => isNegative(eachOperableNumber).pipe(Effect.runSync);
+
+      expect(eachOperation).not.toThrow();
     });
 
     it.each(infiniteAssertions)('should support infinite operands', (eachInfiniteNumber, eachExpectedOutput) => {

--- a/src/library/math/operators/predicate/isNegative.test.ts
+++ b/src/library/math/operators/predicate/isNegative.test.ts
@@ -129,7 +129,9 @@ describe(isNegative, () => {
     it.each(negativeFiniteNumbers)('should detect negative operands', (eachNegativeNumber) => {
       expect.assertions(1);
 
-      expect(isNegative(eachNegativeNumber).pipe(Effect.runSync)).toBe(true);
+      const outputForEachNegativeNumber = isNegative(eachNegativeNumber).pipe(Effect.runSync);
+
+      expect(outputForEachNegativeNumber).toBe(true);
     });
   });
 });

--- a/src/library/math/operators/predicate/isNegative.test.ts
+++ b/src/library/math/operators/predicate/isNegative.test.ts
@@ -113,7 +113,9 @@ describe(isNegative, () => {
     it.each(neutralFiniteNumbers)('should detect neutral operands', (eachNeutralNumber) => {
       expect.assertions(1);
 
-      expect(isNegative(eachNeutralNumber).pipe(Effect.runSync)).toBe(false);
+      const outputForEachNeutralNumber = isNegative(eachNeutralNumber).pipe(Effect.runSync);
+
+      expect(outputForEachNeutralNumber).toBe(false);
     });
 
     it.each(positiveFiniteNumbers)('should detect positive operands', (eachPositiveNumber) => {

--- a/src/library/math/operators/predicate/isNegative.test.ts
+++ b/src/library/math/operators/predicate/isNegative.test.ts
@@ -121,7 +121,9 @@ describe(isNegative, () => {
     it.each(positiveFiniteNumbers)('should detect positive operands', (eachPositiveNumber) => {
       expect.assertions(1);
 
-      expect(isNegative(eachPositiveNumber).pipe(Effect.runSync)).toBe(false);
+      const outputForEachPositiveNumber = isNegative(eachPositiveNumber).pipe(Effect.runSync);
+
+      expect(outputForEachPositiveNumber).toBe(false);
     });
 
     it.each(negativeFiniteNumbers)('should detect negative operands', (eachNegativeNumber) => {

--- a/src/library/math/operators/predicate/isNegative.test.ts
+++ b/src/library/math/operators/predicate/isNegative.test.ts
@@ -105,7 +105,9 @@ describe(isNegative, () => {
     it.each(infiniteAssertions)('should support infinite operands', (eachInfiniteNumber, eachExpectedOutput) => {
       expect.assertions(1);
 
-      expect(isNegative(eachInfiniteNumber).pipe(Effect.runSync)).toBe(eachExpectedOutput);
+      const eachActualOutput = isNegative(eachInfiniteNumber).pipe(Effect.runSync);
+
+      expect(eachActualOutput).toBe(eachExpectedOutput);
     });
 
     it.each(neutralFiniteNumbers)('should detect neutral operands', (eachNeutralNumber) => {

--- a/src/library/math/operators/predicate/isNegative.test.ts
+++ b/src/library/math/operators/predicate/isNegative.test.ts
@@ -39,7 +39,9 @@ describe(isNegative, () => {
       it('should reject the operand', () => {
         expect.assertions(1);
 
-        expect(() => isNegative(soleInoperableNumber).pipe(Effect.runSync)).toThrow(Error);
+        const soleFailingOperation = (): boolean => isNegative(soleInoperableNumber).pipe(Effect.runSync);
+
+        expect(soleFailingOperation).toThrow(Error);
       });
 
       it('should safely propagate the rejection', () => {

--- a/src/library/math/operators/predicate/isNegative.test.ts
+++ b/src/library/math/operators/predicate/isNegative.test.ts
@@ -61,7 +61,9 @@ describe(isNegative, () => {
       it('should clearly communicate the rejection to developers', () => {
         expect.assertions(1);
 
-        expect(() => isNegative(soleInoperableNumber).pipe(Effect.runSync)).toThrow('Operand must be operable');
+        const soleFailingOperation = (): boolean => isNegative(soleInoperableNumber).pipe(Effect.runSync);
+
+        expect(soleFailingOperation).toThrow('Operand must be operable');
       });
     });
   });


### PR DESCRIPTION
- the inputs for `expect(...)` should result in a phrase that flows like natural language
- if the inlined input doesn't achieve this, it's preferred to extract a variable