### PR TITLE
linter: enforces 2-space indentation for all json files

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,61 +1,61 @@
 {
-    "cSpell.words": [
-        "vite",
-        "vitest",
-        "vuetify"
-    ],
-    "cSpell.customDictionaries": {
-        "package/effect": {
-            "name": "package/effect",
-            "path": "./dictionary.effect.txt",
-            "description": "Words introduced by the effect package",
-            "addWords": false
-        },
-        "library/math": {
-            "name": "library/math",
-            "path": "./src/library/math/dictionary.txt",
-            "description": "Words introduced by the @/library/math module",
-            "addWords": false
-        },
-        "library/Shortfin": {
-            "name": "library/Shortfin",
-            "path": "./src/library/Shortfin/dictionary.txt",
-            "description": "Words introduced by the @/library/Shortfin module",
-            "addWords": false
-        },
-        "stability-ai": {
-            "name": "stability-ai",
-            "path": "./dictionary.stability-ai.txt",
-            "description": "Words introduced by the stability-ai organization",
-            "addWords": false
-        }
+  "cSpell.words": [
+    "vite",
+    "vitest",
+    "vuetify"
+  ],
+  "cSpell.customDictionaries": {
+    "package/effect": {
+      "name": "package/effect",
+      "path": "./dictionary.effect.txt",
+      "description": "Words introduced by the effect package",
+      "addWords": false
     },
-    "editor.codeActionsOnSave": {
-        "source.fixAll": "explicit"
+    "library/math": {
+      "name": "library/math",
+      "path": "./src/library/math/dictionary.txt",
+      "description": "Words introduced by the @/library/math module",
+      "addWords": false
     },
-    "editor.rulers": [
-        {
-            "column": 80,
-            "color": "#00ff0020"
-        },
-        {
-            "column": 100,
-            "color": "#ffff0020"
-        },
-        {
-            "column": 120,
-            "color": "#ff000020"
-        }
-    ],
-    "explorer.fileNesting.enabled": true,
-    "explorer.fileNesting.patterns": {
-        "*.ts": "${capture}.test.ts",
-        "tsconfig.json": "tsconfig.*.json",
-        "vite.config.*": "jsconfig*, vitest.config.*, cypress.config.*, playwright.config.*, env.d.ts",
-        "package.json": "package-lock.json, pnpm*, .yarnrc*, yarn*",
-        "eslint.config.ts": ".eslint*, eslint*, .prettier*, prettier*, .editorconfig"
+    "library/Shortfin": {
+      "name": "library/Shortfin",
+      "path": "./src/library/Shortfin/dictionary.txt",
+      "description": "Words introduced by the @/library/Shortfin module",
+      "addWords": false
     },
-    "[markdown]": {
-        "editor.rulers": []
+    "stability-ai": {
+      "name": "stability-ai",
+      "path": "./dictionary.stability-ai.txt",
+      "description": "Words introduced by the stability-ai organization",
+      "addWords": false
     }
+  },
+  "editor.codeActionsOnSave": {
+    "source.fixAll": "explicit"
+  },
+  "editor.rulers": [
+    {
+      "column": 80,
+      "color": "#00ff0020"
+    },
+    {
+      "column": 100,
+      "color": "#ffff0020"
+    },
+    {
+      "column": 120,
+      "color": "#ff000020"
+    }
+  ],
+  "explorer.fileNesting.enabled": true,
+  "explorer.fileNesting.patterns": {
+    "*.ts": "${capture}.test.ts",
+    "tsconfig.json": "tsconfig.*.json",
+    "vite.config.*": "jsconfig*, vitest.config.*, cypress.config.*, playwright.config.*, env.d.ts",
+    "package.json": "package-lock.json, pnpm*, .yarnrc*, yarn*",
+    "eslint.config.ts": ".eslint*, eslint*, .prettier*, prettier*, .editorconfig"
+  },
+  "[markdown]": {
+    "editor.rulers": []
+  }
 }

--- a/eslint.jsonc.ts
+++ b/eslint.jsonc.ts
@@ -18,6 +18,16 @@ const pluginJSON: Linter.Config[] = [
       '**/.vite/**',
     ],
   },
+  {
+    name : 'shark-ui/jsonc/rules',
+    files: jsonPatterns,
+    rules: {
+      'jsonc/indent': [
+        'error',
+        2,
+      ],
+    },
+  },
 ];
 
 export {

--- a/public/config/text-to-image.json
+++ b/public/config/text-to-image.json
@@ -1,3 +1,3 @@
 {
-    "server": null
+  "server": null
 }


### PR DESCRIPTION
Follows up on #1297 