### PR TITLE
linter: enforces multiline arrays

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -127,7 +127,9 @@ configureVueProject({
 const configWithVueTS = defineConfigWithVueTs(
   {
     name : 'app/files-to-lint',
-    files: ['**/*.{ts,mts,tsx,vue}'],
+    files: [
+      '**/*.{ts,mts,tsx,vue}',
+    ],
   },
 
   {

--- a/eslint.jsonc.ts
+++ b/eslint.jsonc.ts
@@ -51,6 +51,18 @@ const pluginJSON: Linter.Config[] = [
     name : 'shark-ui/jsonc/rules',
     files: jsonPatterns,
     rules: {
+      'jsonc/array-bracket-newline': [
+        'error',
+        {
+          minItems: 1,
+        }, // Mirrors configuration specified in "eslint.stylistic.ts"
+      ],
+      'jsonc/array-element-newline': [
+        'error',
+        {
+          minItems: 1,
+        }, // Mirrors configuration specified in "eslint.stylistic.ts"
+      ],
       'jsonc/indent': [
         'error',
         2,

--- a/eslint.stylistic.ts
+++ b/eslint.stylistic.ts
@@ -10,6 +10,18 @@ const extraConfig: ConfigWithExtends = {
     '@stylistic': stylistic,
   },
   rules: {
+    '@stylistic/array-bracket-newline': [
+      'error',
+      {
+        minItems: 1,
+      }, // Reduces diff churn by isolating changes to the array elements.
+    ],
+    '@stylistic/array-element-newline': [
+      'error',
+      {
+        minItems: 1,
+      }, // Reduces diff churn by isolating changes to each array element.
+    ],
     '@stylistic/arrow-parens': [
       'error',
       'always', // Helps minimize diffs and mitigate merge conflicts.

--- a/src/features/Reporting/promptUserWith.ts
+++ b/src/features/Reporting/promptUserWith.ts
@@ -33,9 +33,11 @@ const Reporting_promptUserWith = (givenIssue: unknown): void => {
   const SharkUIRepository = new GitHub.Repository('nod-ai', 'shark-ui');
 
   const newIssue = SharkUIRepository.Issue.from({
-    title   : `[Unexpected Error]: can't <some task> when <some context>`,
-    body    : `### Details\n${formattedErrorDetails}`.replaceAll('\n', '\n> '),
-    labels  : ['bug'],
+    title : `[Unexpected Error]: can't <some task> when <some context>`,
+    body  : `### Details\n${formattedErrorDetails}`.replaceAll('\n', '\n> '),
+    labels: [
+      'bug',
+    ],
     category: 'Bug',
   });
 

--- a/src/features/TextToImage/Client/SDXL/toSharkUIOutput/first.ts
+++ b/src/features/TextToImage/Client/SDXL/toSharkUIOutput/first.ts
@@ -36,7 +36,10 @@ const toSharkUIOutput_first = (
     !isNonEmptyArray(inferredOutputs)
   ) return yield* Effect.fail(new Error('Response had no text-to-image outputs.'));
 
-  const [firstPipelineOutput] = inferredOutputs;
+  const [
+    firstPipelineOutput,
+  ] = inferredOutputs;
+
   return firstPipelineOutput;
 });
 

--- a/src/features/TextToImage/components/TextToImageInputSection.vue
+++ b/src/features/TextToImage/components/TextToImageInputSection.vue
@@ -53,7 +53,12 @@ type InputTextByQualitativeWeight = Record<QualitativeTextWeight, string>;
 
 const byQualitativeWeight = (givenInputText: StandardizedInputText): InputTextByQualitativeWeight => {
   const entriesForInputTextByQualitativeWeight = Object.entries(qualitativeToQuantitativeTextWeightMap)
-    .map(([eachUnsafeQualitativeWeight, eachQuantitativeWeight]) => {
+    .map((eachWeightMapEntry) => {
+      const [
+        eachUnsafeQualitativeWeight,
+        eachQuantitativeWeight,
+      ] = eachWeightMapEntry;
+
       const eachSerializationByWeight = givenInputText
         .filter(($0) => $0.weight === eachQuantitativeWeight)
         .map(($0) => $0.text.trim())
@@ -76,7 +81,12 @@ const byQualitativeWeight = (givenInputText: StandardizedInputText): InputTextBy
 
 const standardized = (givenInputText: InputTextByQualitativeWeight): StandardizedInputText => {
   const computedInputText = Object.entries(qualitativeToQuantitativeTextWeightMap)
-    .map(([eachUnsafeQualitativeWeight, eachQuantitativeWeight]): StandardizedInputText[number] => {
+    .map((eachWeightMapEntry): StandardizedInputText[number] => {
+      const [
+        eachUnsafeQualitativeWeight,
+        eachQuantitativeWeight,
+      ] = eachWeightMapEntry;
+
       const eachQualitativeWeight = eachUnsafeQualitativeWeight as QualitativeTextWeight;
       const weightedText = givenInputText[eachQualitativeWeight];
 

--- a/src/library/Shortfin/TextToImage/SDXL/Client/definition.declared.ts
+++ b/src/library/Shortfin/TextToImage/SDXL/Client/definition.declared.ts
@@ -35,7 +35,11 @@ class Shortfin_TextToImage_SDXL_Client {
 
     const decodedBodyFrom = HttpClientResponse.schemaBodyJson(Shortfin_TextToImage_SDXL_Client_Response.Body);
     const decodedResource = yield* decodedBodyFrom(generationResponse).pipe(Effect.orDie);
-    const [soleGeneratedImage] = decodedResource.images;
+
+    const [
+      soleGeneratedImage,
+    ] = decodedResource.images;
+
     return soleGeneratedImage;
   }).pipe(
     Effect.provide(FetchHttpClient.layer),

--- a/src/library/math/operators/predicate/isNegative.test.ts
+++ b/src/library/math/operators/predicate/isNegative.test.ts
@@ -65,11 +65,17 @@ describe(isNegative, () => {
 
   describe('the happy outcomes', () => {
     const infiniteAssertions = [
-      [infinite.negative, true],
-      [infinite.positive, false],
+      {
+        value         : infinite.negative,
+        expectedOutput: true,
+      },
+      {
+        value         : infinite.positive,
+        expectedOutput: false,
+      },
     ] as const;
 
-    const infiniteNumbers = infiniteAssertions.map(($0) => $0[0]);
+    const infiniteNumbers = infiniteAssertions.map(($0) => $0.value);
 
     const neutralFiniteNumbers = [
       neutralNumber,
@@ -103,12 +109,12 @@ describe(isNegative, () => {
       expect(eachOperationDidSucceed).toBe(true);
     }));
 
-    it.effect.each(infiniteAssertions)('should support infinite operands', ([eachInfiniteNumber, eachExpectedOutput]) => Effect.gen(function* () {
+    it.effect.each(infiniteAssertions)('should support infinite operands', (eachAssertion) => Effect.gen(function* () {
       expect.assertions(1);
 
-      const eachActualOutput = yield* isNegative(eachInfiniteNumber);
+      const eachActualOutput = yield* isNegative(eachAssertion.value);
 
-      expect(eachActualOutput).toBe(eachExpectedOutput);
+      expect(eachActualOutput).toBe(eachAssertion.expectedOutput);
     }));
 
     it.effect.each(neutralFiniteNumbers)('should detect neutral operands', (eachNeutralNumber) => Effect.gen(function* () {

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -3,8 +3,14 @@
     "./tsconfig.common.json",
     "@vue/tsconfig/tsconfig.dom.json"
   ],
-  "include": ["env.d.ts", "src/**/*", "src/**/*.vue"],
-  "exclude": ["src/**/__tests__/*"],
+  "include": [
+    "env.d.ts",
+    "src/**/*",
+    "src/**/*.vue"
+  ],
+  "exclude": [
+    "src/**/__tests__/*"
+  ],
   "compilerOptions": {
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
 
@@ -17,7 +23,9 @@
     ],
     "noImplicitOverride": true,
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": [
+        "./src/*"
+      ]
     }
   }
 }

--- a/tsconfig.vitest.json
+++ b/tsconfig.vitest.json
@@ -1,11 +1,17 @@
 {
   "extends": "./tsconfig.app.json",
-  "include": ["src/**/__tests__/*", "env.d.ts"],
+  "include": [
+    "src/**/__tests__/*",
+    "env.d.ts"
+  ],
   "exclude": [],
   "compilerOptions": {
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.vitest.tsbuildinfo",
 
     "lib": [],
-    "types": ["node", "jsdom"]
+    "types": [
+      "node",
+      "jsdom"
+    ]
   }
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -15,8 +15,11 @@ const vitestConfig = mergeConfig(
   defineConfig({
     test: {
       environment: 'jsdom',
-      exclude    : [...configDefaults.exclude, 'e2e/**'],
-      root       : fileURLToPath(new URL('./', import.meta.url)),
+      exclude    : [
+        ...configDefaults.exclude,
+        'e2e/**',
+      ],
+      root: fileURLToPath(new URL('./', import.meta.url)),
     },
   }),
 );


### PR DESCRIPTION
- changes to tuples or multi-element arrays can be a common source of diff noise
- this can come about when adding, removing, renaming, or reordering elements
- by keeping elements on separate lines, each of those kinds of changes are easier to do and/or easier to resolve in the context of a merge conflict.

Found while drafting #1336 