### PR TITLE
linter(vue): enforces same-name shorthand for v-bind

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -8,8 +8,6 @@ import {
   defineConfig,
 } from 'eslint/config';
 
-import uncustomizedPluginVue from 'eslint-plugin-vue';
-
 import type {
   ConfigWithExtends,
 } from 'typescript-eslint';
@@ -28,6 +26,7 @@ import pluginMarkdown, {
 
 import pluginStylistic from './eslint.stylistic';
 import pluginVitest from './eslint.vitest';
+import pluginVue from './eslint.vue';
 
 const extraConfigForESLint: ConfigWithExtends = {
   name : 'amd-shark-ui/eslint',
@@ -147,7 +146,7 @@ const configWithVueTS = defineConfigWithVueTs(
   ...pluginImport,
   ...pluginInternal,
 
-  uncustomizedPluginVue.configs['flat/recommended'],
+  ...pluginVue,
   VueTSConfig.strictTypeChecked,
   VueTSConfig.stylisticTypeChecked,
   VueTSConfig_overridesForAugmentationsToModuleDefinitions,

--- a/eslint.vue.ts
+++ b/eslint.vue.ts
@@ -1,0 +1,13 @@
+import uncustomizedPluginVue from 'eslint-plugin-vue';
+
+import type {
+  InfiniteDepthConfigWithExtends,
+} from 'typescript-eslint';
+
+const pluginVue: InfiniteDepthConfigWithExtends[] = [
+  uncustomizedPluginVue.configs['flat/recommended'],
+];
+
+export {
+  pluginVue as default,
+};

--- a/eslint.vue.ts
+++ b/eslint.vue.ts
@@ -6,6 +6,17 @@ import type {
 
 const pluginVue: InfiniteDepthConfigWithExtends[] = [
   uncustomizedPluginVue.configs['flat/recommended'],
+  {
+    rules: {
+      'vue/v-bind-style': [
+        'error',
+        'shorthand',
+        {
+          sameNameShorthand: 'always', // Makes it easier to see when a prop is just being passed through to a child component
+        },
+      ],
+    },
+  },
 ];
 
 export {

--- a/src/features/TextToImage/components/TextToImageOutputAlert.vue
+++ b/src/features/TextToImage/components/TextToImageOutputAlert.vue
@@ -12,10 +12,10 @@ defineProps<{
 <template>
   <TextToImageServerSpecificationAlert
     v-if="(error instanceof TextToImage.Server.Error.MissingSpecification)"
-    :error="error"
+    :error
   />
   <TextToImageServerConnectionAlert
     v-else
-    :error="error"
+    :error
   />
 </template>

--- a/src/pages/TextToImagePage.vue
+++ b/src/pages/TextToImagePage.vue
@@ -94,7 +94,7 @@ const imageGeneration = progressiveRef(Effect.gen(function* () {
       <DiscreteSlider
         v-model="currentNumberOfDiffusionSteps"
         label="Number of Diffusion Steps"
-        :range="range"
+        :range
         :tick-step="10"
       />
 


### PR DESCRIPTION
Found while drafting #1399