### PR TITLE
linter(import): permits accessing submodules from scoped packages

### DIFF
--- a/eslint.import.ts
+++ b/eslint.import.ts
@@ -48,7 +48,7 @@ const extendedConfig: ConfigWithExtends = {
       {
         allow: [
           '**/*.vue', // .vue files must be imported directly for bundler to enable type-safety
-          '[a-z]*/**', // matches packages
+          '?(@)[a-z]*/**', // matches packages
           '@/*/*', // matches src modules
           '@/library/utilitiesByType/*', // bag of tools where consumer must pick a type
         ],


### PR DESCRIPTION
- packages define their own API surface, so there's no need to restrict access to path that might otherwise be considered internal modules