### PR TITLE
refactor: avoids implicit call of effectful methods

### DIFF
--- a/src/features/TextToImage/Client/SDXL/generateOutputFrom.ts
+++ b/src/features/TextToImage/Client/SDXL/generateOutputFrom.ts
@@ -38,7 +38,7 @@ const TextToImage_Client_SDXL_generateOutputFrom = (
     >;
   },
 ): TextToImage_Client_Generation.Effect => Effect.gen(function* () {
-  const shimmedStabilityAIClient = yield* TextToImage_Client_SDXL_initialize;
+  const shimmedStabilityAIClient = yield* TextToImage_Client_SDXL_initialize();
 
   const promisedTextToImageResponse = shimmedStabilityAIClient.version1.image.forciblyGenerateFromText({
     engineId              : 'stable-diffusion-xl-1024-v1-0',

--- a/src/features/TextToImage/Client/SDXL/initialize.ts
+++ b/src/features/TextToImage/Client/SDXL/initialize.ts
@@ -12,7 +12,7 @@ const TextToImage_Client_SDXL_initialize: Effect.Effect<
   ShimmedStabilityAIClient,
   TextToImage_Server.Error.MissingSpecification
 > = Effect.gen(function* () {
-  const currentTextToImageServer = yield* TextToImage_Server.Current.retrieve;
+  const currentTextToImageServer = yield* TextToImage_Server.Current.retrieve();
 
   const newStabilityAIClient = new ShimmedStabilityAIClient({
     serverURL: currentTextToImageServer.origin,

--- a/src/features/TextToImage/Client/SDXL/initialize.ts
+++ b/src/features/TextToImage/Client/SDXL/initialize.ts
@@ -8,10 +8,10 @@ import {
   TextToImage_Server,
 } from '../../Server';
 
-const TextToImage_Client_SDXL_initialize: Effect.Effect<
+const TextToImage_Client_SDXL_initialize = (): Effect.Effect<
   ShimmedStabilityAIClient,
   TextToImage_Server.Error.MissingSpecification
-> = Effect.gen(function* () {
+> => Effect.gen(function* () {
   const currentTextToImageServer = yield* TextToImage_Server.Current.retrieve();
 
   const newStabilityAIClient = new ShimmedStabilityAIClient({

--- a/src/features/TextToImage/Config/Dynamic/fetch.ts
+++ b/src/features/TextToImage/Config/Dynamic/fetch.ts
@@ -20,7 +20,7 @@ import {
   TextToImage_Config_Dynamic_endpoint,
 } from './endpoint';
 
-const TextToImage_Config_Dynamic_fetch: TextToImage_Config_Dynamic_Fetching.Effect = Effect.gen(function* () {
+const TextToImage_Config_Dynamic_fetch = (): TextToImage_Config_Dynamic_Fetching.Effect => Effect.gen(function* () {
   const endpointResponse = yield* HttpClient.get(TextToImage_Config_Dynamic_endpoint);
   const decodedBodyFrom = HttpClientResponse.schemaBodyJson(TextToImage_Config);
   const decodedConfigFromEndpoint = yield* decodedBodyFrom(endpointResponse).pipe(Effect.orDie);

--- a/src/features/TextToImage/Config/Static/read.ts
+++ b/src/features/TextToImage/Config/Static/read.ts
@@ -20,7 +20,7 @@ import {
   TextToImage_Config_Static_file,
 } from './file';
 
-const TextToImage_Config_Static_read: TextToImage_Config_Static_Reading.Effect = Effect.gen(function* () {
+const TextToImage_Config_Static_read = (): TextToImage_Config_Static_Reading.Effect => Effect.gen(function* () {
   const fileResponse = yield* HttpClient.get(TextToImage_Config_Static_file);
   const decodedBodyFrom = HttpClientResponse.schemaBodyJson(TextToImage_Config);
   const decodedConfigFromFile = yield* decodedBodyFrom(fileResponse).pipe(Effect.orDie);

--- a/src/features/TextToImage/Server/Current/retrieve.ts
+++ b/src/features/TextToImage/Server/Current/retrieve.ts
@@ -30,7 +30,7 @@ const TextToImage_Server_Current_retrieve = (): Effect.Effect<
   ) return TextToImage_Server_Current_accordingToEnvironment.value;
 
   const remoteConfig = yield* Effect.firstSuccessOf([
-    TextToImage_Config.Static.read,
+    TextToImage_Config.Static.read(),
     TextToImage_Config.Dynamic.fetch,
   ]).pipe(
     Effect.orElseSucceed(() => TextToImage_Config.empty),

--- a/src/features/TextToImage/Server/Current/retrieve.ts
+++ b/src/features/TextToImage/Server/Current/retrieve.ts
@@ -21,10 +21,10 @@ import {
   TextToImage_Server_Current_accordingToEnvironment,
 } from './accordingToEnvironment';
 
-const TextToImage_Server_Current_retrieve: Effect.Effect<
+const TextToImage_Server_Current_retrieve = (): Effect.Effect<
   WebAPI.Server,
   TextToImage_Server_Error.MissingSpecification
-> = Effect.gen(function* () {
+> => Effect.gen(function* () {
   if (
     Option.isSome(TextToImage_Server_Current_accordingToEnvironment)
   ) return TextToImage_Server_Current_accordingToEnvironment.value;

--- a/src/features/TextToImage/Server/Current/retrieve.ts
+++ b/src/features/TextToImage/Server/Current/retrieve.ts
@@ -31,7 +31,7 @@ const TextToImage_Server_Current_retrieve = (): Effect.Effect<
 
   const remoteConfig = yield* Effect.firstSuccessOf([
     TextToImage_Config.Static.read(),
-    TextToImage_Config.Dynamic.fetch,
+    TextToImage_Config.Dynamic.fetch(),
   ]).pipe(
     Effect.orElseSucceed(() => TextToImage_Config.empty),
   );


### PR DESCRIPTION
- prior to #1092, these methods were plain arrow functions, hence the use of verbs to name the methods
- the arrow functions were converted to `Effect`s because they're technically "callable"
- since `Effect`s aren't callable in the traditional sense (they're actually "runnable"), it's preferrable to preserve the "function feeling" by turning these declarations into "effect getters"
- this will also make it more obvious that these need test suites