### PR TITLE
linter: enforces treating facades for external libraries as single-file modules

### DIFF
--- a/eslint.internal.ts
+++ b/eslint.internal.ts
@@ -29,6 +29,7 @@ const pluginInternal: ConfigWithExtends[] = [
             'exports.object.primary.ts', // Always a barrel file, so should never be directory-based
             'exports.object.auxiliaries.ts', // Always a barrel file, so should never be directory-based
             'exports.toolbox.ts', // Always a barrel file, so should never be directory-based
+            'external.ts', // Always a barrel file, so should never be directory-based
           ],
         },
       ],

--- a/src/library/vue/Ref/exports.toolbox.ts
+++ b/src/library/vue/Ref/exports.toolbox.ts
@@ -1,3 +1,3 @@
-export * from './external';
+export * from './external.ts';
 
 export * from './set';

--- a/src/library/vue/Ref/set.ts
+++ b/src/library/vue/Ref/set.ts
@@ -1,6 +1,6 @@
 import type {
   Ref,
-} from './external';
+} from './external.ts';
 
 /** Updates the wrapped instance */
 const set = <SomeState>(

--- a/src/library/vue/exports.toolbox.ts
+++ b/src/library/vue/exports.toolbox.ts
@@ -1,4 +1,4 @@
-export * from './external';
+export * from './external.ts';
 
 export * from './Ref';
 


### PR DESCRIPTION
- each facade should only wrap re-exports from a single external library
- ergo, there's never a reason to convert from a single-file to a directory-based module
- useful when having agents craft new modules

Enforces precedent set by #1411