### PR TITLE
tests(unit): adds cli for stubbing missing suites

### DIFF
--- a/eslint.jsonc.ts
+++ b/eslint.jsonc.ts
@@ -25,6 +25,7 @@ const rulesForPackageJSON: Linter.Config = {
           'build-only',
           'preview',
           'test:unit',
+          'test:unit:generate-missing',
           'test:e2e',
           'test:e2e:dev',
         ],

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "build-only": "vite build",
     "preview": "vite preview",
     "test:unit": "vitest",
+    "test:unit:generate-missing": "jiti vitest/test-companion-cli generate-missing",
     "test:e2e": "start-server-and-test preview http://localhost:4173 'cypress run --e2e'",
     "test:e2e:dev": "start-server-and-test 'vite dev --port 4173' http://localhost:4173 'cypress open --e2e'"
   },

--- a/vitest/Coverage/Summary/ByFilePath.ts
+++ b/vitest/Coverage/Summary/ByFilePath.ts
@@ -1,0 +1,18 @@
+import {
+  Schema,
+} from 'effect';
+
+import {
+  Coverage_Summary_ByLanguageConstruct,
+} from './ByLanguageConstruct';
+
+const Coverage_Summary_ByFilePath = Schema.Record({
+  key  : Schema.String,
+  value: Coverage_Summary_ByLanguageConstruct,
+});
+
+type Coverage_Summary_ByFilePath = typeof Coverage_Summary_ByFilePath.Type;
+
+export {
+  Coverage_Summary_ByFilePath,
+};

--- a/vitest/Coverage/Summary/ByLanguageConstruct.ts
+++ b/vitest/Coverage/Summary/ByLanguageConstruct.ts
@@ -1,0 +1,23 @@
+import {
+  Schema,
+} from 'effect';
+
+import {
+  Coverage_Summary_ByMetric,
+} from './ByMetric';
+
+class Coverage_Summary_ByLanguageConstruct
+  extends Schema.Class<
+    Coverage_Summary_ByLanguageConstruct
+  >(
+    'Coverage_Summary_ByLanguageConstruct',
+  )({
+    lines     : Coverage_Summary_ByMetric,
+    functions : Coverage_Summary_ByMetric,
+    statements: Coverage_Summary_ByMetric,
+    branches  : Coverage_Summary_ByMetric,
+  }) {}
+
+export {
+  Coverage_Summary_ByLanguageConstruct,
+};

--- a/vitest/Coverage/Summary/ByMetric.ts
+++ b/vitest/Coverage/Summary/ByMetric.ts
@@ -1,0 +1,19 @@
+import {
+  Schema,
+} from 'effect';
+
+class Coverage_Summary_ByMetric
+  extends Schema.Class<
+    Coverage_Summary_ByMetric
+  >(
+    'Coverage_Summary_ByMetric',
+  )({
+    total  : Schema.Number,
+    covered: Schema.Number,
+    skipped: Schema.Number,
+    pct    : Schema.Number,
+  }) {}
+
+export {
+  Coverage_Summary_ByMetric,
+};

--- a/vitest/Coverage/Summary/FromMixed.ts
+++ b/vitest/Coverage/Summary/FromMixed.ts
@@ -1,0 +1,46 @@
+import {
+  ParseResult,
+  Schema,
+} from 'effect';
+
+import {
+  isUndefined,
+} from 'effect/Predicate';
+
+import {
+  Coverage_Summary_Mixed,
+} from './Mixed';
+
+import {
+  Coverage_Summary,
+} from './definition.declared.ts';
+
+const Coverage_Summary_FromMixed = Schema.transformOrFail(
+  Coverage_Summary_Mixed.Schema,
+  Coverage_Summary,
+  {
+    decode: (someMixedRecord, _, ast) => {
+      const {
+        [Coverage_Summary_Mixed.keyForAggregate]: aggregateSummary, // TODO this is missing the "branchTrue" key
+        ...summaryByFile
+      } = someMixedRecord;
+
+      if (
+        isUndefined(aggregateSummary)
+      ) return ParseResult.fail(new ParseResult.Type(ast, aggregateSummary, 'Expected aggregate summary'));
+
+      return ParseResult.succeed({
+        aggregate : aggregateSummary,
+        byFilePath: summaryByFile,
+      });
+    },
+    encode: ($0) => ParseResult.succeed({
+      [Coverage_Summary_Mixed.keyForAggregate]: $0.aggregate,
+      ...$0.byFilePath,
+    }),
+  },
+);
+
+export {
+  Coverage_Summary_FromMixed,
+};

