### PR TITLE
fix: corrects kebab-case repo names

### DIFF
--- a/.github/ISSUE_TEMPLATE/track-release.md
+++ b/.github/ISSUE_TEMPLATE/track-release.md
@@ -10,20 +10,20 @@ assignees: bjacobgordon
 
 ## Checkpoints
 
-- [ ] create `staging/v#.#.#` branch off of [integration](https://github.com/nod-ai/amdshark-ui/tree/integration)
+- [ ] create `staging/v#.#.#` branch off of [integration](https://github.com/nod-ai/amd-shark-ui/tree/integration)
   - [ ] commit version bump to "*-rc.0"
 - [ ] open PR for branch: ?
 - [ ] perform QA, listing issues below
   - [ ] when done, commit version bump without pre-release component
-- [ ] [draft release entry](https://github.com/nod-ai/amdshark-ui/releases/new): ?
+- [ ] [draft release entry](https://github.com/nod-ai/amd-shark-ui/releases/new): ?
 - [ ] bundle package
 - [ ] add package to release notes
-- [ ] merge PR into [release](https://github.com/nod-ai/amdshark-ui/tree/release) branch
-  - [ ] add tag on [release](https://github.com/nod-ai/amdshark-ui/tree/release) branch: ?
-- [ ] open PR comparing [release](https://github.com/nod-ai/amdshark-ui/tree/release) to [integration](https://github.com/nod-ai/amdshark-ui/tree/integration): #???
+- [ ] merge PR into [release](https://github.com/nod-ai/amd-shark-ui/tree/release) branch
+  - [ ] add tag on [release](https://github.com/nod-ai/amd-shark-ui/tree/release) branch: ?
+- [ ] open PR comparing [release](https://github.com/nod-ai/amd-shark-ui/tree/release) to [integration](https://github.com/nod-ai/amd-shark-ui/tree/integration): #???
   - [ ] merge with merge commit rather than "squash and merge" or "rebase and merge" (ensures `release` is strictly behind `integration`)
 - [ ] submit release draft
-- [ ] update [template](https://github.com/nod-ai/amdshark-ui/blob/integration/.github/ISSUE_TEMPLATE/track-release.md), if needed
+- [ ] update [template](https://github.com/nod-ai/amd-shark-ui/blob/integration/.github/ISSUE_TEMPLATE/track-release.md), if needed
 
 ## Problems
 

--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@
 
 ## Introduction
 
-Welcome to AMD-SHARK UI! This repo contains a basic app to demonstrate how to use the [Shortfin](https://github.com/nod-ai/amdshark-ai/tree/main/shortfin) Web APIs for text-to-image and text-to-text inference.
+Welcome to AMD-SHARK UI! This repo contains a basic app to demonstrate how to use the [Shortfin](https://github.com/nod-ai/amd-shark-ai/tree/main/shortfin) Web APIs for text-to-image and text-to-text inference.
 
 ## Preview
 
-![A screenshot of AMD-SHARK UI, depicted after a successful inference request for the legendary Blue-Eyes White Snow Cat](docs/screenshots/amdshark-ui-after-successful-image-generation.png "AMD-SHARK UI after Successful Image Generation")
+![A screenshot of AMD-SHARK UI, depicted after a successful inference request for the legendary Blue-Eyes White Snow Cat](docs/screenshots/amd-shark-ui-after-successful-image-generation.png "AMD-SHARK UI after Successful Image Generation")
 
 ## Setup
 
@@ -21,4 +21,4 @@ DISCLAIMER: this application is for demonstration purposes only and is not inten
 
 ## Need Anything?
 
-- [Create an issue](https://github.com/nod-ai/amdshark-ui/issues)
+- [Create an issue](https://github.com/nod-ai/amd-shark-ui/issues)

--- a/docs/setup/common_prerequisites.md
+++ b/docs/setup/common_prerequisites.md
@@ -3,5 +3,5 @@
 Follow these steps to get the full AMD-SHARK UI experience, regardless of your flow!
 
 1. Serve an instance of the Shortfin text-to-image service
-    - i.e. [for SDXL](https://github.com/nod-ai/amdshark-ai/tree/main/shortfin/python/shortfin_apps/sd)
+    - i.e. [for SDXL](https://github.com/nod-ai/amd-shark-ai/tree/main/shortfin/python/shortfin_apps/sd)
 1. **If inference is being served from a remote machine**, [have your local machine forward the requests](local_forwarding.md)

--- a/docs/setup/for_developers.md
+++ b/docs/setup/for_developers.md
@@ -15,8 +15,8 @@ Let's sink some teeth into AMD-SHARK UI!
 1. Clone the latest version
 
     ```shell
-    git clone https://github.com/nod-ai/amdshark-ui.git
-    cd amdshark-ui
+    git clone https://github.com/nod-ai/amd-shark-ui.git
+    cd amd-shark-ui
     ```
 
 1. Install it's dependencies:

--- a/docs/setup/for_users.md
+++ b/docs/setup/for_users.md
@@ -6,7 +6,7 @@ Let's get AMD-SHARK UI up and swimming!
 
 ## Installation
 
-1. Go to [the latest release](https://github.com/nod-ai/amdshark-ui/releases)
+1. Go to [the latest release](https://github.com/nod-ai/amd-shark-ui/releases)
 1. Find the "Assets" section of the release
 1. Download a versioned copy
     - i.e. "package-v1.0.0.zip"

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -30,7 +30,7 @@ import pluginStylistic from './eslint.stylistic';
 import pluginVitest from './eslint.vitest';
 
 const extraConfigForESLint: ConfigWithExtends = {
-  name : 'amdshark-ui/eslint',
+  name : 'amd-shark-ui/eslint',
   rules: {
     'curly': [
       'error',
@@ -71,7 +71,7 @@ const extraConfigForESLint: ConfigWithExtends = {
 };
 
 const extraConfigForTypeScriptESLint: ConfigWithExtends = {
-  name : 'amdshark-ui/@typescript-eslint',
+  name : 'amd-shark-ui/@typescript-eslint',
   rules: {
     '@typescript-eslint/consistent-type-exports': [
       'error',
@@ -109,7 +109,7 @@ const extraConfigForTypeScriptESLint: ConfigWithExtends = {
 };
 
 const VueTSConfig_overridesForAugmentationsToModuleDefinitions: ConfigWithExtends = {
-  name : 'amdshark-ui/module-definition-augmentations',
+  name : 'amd-shark-ui/module-definition-augmentations',
   files: [
     '**/definition.declared.augmentation.ts',
   ],

--- a/eslint.import.ts
+++ b/eslint.import.ts
@@ -5,7 +5,7 @@ import type {
 } from 'typescript-eslint';
 
 const extendedConfig: ConfigWithExtends = {
-  name : 'amdshark-ui/import',
+  name : 'amd-shark-ui/import',
   files: [
     '**/*.{ts,vue}',
   ],

--- a/eslint.internal.ts
+++ b/eslint.internal.ts
@@ -6,7 +6,7 @@ import eslintInternal from './eslint-internal';
 
 const pluginInternal: ConfigWithExtends[] = [
   {
-    name   : 'amdshark-ui/internal',
+    name   : 'amd-shark-ui/internal',
     plugins: {
       internal: eslintInternal,
     },

--- a/eslint.jsonc.ts
+++ b/eslint.jsonc.ts
@@ -5,7 +5,7 @@ import type {
 import pluginJsonc from 'eslint-plugin-jsonc';
 
 const rulesForPackageJSON: Linter.Config = {
-  name : 'amdshark-ui/jsonc/package-json',
+  name : 'amd-shark-ui/jsonc/package-json',
   files: [
     '**/package.json',
   ],
@@ -40,7 +40,7 @@ const jsonPatterns = [
 const pluginJSON: Linter.Config[] = [
   ...pluginJsonc.configs['flat/recommended-with-json'],
   {
-    name   : 'amdshark-ui/jsonc/ignore-generated',
+    name   : 'amd-shark-ui/jsonc/ignore-generated',
     ignores: [
       '**/package-lock.json',
       '**/coverage/**',
@@ -48,7 +48,7 @@ const pluginJSON: Linter.Config[] = [
     ],
   },
   {
-    name : 'amdshark-ui/jsonc/rules',
+    name : 'amd-shark-ui/jsonc/rules',
     files: jsonPatterns,
     rules: {
       'jsonc/array-bracket-newline': [

--- a/eslint.stylistic.ts
+++ b/eslint.stylistic.ts
@@ -5,7 +5,7 @@ import type {
 } from 'typescript-eslint';
 
 const extraConfig: ConfigWithExtends = {
-  name   : 'amdshark-ui/extra-stylistic',
+  name   : 'amd-shark-ui/extra-stylistic',
   plugins: {
     '@stylistic': stylistic,
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "amdshark-ui",
+  "name": "amd-shark-ui",
   "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "amdshark-ui",
+      "name": "amd-shark-ui",
       "version": "0.6.0",
       "dependencies": {
         "@effect/platform": "^0.93.6",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "amdshark-ui",
+  "name": "amd-shark-ui",
   "version": "0.6.0",
   "private": true,
   "type": "module",

--- a/src/features/Reporting/promptUserWith.ts
+++ b/src/features/Reporting/promptUserWith.ts
@@ -30,7 +30,7 @@ const Reporting_promptUserWith = (givenIssue: unknown): void => {
     !userDidPermitDraftingNewIssue
   ) return;
 
-  const AMDSharkUIRepository = new GitHub.Repository('nod-ai', 'amdshark-ui');
+  const AMDSharkUIRepository = new GitHub.Repository('nod-ai', 'amd-shark-ui');
 
   const newIssue = AMDSharkUIRepository.Issue.from({
     title : `[Unexpected Error]: can't <some task> when <some context>`,


### PR DESCRIPTION
- a hyphen was missing, which broke many hyperlinks

Introduced in #1362