### PR TITLE
refactor(text-to-image): converts `TextToImage.Pipeline.Output.Image` to `Data.case`

### DIFF
--- a/src/features/TextToImage/Client/SDXL/toSharkUIOutput/Image/definition.declared.ts
+++ b/src/features/TextToImage/Client/SDXL/toSharkUIOutput/Image/definition.declared.ts
@@ -8,7 +8,7 @@ import type * as StabilityAIClient from 'stabilityai-client-typescript/models/co
 import Sequence from '@/library/Sequence';
 import URI from '@/library/URI';
 
-import type {
+import {
   TextToImage_Pipeline,
 } from '@/features/TextToImage/Pipeline'; // eslint-disable-line import/no-internal-modules -- more concise than relative import
 
@@ -27,10 +27,10 @@ function toSharkUIOutput_Image(
       Effect.orElseFail(() => new Error('Data for Stability AI image was not base64-encoded.')),
     );
 
-    const derivedImage = {
+    const derivedImage = TextToImage_Pipeline.Output.Image({
       uri        : new URI.Image('png', 'base64', base64DataOfRawImage),
       description: given.description,
-    };
+    });
 
     return derivedImage;
   });

--- a/src/features/TextToImage/Pipeline/Output/Image.ts
+++ b/src/features/TextToImage/Pipeline/Output/Image.ts
@@ -1,3 +1,7 @@
+import {
+  Data,
+} from 'effect';
+
 import type URI from '@/library/URI';
 
 interface TextToImage_Pipeline_Output_Image {
@@ -5,6 +9,8 @@ interface TextToImage_Pipeline_Output_Image {
   description: string;
 }
 
-export type {
+const TextToImage_Pipeline_Output_Image = Data.case<TextToImage_Pipeline_Output_Image>();
+
+export {
   TextToImage_Pipeline_Output_Image,
 };

--- a/src/features/TextToImage/Pipeline/Output/definition.declared.augmentation.ts
+++ b/src/features/TextToImage/Pipeline/Output/definition.declared.augmentation.ts
@@ -1,11 +1,17 @@
-import type {
+import {
   TextToImage_Pipeline_Output_Image,
 } from './Image';
+
+import {
+  TextToImage_Pipeline_Output,
+} from './definition.declared.ts';
+
+TextToImage_Pipeline_Output.Image = TextToImage_Pipeline_Output_Image;
 
 declare module './definition.declared.ts' {
   namespace TextToImage_Pipeline_Output {
     export {
-      type TextToImage_Pipeline_Output_Image as Image,
+      /**/ TextToImage_Pipeline_Output_Image as Image,
     };
   }
 }


### PR DESCRIPTION
- avoids over-reliance on structural type matches

Follows precedent set by #1258 with `TextToImage.Pipeline.Output`