### PR TITLE
build(vitest): ensures test suites can access same libraries as their units

### DIFF
--- a/tsconfig.vitest.json
+++ b/tsconfig.vitest.json
@@ -8,7 +8,6 @@
   "compilerOptions": {
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.vitest.tsbuildinfo",
 
-    "lib": [],
     "types": [
       "node",
       "jsdom"


### PR DESCRIPTION
- the `compileOptions.lib` option specified in "tsconfig.app.json" enables use of newer JS/TS features such as the `using` keyword and `String.prototype.replaceAll`
- "tsconfig.vitest.json" extends the above-mentioned config, and tests within its jurisdiction reference modules that are within the module above.
- any test suite that imports a unit using those newer JS/TS features will also need access to those libraries
- without inheriting `compileOptions.lib`, the tests implementations won't be able to pass the compiler