### PR TITLE
docs(agents): defines project-level instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,5 @@
+# Agent Instructions
+
+- [Validate changes](docs/setup/for_developers.md#validation)
+  - Do this after initial draft to leverage automated fixes and preserve context window.
+  - Iterate until all issues are resolved before passing to the user for review.


### PR DESCRIPTION
- this first instruction increases the chances that changes made by an agent are already linted and don't upset the compiler