--- a/vitest/Coverage/Summary/Mixed/Schema.ts
+++ b/vitest/Coverage/Summary/Mixed/Schema.ts
@@ -1,0 +1,16 @@
+import {
+  Schema,
+} from 'effect';
+
+import {
+  Coverage_Summary_ByLanguageConstruct,
+} from '../ByLanguageConstruct';
+
+const Coverage_Summary_Mixed_Schema = Schema.Record({
+  key  : Schema.String,
+  value: Coverage_Summary_ByLanguageConstruct,
+});
+
+export {
+  Coverage_Summary_Mixed_Schema,
+};

--- a/vitest/Coverage/Summary/Mixed/definition.declared.ts
+++ b/vitest/Coverage/Summary/Mixed/definition.declared.ts
@@ -1,0 +1,18 @@
+import {
+  Coverage_Summary_Mixed_Schema,
+} from './Schema';
+
+import {
+  Coverage_Summary_Mixed_keyForAggregate,
+} from './keyForAggregate';
+
+type Coverage_Summary_Mixed = typeof Coverage_Summary_Mixed_Schema.Type;
+
+const Coverage_Summary_Mixed = Object.freeze({
+  Schema         : Coverage_Summary_Mixed_Schema,
+  keyForAggregate: Coverage_Summary_Mixed_keyForAggregate,
+});
+
+export {
+  Coverage_Summary_Mixed,
+};

--- a/vitest/Coverage/Summary/Mixed/exports.object.primary.ts
+++ b/vitest/Coverage/Summary/Mixed/exports.object.primary.ts
@@ -1,0 +1,1 @@
+export * from './definition.declared.ts';

--- a/vitest/Coverage/Summary/Mixed/index.ts
+++ b/vitest/Coverage/Summary/Mixed/index.ts
@@ -1,0 +1,1 @@
+export * from './exports.object.primary.ts';

--- a/vitest/Coverage/Summary/Mixed/keyForAggregate.ts
+++ b/vitest/Coverage/Summary/Mixed/keyForAggregate.ts
@@ -1,0 +1,5 @@
+const Coverage_Summary_Mixed_keyForAggregate = 'total';
+
+export {
+  Coverage_Summary_Mixed_keyForAggregate,
+};

--- a/vitest/Coverage/Summary/Path/defaultRelativeToProjectRoot.ts
+++ b/vitest/Coverage/Summary/Path/defaultRelativeToProjectRoot.ts
@@ -1,0 +1,5 @@
+const Coverage_Summary_Path_defaultRelativeToProjectRoot = './coverage/coverage-summary.json';
+
+export {
+  Coverage_Summary_Path_defaultRelativeToProjectRoot,
+};

--- a/vitest/Coverage/Summary/Path/definition.assembled.members.ts
+++ b/vitest/Coverage/Summary/Path/definition.assembled.members.ts
@@ -1,0 +1,3 @@
+export {
+  Coverage_Summary_Path_defaultRelativeToProjectRoot as defaultRelativeToProjectRoot,
+} from './defaultRelativeToProjectRoot';

--- a/vitest/Coverage/Summary/Path/definition.assembled.ts
+++ b/vitest/Coverage/Summary/Path/definition.assembled.ts
@@ -1,0 +1,1 @@
+export * as Coverage_Summary_Path from './definition.assembled.members.ts';

--- a/vitest/Coverage/Summary/Path/exports.object.primary.ts
+++ b/vitest/Coverage/Summary/Path/exports.object.primary.ts
@@ -1,0 +1,1 @@
+export * from './definition.assembled.ts';

