### PR TITLE
linter(editor): widens scope to all file types

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -4,6 +4,5 @@ indent_size = 2
 indent_style = space
 insert_final_newline = true
 trim_trailing_whitespace = true
-
 end_of_line = lf
 max_line_length = 100

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,4 +1,4 @@
-[*.{js,jsx,mjs,cjs,ts,tsx,mts,cts,vue}]
+[*]
 charset = utf-8
 indent_size = 2
 indent_style = space


### PR DESCRIPTION
- the editor config rules are actually generic and can be applied to `.json`, `.md`, `.yaml`, etc.

Need was discovered while reviewing #1329