### PR TITLE
types(config): corrects test patterns

### DIFF
--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -9,7 +9,7 @@
     "src/**/*.vue"
   ],
   "exclude": [
-    "src/**/__tests__/*"
+    "src/**/*.test*"
   ],
   "compilerOptions": {
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",

--- a/tsconfig.vitest.json
+++ b/tsconfig.vitest.json
@@ -1,7 +1,7 @@
 {
   "extends": "./tsconfig.app.json",
   "include": [
-    "src/**/__tests__/*",
+    "src/**/*.test*",
     "env.d.ts"
   ],
   "exclude": [],


### PR DESCRIPTION
- this codebase puts unit test suites adjacent to their units rather than mirroring them in something like a "/__tests__" directory