### PR TITLE
tests(unit): outputs coverage summary

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,6 +6,7 @@ import {
   mergeConfig,
   defineConfig,
   configDefaults,
+  coverageConfigDefaults,
 } from 'vitest/config';
 
 import viteConfig from './vite.config';
@@ -25,6 +26,15 @@ const vitestConfig = mergeConfig(
         include: [
           'src/library/**/*.ts',
           'src/features/**/*.ts',
+        ],
+        exclude: [
+          ...coverageConfigDefaults.exclude,
+          'src/**/index.ts', // barrel files as entry points
+          'src/**/exports.*.ts', // barrel files as export control
+          'src/**/definition.assembled*.ts', // barrel files as object assemblers
+          'src/**/definition.declared.augmentation.ts', // side-effect files for module augmentation
+          'src/**/definition.declared.withAugmentation.ts', // barrel files as object augmenters
+          'src/**/external.ts', // facades for external libraries
         ],
       },
     },

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -19,7 +19,10 @@ const vitestConfig = mergeConfig(
         ...configDefaults.exclude,
         'e2e/**',
       ],
-      root: fileURLToPath(new URL('./', import.meta.url)),
+      root    : fileURLToPath(new URL('./', import.meta.url)),
+      coverage: {
+        enabled: true,
+      },
     },
   }),
 );

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -22,6 +22,10 @@ const vitestConfig = mergeConfig(
       root    : fileURLToPath(new URL('./', import.meta.url)),
       coverage: {
         enabled: true,
+        include: [
+          'src/library/**/*.ts',
+          'src/features/**/*.ts',
+        ],
       },
     },
   }),

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -36,6 +36,9 @@ const vitestConfig = mergeConfig(
           'src/**/definition.declared.withAugmentation.ts', // barrel files as object augmenters
           'src/**/external.ts', // facades for external libraries
         ],
+        reporter: [
+          'json-summary', // "json" to make it machine readable, "summary" for a schema that's easier to parse
+        ],
       },
     },
   }),


### PR DESCRIPTION
- the coverage summary can indicate which units have no coverage at all
- from there, the list can be narrowed down to those that don't even have a companion test file