--- a/vitest/Coverage/Summary/Path/index.ts
+++ b/vitest/Coverage/Summary/Path/index.ts
@@ -1,0 +1,1 @@
+export * from './exports.object.primary.ts';

--- a/vitest/Coverage/Summary/definition.declared.augmentation.ts
+++ b/vitest/Coverage/Summary/definition.declared.augmentation.ts
@@ -1,0 +1,35 @@
+import {
+  Coverage_Summary_ByFilePath,
+} from './ByFilePath';
+
+import {
+  Coverage_Summary_ByLanguageConstruct,
+} from './ByLanguageConstruct';
+
+import {
+  Coverage_Summary_ByMetric,
+} from './ByMetric';
+
+import {
+  Coverage_Summary,
+} from './definition.declared.ts';
+
+import {
+  Coverage_Summary_rootedAt,
+} from './rootedAt';
+
+Coverage_Summary.ByFilePath /*    */ = Coverage_Summary_ByFilePath;
+Coverage_Summary.ByLanguageConstruct = Coverage_Summary_ByLanguageConstruct;
+Coverage_Summary.ByMetric /*      */ = Coverage_Summary_ByMetric;
+Coverage_Summary.rootedAt /*      */ = Coverage_Summary_rootedAt;
+
+declare module './definition.declared.ts' {
+  namespace Coverage_Summary {
+    export {
+      Coverage_Summary_ByFilePath /*    */ as ByFilePath,
+      Coverage_Summary_ByLanguageConstruct as ByLanguageConstruct,
+      Coverage_Summary_ByMetric /*      */ as ByMetric,
+      Coverage_Summary_rootedAt /*      */ as rootedAt,
+    };
+  }
+}

--- a/vitest/Coverage/Summary/definition.declared.ts
+++ b/vitest/Coverage/Summary/definition.declared.ts
@@ -1,0 +1,25 @@
+import {
+  Schema,
+} from 'effect';
+
+import {
+  Coverage_Summary_ByFilePath,
+} from './ByFilePath';
+
+import {
+  Coverage_Summary_ByLanguageConstruct,
+} from './ByLanguageConstruct';
+
+class Coverage_Summary
+  extends Schema.Class<
+    Coverage_Summary
+  >(
+    'Coverage_Summary',
+  )({
+    aggregate : Coverage_Summary_ByLanguageConstruct,
+    byFilePath: Coverage_Summary_ByFilePath,
+  }) {}
+
+export {
+  Coverage_Summary,
+};

--- a/vitest/Coverage/Summary/definition.declared.withAugmentation.ts
+++ b/vitest/Coverage/Summary/definition.declared.withAugmentation.ts
@@ -1,0 +1,3 @@
+import './definition.declared.augmentation.ts';
+
+export * from './definition.declared.ts';

--- a/vitest/Coverage/Summary/exports.object.primary.ts
+++ b/vitest/Coverage/Summary/exports.object.primary.ts
@@ -1,0 +1,1 @@
+export * from './definition.declared.withAugmentation.ts';

--- a/vitest/Coverage/Summary/index.ts
+++ b/vitest/Coverage/Summary/index.ts
@@ -1,0 +1,1 @@
+export * from './exports.object.primary.ts';

