### PR TITLE
refactor: transfers pattern concerns from "eslint.markdown.ts" to "eslint.config.ts"

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -16,7 +16,11 @@ import type {
 
 import pluginCypress from './cypress/eslint.config';
 import pluginImport from './eslint.import';
-import pluginMarkdown from './eslint.markdown';
+
+import pluginMarkdown, {
+  markdownPatterns,
+} from './eslint.markdown';
+
 import pluginStylistic from './eslint.stylistic';
 import pluginVitest from './eslint.vitest';
 
@@ -143,14 +147,12 @@ const completeConfig = defineConfig([
     // @ts-expect-error: according to bullet "2." under https://typescript-eslint.io/packages/typescript-eslint/#migrating-to-defineconfig
     extends: configWithVueTS,
     ignores: [
-      '**/*.md',
+      ...markdownPatterns,
     ],
   },
   {
     extends: pluginMarkdown,
-    files  : [
-      '**/*.md',
-    ],
+    files  : markdownPatterns,
   },
 ]);
 

--- a/eslint.markdown.ts
+++ b/eslint.markdown.ts
@@ -11,6 +11,11 @@ const pluginMarkdown: Linter.Config[] = [
   },
 ];
 
+const markdownPatterns = [
+  '**/*.md',
+];
+
 export {
   pluginMarkdown as default,
+  markdownPatterns,
 };


### PR DESCRIPTION
Sets precedent for #1297