### PR TITLE
ci(dependabot): increases open PR limit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,7 +19,7 @@ updates:
       interval: "daily"
       time: "06:00"
       timezone: "EST"
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 10
     commit-message:
       prefix: "chore"
       include: "scope"


### PR DESCRIPTION
- the low limit was causing automatic bumps to be stuck behind manual bumps