--- a/vitest/Coverage/Summary/rootedAt.ts
+++ b/vitest/Coverage/Summary/rootedAt.ts
@@ -1,0 +1,50 @@
+import {
+  FileSystem,
+  Path,
+} from '@effect/platform';
+
+import {
+  Effect,
+  Schema,
+} from 'effect';
+
+import {
+  Coverage_Summary_FromMixed,
+} from './FromMixed';
+
+import {
+  Coverage_Summary_Path,
+} from './Path';
+
+import type {
+  Coverage_Summary,
+} from './definition.declared.ts';
+
+const Coverage_Summary_rootedAt = (
+  givenPathToProjectRoot: Path.Path.Parsed,
+): Effect.Effect<
+  Coverage_Summary,
+  Error,
+  | Path.Path
+  | FileSystem.FileSystem
+> => Effect.gen(function* () {
+  const ProvidedPath = yield* Path.Path;
+  const absolutePathToProjectRoot = ProvidedPath.format(givenPathToProjectRoot);
+  const absolutePathToCoverageSummary = ProvidedPath.resolve(absolutePathToProjectRoot, Coverage_Summary_Path.defaultRelativeToProjectRoot);
+
+  const ProvidedFileSystem = yield* FileSystem.FileSystem;
+
+  const contentsOfCoverageSummaryInJSON = yield* ProvidedFileSystem.readFileString(absolutePathToCoverageSummary, 'utf8').pipe(
+    Effect.mapError(($0) => new Error('Coverage summary could not be read.', {
+      cause: $0,
+    })),
+  );
+
+  const decodeCoverageSummaryFrom = Schema.decodeUnknown(Schema.parseJson(Coverage_Summary_FromMixed));
+  const decodedCoverageSummary = yield* decodeCoverageSummaryFrom(contentsOfCoverageSummaryInJSON);
+  return decodedCoverageSummary;
+});
+
+export {
+  Coverage_Summary_rootedAt,
+};

--- a/vitest/Coverage/definition.assembled.members.ts
+++ b/vitest/Coverage/definition.assembled.members.ts
@@ -1,0 +1,3 @@
+export {
+  Coverage_Summary as Summary,
+} from './Summary';

--- a/vitest/Coverage/definition.assembled.ts
+++ b/vitest/Coverage/definition.assembled.ts
@@ -1,0 +1,1 @@
+export * as Coverage from './definition.assembled.members.ts';

--- a/vitest/Coverage/exports.object.primary.ts
+++ b/vitest/Coverage/exports.object.primary.ts
@@ -1,0 +1,1 @@
+export * from './definition.assembled.ts';

--- a/vitest/Coverage/index.ts
+++ b/vitest/Coverage/index.ts
@@ -1,0 +1,1 @@
+export * from './exports.object.primary.ts';

--- a/vitest/TestCompanion.ts
+++ b/vitest/TestCompanion.ts
@@ -1,5 +1,6 @@
-import type {
-  Path,
+import {
+  FileSystem,
+  type Path,
 } from '@effect/platform';
 
 import {
@@ -102,6 +103,37 @@ class TestCompanion
     yield* Effect.try(() => currentProject.saveSync());
 
     return testCompanionSource;
+  });
+
+  public readonly doesExist: Effect.Effect<
+    boolean,
+    Error,
+    | Path.Path
+    | FileSystem.FileSystem
+  > = Effect.gen(this, function* () {
+    const /*     */ pathToTestCompanion = yield* this.path;
+    const serializedPathToTestCompanion = yield* pathToTestCompanion.serialized;
+    const ProvidedFileSystem = yield* FileSystem.FileSystem;
+    return yield* ProvidedFileSystem.exists(serializedPathToTestCompanion);
+  });
+
+  public static doesExistFor = (
+    givenUnit: TypeScript.File,
+  ): Effect.Effect<
+    boolean,
+    Error,
+    | Path.Path
+    | FileSystem.FileSystem
+  > => Effect.gen(this, function* () {
+    if (
+      !(yield* givenUnit.doesExist)
+    ) return yield* Effect.fail(new Error(`Unit does not exist at ${yield* givenUnit.path.serialized}`));
+
+    const expectedTestCompanion = new TestCompanion({
+      unit: givenUnit,
+    });
+
+    return yield* expectedTestCompanion.doesExist;
   });
 }
 

