### PR TITLE
linter: enforces `scripts` order in package.json

### DIFF
--- a/eslint.jsonc.ts
+++ b/eslint.jsonc.ts
@@ -4,6 +4,35 @@ import type {
 
 import pluginJsonc from 'eslint-plugin-jsonc';
 
+const rulesForPackageJSON: Linter.Config = {
+  name : 'shark-ui/jsonc/package-json',
+  files: [
+    '**/package.json',
+  ],
+  rules: {
+    'jsonc/sort-keys': [
+      'error',
+      {
+        pathPattern: '^scripts$',
+        order      : [
+          'dev',
+          'prepare',
+          'lint',
+          'lint:docs',
+          'lint:json',
+          'type-check',
+          'build',
+          'build-only',
+          'preview',
+          'test:unit',
+          'test:e2e',
+          'test:e2e:dev',
+        ],
+      },
+    ],
+  },
+};
+
 const jsonPatterns = [
   '**/*.json',
 ];
@@ -28,6 +57,7 @@ const pluginJSON: Linter.Config[] = [
       ],
     },
   },
+  rulesForPackageJSON,
 ];
 
 export {

--- a/package.json
+++ b/package.json
@@ -9,13 +9,13 @@
     "build": "run-p type-check \"build-only {@}\" --",
     "preview": "vite preview",
     "test:unit": "vitest",
-    "test:e2e": "start-server-and-test preview http://localhost:4173 'cypress run --e2e'",
-    "test:e2e:dev": "start-server-and-test 'vite dev --port 4173' http://localhost:4173 'cypress open --e2e'",
     "build-only": "vite build",
     "type-check": "vue-tsc --build",
     "lint": "eslint . --cache --fix",
     "lint:docs": "markdownlint-cli2 --fix '**/*.md'",
-    "lint:json": "eslint '**/*.json' --fix"
+    "lint:json": "eslint '**/*.json' --fix",
+    "test:e2e": "start-server-and-test preview http://localhost:4173 'cypress run --e2e'",
+    "test:e2e:dev": "start-server-and-test 'vite dev --port 4173' http://localhost:4173 'cypress open --e2e'"
   },
   "dependencies": {
     "@effect/platform": "^0.92.1",

--- a/package.json
+++ b/package.json
@@ -5,10 +5,10 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
+    "prepare": "cypress install && husky",
     "build": "run-p type-check \"build-only {@}\" --",
     "preview": "vite preview",
     "test:unit": "vitest",
-    "prepare": "cypress install && husky",
     "test:e2e": "start-server-and-test preview http://localhost:4173 'cypress run --e2e'",
     "test:e2e:dev": "start-server-and-test 'vite dev --port 4173' http://localhost:4173 'cypress open --e2e'",
     "build-only": "vite build",

--- a/package.json
+++ b/package.json
@@ -9,11 +9,11 @@
     "lint": "eslint . --cache --fix",
     "lint:docs": "markdownlint-cli2 --fix '**/*.md'",
     "lint:json": "eslint '**/*.json' --fix",
+    "type-check": "vue-tsc --build",
     "build": "run-p type-check \"build-only {@}\" --",
     "preview": "vite preview",
     "test:unit": "vitest",
     "build-only": "vite build",
-    "type-check": "vue-tsc --build",
     "test:e2e": "start-server-and-test preview http://localhost:4173 'cypress run --e2e'",
     "test:e2e:dev": "start-server-and-test 'vite dev --port 4173' http://localhost:4173 'cypress open --e2e'"
   },

--- a/package.json
+++ b/package.json
@@ -11,9 +11,9 @@
     "lint:json": "eslint '**/*.json' --fix",
     "type-check": "vue-tsc --build",
     "build": "run-p type-check \"build-only {@}\" --",
+    "build-only": "vite build",
     "preview": "vite preview",
     "test:unit": "vitest",
-    "build-only": "vite build",
     "test:e2e": "start-server-and-test preview http://localhost:4173 'cypress run --e2e'",
     "test:e2e:dev": "start-server-and-test 'vite dev --port 4173' http://localhost:4173 'cypress open --e2e'"
   },

--- a/package.json
+++ b/package.json
@@ -6,14 +6,14 @@
   "scripts": {
     "dev": "vite",
     "prepare": "cypress install && husky",
+    "lint": "eslint . --cache --fix",
+    "lint:docs": "markdownlint-cli2 --fix '**/*.md'",
+    "lint:json": "eslint '**/*.json' --fix",
     "build": "run-p type-check \"build-only {@}\" --",
     "preview": "vite preview",
     "test:unit": "vitest",
     "build-only": "vite build",
     "type-check": "vue-tsc --build",
-    "lint": "eslint . --cache --fix",
-    "lint:docs": "markdownlint-cli2 --fix '**/*.md'",
-    "lint:json": "eslint '**/*.json' --fix",
     "test:e2e": "start-server-and-test preview http://localhost:4173 'cypress run --e2e'",
     "test:e2e:dev": "start-server-and-test 'vite dev --port 4173' http://localhost:4173 'cypress open --e2e'"
   },


### PR DESCRIPTION
 - arranges scripts in SDLC order

Follows up on #1297