### PR TITLE
linter: enforces new lines between named imports

### DIFF
--- a/eslint-internal/createInternalRule.ts
+++ b/eslint-internal/createInternalRule.ts
@@ -1,0 +1,9 @@
+import {
+  RuleCreator,
+} from '@typescript-eslint/utils/eslint-utils';
+
+const createInternalRule = RuleCreator((name) => `eslint-internal/${name}`);
+
+export {
+  createInternalRule,
+};

--- a/eslint-internal/rules/definition.declared.ts
+++ b/eslint-internal/rules/definition.declared.ts
@@ -2,8 +2,13 @@ import {
   preferNewLinesAroundConditionOfBlocklessIfStatements,
 } from './preferNewLinesAroundConditionOfBlocklessIfStatements';
 
+import {
+  preferNewLinesBetweenNamedImports,
+} from './preferNewLinesBetweenNamedImports';
+
 const pluginInternal_rules = {
   'prefer-new-lines-around-condition-of-blockless-if-statements': preferNewLinesAroundConditionOfBlocklessIfStatements,
+  'prefer-new-lines-between-named-imports'                      : preferNewLinesBetweenNamedImports,
 };
 
 export {

--- a/eslint-internal/rules/preferNewLinesAroundConditionOfBlocklessIfStatements.ts
+++ b/eslint-internal/rules/preferNewLinesAroundConditionOfBlocklessIfStatements.ts
@@ -10,12 +10,12 @@ import {
 } from '@typescript-eslint/utils/ast-utils';
 
 import {
-  RuleCreator,
-} from '@typescript-eslint/utils/eslint-utils';
-
-import {
   Effect,
 } from 'effect';
+
+import {
+  createInternalRule,
+} from '../createInternalRule';
 
 const hasBlock = (
   givenIfStatement: TSESTree.IfStatement,
@@ -90,8 +90,6 @@ const newLineExistsBefore = (
 
   return (previousToken.loc.end.line < givenToken.loc.start.line);
 });
-
-const createInternalRule = RuleCreator((name) => `eslint-internal/${name}`);
 
 const preferNewLinesAroundConditionOfBlocklessIfStatements = createInternalRule({
   name: 'prefer-new-lines-around-condition-of-blockless-if-statements',

--- a/eslint-internal/rules/preferNewLinesBetweenNamedImports.ts
+++ b/eslint-internal/rules/preferNewLinesBetweenNamedImports.ts
@@ -1,0 +1,80 @@
+import {
+  AST_NODE_TYPES,
+  type TSESTree,
+} from '@typescript-eslint/utils';
+
+import {
+  isNonEmptyArray,
+} from 'effect/Array';
+
+import {
+  createInternalRule,
+} from '../createInternalRule';
+
+const endPositionOfFirstCharacterOf = (
+  givenSpecifier: TSESTree.ImportSpecifier,
+): TSESTree.Position => ({
+  line  : givenSpecifier.loc.start.line,
+  column: givenSpecifier.loc.start.column + 1,
+});
+
+const locationOfFirstCharacterOf = (
+  givenSpecifier: TSESTree.ImportSpecifier,
+): TSESTree.SourceLocation => ({
+  start: givenSpecifier.loc.start,
+  end  : endPositionOfFirstCharacterOf(givenSpecifier),
+});
+
+const preferNewLinesBetweenNamedImports = createInternalRule({
+  name: 'prefer-new-lines-between-named-imports',
+  meta: {
+    docs: {
+      description: 'Enforce newlines between named imports in import declarations',
+    },
+    messages: {
+      missingNewLine: 'Each named import should be on its own line',
+    },
+    type   : 'layout',
+    schema : [],
+    fixable: 'whitespace',
+  },
+  defaultOptions: [],
+  create        : (context) => ({
+    ImportDeclaration: (someImportDeclaration) => {
+      const namedSpecifiers = someImportDeclaration.specifiers.filter(($0) => $0.type === AST_NODE_TYPES.ImportSpecifier);
+
+      if (
+        !isNonEmptyArray(namedSpecifiers)
+      ) return;
+
+      const reportFixableMissingNewLineBefore = (
+        givenSpecifier: TSESTree.ImportSpecifier,
+      ): void => {
+        context.report({
+          node     : someImportDeclaration,
+          messageId: 'missingNewLine',
+          loc      : locationOfFirstCharacterOf(givenSpecifier),
+          fix      : ($0) => $0.insertTextBefore(givenSpecifier, '\n'),
+        });
+      };
+
+      namedSpecifiers.forEach((eachSpecifier, indexOfEachSpecifier, allSpecifiers) => {
+        if (
+          indexOfEachSpecifier === 0
+        ) return;
+
+        const previousSpecifier = allSpecifiers[indexOfEachSpecifier - 1];
+
+        if (
+          previousSpecifier.loc.end.line !== eachSpecifier.loc.start.line
+        ) return;
+
+        reportFixableMissingNewLineBefore(eachSpecifier);
+      });
+    },
+  }),
+});
+
+export {
+  preferNewLinesBetweenNamedImports,
+};

--- a/eslint.internal.ts
+++ b/eslint.internal.ts
@@ -14,6 +14,9 @@ const pluginInternal: ConfigWithExtends[] = [
       'internal/prefer-new-lines-around-condition-of-blockless-if-statements': [
         'error', // Reduces diff noise when modifying conditions of guard clauses
       ],
+      'internal/prefer-new-lines-between-named-imports': [
+        'error', // Reduces diff noise and chance of merge conflicts when modifying import statements
+      ],
     },
   },
 ];


### PR DESCRIPTION
- makes changes to named imports are easier to combine during merge conflicts