### PR TITLE
ci: enforces existence of test suite for all units

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -82,3 +82,13 @@ jobs:
         run: |
           echo "::notice::Run \`npm run test:unit\` in your dev environment for a detailed report about failed unit tests"
           exit 1
+      - name: Ensure all units are covered
+        if: steps.changed-files.outputs.any_changed == 'true'
+        id: test_unit_missing
+        run: npm run test:unit:ensure-all
+        continue-on-error: true
+      - name: If there are missing unit tests, highlight debug tools
+        if: steps.test_unit_missing.outcome == 'failure'
+        run: |
+          echo "::notice::Run \`npm run test:unit -- run && npm run test:unit:ensure-all\` in your dev environment to see which units are missing a test companion"
+          exit 1

--- a/eslint.jsonc.ts
+++ b/eslint.jsonc.ts
@@ -25,6 +25,7 @@ const rulesForPackageJSON: Linter.Config = {
           'build-only',
           'preview',
           'test:unit',
+          'test:unit:ensure-all',
           'test:unit:generate-missing',
           'test:e2e',
           'test:e2e:dev',

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "build-only": "vite build",
     "preview": "vite preview",
     "test:unit": "vitest",
+    "test:unit:ensure-all": "jiti vitest/test-companion-cli ensure-none-are-missing",
     "test:unit:generate-missing": "jiti vitest/test-companion-cli generate-missing",
     "test:e2e": "start-server-and-test preview http://localhost:4173 'cypress run --e2e'",
     "test:e2e:dev": "start-server-and-test 'vite dev --port 4173' http://localhost:4173 'cypress open --e2e'"

--- a/vitest/test-companion-cli/definition.declared.ts
+++ b/vitest/test-companion-cli/definition.declared.ts
@@ -3,6 +3,10 @@ import {
 } from '@effect/cli';
 
 import {
+  TestCompanionCLI_ensureNoneAreMissing,
+} from './ensure-none-are-missing';
+
+import {
   TestCompanionCLI_generateForUnit,
 } from './generate-for-unit';
 
@@ -17,6 +21,7 @@ const TestCompanionCLI = Command.make(
   Command.withSubcommands([
     TestCompanionCLI_generateForUnit,
     TestCompanionCLI_generateMissing,
+    TestCompanionCLI_ensureNoneAreMissing,
   ]),
   Command.run({
     name   : 'Test Companion CLI',

--- a/vitest/test-companion-cli/ensure-none-are-missing.ts
+++ b/vitest/test-companion-cli/ensure-none-are-missing.ts
@@ -1,0 +1,54 @@
+import {
+  Command,
+} from '@effect/cli';
+
+import {
+  Path,
+} from '@effect/platform';
+
+import {
+  Console,
+  Effect,
+} from 'effect';
+
+import {
+  isEmptyArray,
+} from 'effect/Array';
+
+import {
+  TestableUnit,
+} from '../TestableUnit';
+
+const TestCompanionCLI_ensureNoneAreMissing = Command.make(
+  'ensure-none-are-missing',
+  {},
+  () => Effect.gen(function* () {
+    const pathsOfUnitsWithoutCompanion = yield* TestableUnit.readAllThatAreMissingTestCompanion;
+
+    if (
+      isEmptyArray(pathsOfUnitsWithoutCompanion)
+    ) return yield* Console.log('No units are missing test companions.');
+
+    const ProvidedPath = yield* Path.Path;
+    const relativePathFromCurrentModuleToProjectRoot = '../../';
+
+    const absolutePathToProjectRoot = yield* ProvidedPath.fromFileUrl(new URL(
+      relativePathFromCurrentModuleToProjectRoot,
+      import.meta.url,
+    ));
+
+    const relativePathsFromProjectRootToUnitsWithoutCompanion = pathsOfUnitsWithoutCompanion
+      .map(($0) => ProvidedPath.format($0.path).replace(absolutePathToProjectRoot, ''));
+
+    const missingTestCompanionsError = new Error([
+      `The following ${pathsOfUnitsWithoutCompanion.length.toString()} unit(s) have no test companion:`,
+      ...relativePathsFromProjectRootToUnitsWithoutCompanion,
+    ].join('\n'));
+
+    return yield* Effect.fail(missingTestCompanionsError);
+  }),
+);
+
+export {
+  TestCompanionCLI_ensureNoneAreMissing,
+};


### PR DESCRIPTION
- on the way to enforcing unit test coverage is ensuring that the unit test files actually exist and contain a "TODO"