--- a/vitest/TestableUnit/allThoseMissingCompanionAccordingTo.ts
+++ b/vitest/TestableUnit/allThoseMissingCompanionAccordingTo.ts
@@ -1,0 +1,67 @@
+import type {
+  FileSystem,
+  Path,
+} from '@effect/platform';
+
+import {
+  Effect,
+  pipe,
+} from 'effect';
+
+import {
+  some,
+} from 'effect/Boolean';
+
+import TypeScript from '../../@internal/TypeScript';
+
+import type {
+  Coverage,
+} from '../Coverage';
+
+import {
+  TestCompanion,
+} from '../TestCompanion';
+
+const TestableUnit_allThoseMissingCompanionAccordingTo = (
+  givenSummary: Coverage.Summary,
+): Effect.Effect<
+  TypeScript.File[],
+  Error,
+  | Path.Path
+  | FileSystem.FileSystem
+> => Effect.gen(function* () {
+  const absolutePathsToUnitsThatHaveNoTestImplementation = Object.entries(givenSummary.byFilePath)
+    .filter((eachEntry) => {
+      const [
+        ,
+        eachMetric,
+      ] = eachEntry;
+
+      return some([
+        (eachMetric.functions.pct === 0),
+        (eachMetric.statements.pct === 0),
+      ]);
+    })
+    .map(($0) => $0[0]);
+
+  const pathsToUnitsThatHaveNoTestImplementation = yield* Effect.all(
+    absolutePathsToUnitsThatHaveNoTestImplementation.map(TypeScript.File.Path.parsedFrom),
+  );
+
+  const unitsThatHaveNoTestImplementation = pathsToUnitsThatHaveNoTestImplementation.map(($0) => new TypeScript.File({
+    path: $0,
+  }));
+
+  const unitsThatHaveNoTestCompanion = yield* pipe(
+    unitsThatHaveNoTestImplementation,
+    Effect.filter(($0) => TestCompanion.doesExistFor($0), {
+      negate: true,
+    }),
+  );
+
+  return unitsThatHaveNoTestCompanion;
+});
+
+export {
+  TestableUnit_allThoseMissingCompanionAccordingTo,
+};

--- a/vitest/TestableUnit/definition.assembled.members.ts
+++ b/vitest/TestableUnit/definition.assembled.members.ts
@@ -1,0 +1,7 @@
+export {
+  TestableUnit_allThoseMissingCompanionAccordingTo as allThoseMissingCompanionAccordingTo,
+} from './allThoseMissingCompanionAccordingTo';
+
+export {
+  TestableUnit_readAllThatAreMissingTestCompanion as readAllThatAreMissingTestCompanion,
+} from './readAllThatAreMissingTestCompanion';

--- a/vitest/TestableUnit/definition.assembled.ts
+++ b/vitest/TestableUnit/definition.assembled.ts
@@ -1,0 +1,1 @@
+export * as TestableUnit from './definition.assembled.members.ts';

--- a/vitest/TestableUnit/exports.object.primary.ts
+++ b/vitest/TestableUnit/exports.object.primary.ts
@@ -1,0 +1,1 @@
+export * from './definition.assembled.ts';

--- a/vitest/TestableUnit/index.ts
+++ b/vitest/TestableUnit/index.ts
@@ -1,0 +1,1 @@
+export * from './exports.object.primary.ts';

--- a/vitest/TestableUnit/readAllThatAreMissingTestCompanion.ts
+++ b/vitest/TestableUnit/readAllThatAreMissingTestCompanion.ts
@@ -1,0 +1,41 @@
+import {
+  type FileSystem,
+  Path,
+} from '@effect/platform';
+
+import {
+  Effect,
+} from 'effect';
+
+import type TypeScript from '../../@internal/TypeScript';
+
+import {
+  Coverage,
+} from '../Coverage';
+
+import {
+  TestableUnit_allThoseMissingCompanionAccordingTo,
+} from './allThoseMissingCompanionAccordingTo';
+
+const TestableUnit_readAllThatAreMissingTestCompanion: Effect.Effect<
+  TypeScript.File[],
+  Error,
+  | Path.Path
+  | FileSystem.FileSystem
+> = Effect.gen(function* () {
+  const ProvidedPath = yield* Path.Path;
+  const relativePathFromCurrentModuleToProjectRoot = '../../';
+
+  const absolutePathToProjectRoot = yield* ProvidedPath.fromFileUrl(new URL(
+    relativePathFromCurrentModuleToProjectRoot,
+    import.meta.url,
+  ));
+
+  const pathToProjectRoot = ProvidedPath.parse(absolutePathToProjectRoot);
+  const latestCoverageSummary = yield* Coverage.Summary.rootedAt(pathToProjectRoot);
+  return yield* TestableUnit_allThoseMissingCompanionAccordingTo(latestCoverageSummary);
+});
+
+export {
+  TestableUnit_readAllThatAreMissingTestCompanion,
+};

