### PR TITLE
linter: enforces ".ts" extensions for single-file only modules

### DIFF
--- a/eslint-internal/rules/definition.declared.ts
+++ b/eslint-internal/rules/definition.declared.ts
@@ -6,9 +6,14 @@ import {
   preferNewLinesBetweenNamedImports,
 } from './preferNewLinesBetweenNamedImports';
 
+import {
+  requireExtensionForTSModules,
+} from './requireExtensionForTSModules';
+
 const pluginInternal_rules = {
   'prefer-new-lines-around-condition-of-blockless-if-statements': preferNewLinesAroundConditionOfBlocklessIfStatements,
   'prefer-new-lines-between-named-imports'                      : preferNewLinesBetweenNamedImports,
+  'require-extension-for-ts-modules'                            : requireExtensionForTSModules,
 };
 
 export {

--- a/eslint-internal/rules/requireExtensionForTSModules.ts
+++ b/eslint-internal/rules/requireExtensionForTSModules.ts
@@ -1,0 +1,137 @@
+import type {
+  TSESTree,
+} from '@typescript-eslint/utils';
+
+import {
+  Effect,
+} from 'effect';
+
+import {
+  escape,
+} from 'effect/RegExp';
+
+import {
+  createInternalRule,
+} from '../createInternalRule';
+
+const TypeScript_File_Path_extension = '.ts';
+
+interface WhitelistOption {
+  allow: string[];
+}
+
+const requireExtensionForTSModules = createInternalRule({
+  name: 'require-extension-for-ts-modules',
+  meta: {
+    docs: {
+      description: `Enforce specifying ${TypeScript_File_Path_extension} extensions for specific import paths`,
+    },
+    messages: {
+      requireExtension: `Import path "{{path}}" must include ${TypeScript_File_Path_extension} extension because it matches whitelisted filename "{{filename}}"`,
+      forbidExtension : `Import path "{{path}}" must not include ${TypeScript_File_Path_extension} extension because it does not match any whitelisted filename`,
+    },
+    type  : 'problem',
+    schema: [
+      {
+        type      : 'object',
+        properties: {
+          allow: {
+            type       : 'array',
+            description: 'A list of filenames that are allowed to have the .ts extension',
+            items      : {
+              type: 'string',
+            },
+            minItems   : 1,
+            uniqueItems: true,
+          },
+        },
+        required: [
+          'allow',
+        ],
+        additionalProperties: false,
+      },
+    ],
+    fixable: 'code',
+  },
+  defaultOptions: [
+    {
+      allow: [],
+    },
+  ],
+  create: (
+    context,
+    options: readonly [
+      WhitelistOption,
+    ],
+  ) => Effect.gen(function* () {
+    const whitelistedFilenames = options[0].allow;
+
+    if (
+      whitelistedFilenames.some(($0) => !$0.endsWith(TypeScript_File_Path_extension))
+    ) return yield* Effect.dieMessage(`All filenames must end with ${TypeScript_File_Path_extension}.`);
+
+    if (
+      whitelistedFilenames.some(($0) => $0.includes('/'))
+    ) return yield* Effect.dieMessage('All filenames must exclude their enveloping directories.');
+
+    const ensureTSExtensionForWhitelistedPath = (
+      givenNode:
+        | TSESTree.ImportDeclaration
+        | TSESTree.ExportNamedDeclaration
+        | TSESTree.ExportAllDeclaration,
+    ): void => Effect.gen(function* () {
+      const modulePathLiteral = yield* Effect.fromNullable(givenNode.source);
+
+      const modulePath = modulePathLiteral.value;
+
+      if (modulePath.endsWith(TypeScript_File_Path_extension)) {
+        const modulePathShouldKeepExtension = whitelistedFilenames.some(($0) => modulePath.endsWith($0));
+
+        if (
+          modulePathShouldKeepExtension
+        ) return yield* Effect.void;
+
+        const modulePathWithoutExtension = modulePath.replace(new RegExp(`${escape(TypeScript_File_Path_extension)}$`), '');
+
+        context.report({
+          node     : modulePathLiteral,
+          messageId: 'forbidExtension',
+          data     : {
+            path: modulePath,
+          },
+          fix: ($0) => $0.replaceText(modulePathLiteral, `'${modulePathWithoutExtension}'`),
+        });
+      }
+      else {
+        const modulePathWithExtension = `${modulePath}${TypeScript_File_Path_extension}`;
+
+        const matchingFilename = yield* Effect.fromNullable(
+          whitelistedFilenames.find(($0) => modulePathWithExtension.endsWith($0)),
+        );
+
+        context.report({
+          node     : modulePathLiteral,
+          messageId: 'requireExtension',
+          data     : {
+            path    : modulePath,
+            filename: matchingFilename,
+          },
+          fix: ($0) => $0.replaceText(modulePathLiteral, `'${modulePathWithExtension}'`),
+        });
+      }
+    }).pipe(
+      Effect.orElse(() => Effect.void),
+      Effect.runSync,
+    );
+
+    return {
+      ImportDeclaration     : ensureTSExtensionForWhitelistedPath,
+      ExportNamedDeclaration: ensureTSExtensionForWhitelistedPath,
+      ExportAllDeclaration  : ensureTSExtensionForWhitelistedPath,
+    };
+  }).pipe(Effect.runSync),
+});
+
+export {
+  requireExtensionForTSModules,
+};

--- a/eslint.internal.ts
+++ b/eslint.internal.ts
@@ -17,6 +17,21 @@ const pluginInternal: ConfigWithExtends[] = [
       'internal/prefer-new-lines-between-named-imports': [
         'error', // Reduces diff noise and chance of merge conflicts when modifying import statements
       ],
+      'internal/require-extension-for-ts-modules': [
+        'error',
+        {
+          allow: [
+            'definition.declared.ts', // Always has just one declaration, so should never be directory-based
+            'definition.declared.augmentation.ts', // Always a pure side effect, so should never be directory-based
+            'definition.declared.withAugmentation.ts', // Always a barrel file, so should never be directory-based
+            'definition.assembled.members.ts', // Always a barrel file, so should never be directory-based
+            'definition.assembled.ts', // Always a barrel file, so should never be directory-based
+            'exports.object.primary.ts', // Always a barrel file, so should never be directory-based
+            'exports.object.auxiliaries.ts', // Always a barrel file, so should never be directory-based
+            'exports.toolbox.ts', // Always a barrel file, so should never be directory-based
+          ],
+        },
+      ],
     },
   },
 ];


### PR DESCRIPTION
Enforces precedent set by #609