### PR TITLE
ci(dependabot): automates non-major bumps for markdownlint-cli2

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -45,6 +45,7 @@ jobs:
               "eslint",
               "eslint-plugin-cypress",
               "eslint-plugin-vue",
+              "markdownlint-cli2",
               "typescript-eslint",
               "typescript",
               "vite",


### PR DESCRIPTION
Enabled by #1380