--- a/vitest/test-companion-cli/definition.declared.ts
+++ b/vitest/test-companion-cli/definition.declared.ts
@@ -6,12 +6,17 @@ import {
   TestCompanionCLI_generateForUnit,
 } from './generate-for-unit';
 
+import {
+  TestCompanionCLI_generateMissing,
+} from './generate-missing';
+
 const TestCompanionCLI = Command.make(
   'test-companion',
 ).pipe(
   Command.withDescription('Manage the companion test files for testable units.'),
   Command.withSubcommands([
     TestCompanionCLI_generateForUnit,
+    TestCompanionCLI_generateMissing,
   ]),
   Command.run({
     name   : 'Test Companion CLI',

--- a/vitest/test-companion-cli/generate-missing.ts
+++ b/vitest/test-companion-cli/generate-missing.ts
@@ -1,0 +1,86 @@
+import {
+  Command,
+  Options,
+} from '@effect/cli';
+
+import {
+  Console,
+  Effect,
+  Option,
+} from 'effect';
+
+import {
+  isEmptyArray,
+} from 'effect/Array';
+
+import {
+  InternalProject,
+} from '../../TSMorph';
+
+import {
+  TestCompanion,
+} from '../TestCompanion';
+
+import {
+  TestableUnit,
+} from '../TestableUnit';
+
+const TestCompanionCLI_generateMissing = Command.make(
+  'generate-missing',
+  {
+    count: Options.integer('count').pipe(
+      Options.withDescription('Number of units for which to generate test companions'),
+      Options.optional,
+      Options.mapEffect((potentialCount) => Effect.gen(function* () {
+        if (
+          Option.isNone(potentialCount)
+        ) return potentialCount;
+
+        const minCount = 1;
+
+        if (
+          potentialCount.value < minCount
+        ) return yield* Effect.dieMessage(`Count must be at least ${minCount.toString()} when provided.`);
+
+        return potentialCount;
+      })),
+    ),
+  },
+  (argumentsByName) => Effect.gen(function* () {
+    const unitsWithoutCompanion = yield* TestableUnit.readAllThatAreMissingTestCompanion;
+
+    if (
+      isEmptyArray(unitsWithoutCompanion)
+    ) return yield* Console.log('No units are missing test companions.');
+
+    const numberOfUnitsToTake = argumentsByName.count.pipe(
+      Option.getOrElse(() => unitsWithoutCompanion.length),
+    );
+
+    const takenUnitsWithoutCompanion = unitsWithoutCompanion.slice(0, numberOfUnitsToTake);
+
+    yield* Console.log(`Drafting test companions for ${takenUnitsWithoutCompanion.length.toString()} units...`);
+
+    const indentation = '  ';
+
+    const batchGenerationProject = new InternalProject();
+
+    yield* Effect.forEach(takenUnitsWithoutCompanion, (eachUnit) => Effect.gen(function* () {
+      const emptyTestCompanion = new TestCompanion({
+        unit: eachUnit,
+      });
+
+      const /*            */ draftedTestCompanion = yield* emptyTestCompanion.addTo(batchGenerationProject);
+      const inspectablePathToDraftedTestCompanion = indentation.concat(draftedTestCompanion.getFilePath());
+      yield* Console.log(inspectablePathToDraftedTestCompanion);
+    }));
+
+    yield* Console.log('Saving test companions...');
+    yield* Effect.try(() => batchGenerationProject.saveSync());
+    yield* Console.log('Test companions saved.');
+  }),
+);
+
+export {
+  TestCompanionCLI_generateMissing,
+};


### PR DESCRIPTION
- uses the coverage summary to determine which units ought to have coverage and then generates a stub for each relevant unit
- using this will "raise the tide an inch" for the entire codebase